### PR TITLE
fs: introduce [fs.FS] helpers

### DIFF
--- a/fs/LICENCE.txt
+++ b/fs/LICENCE.txt
@@ -1,0 +1,19 @@
+Copyright 2024 JPI Technologies Ltd <oss@jpi.io>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.

--- a/fs/README.md
+++ b/fs/README.md
@@ -24,3 +24,25 @@ paths starting with `/`, and also returns if the cleaned path satisfies [fs.Vali
 
 as leading `../` are supported, it can be used for concatenations and to clean
 absolute OS paths. `/..` will be returned if the reduction lead to that.
+
+## Proxies
+
+As this package is named `fs` and would shadow the standard `io.fs` package we include aliases
+and proxies of commonly used symbols.
+
+### Types
+
+* `fs.FileInfo`
+* `fs.DirInfo`
+* `fs.PathError`
+* `fs.StatFS`
+
+### Constants
+
+* `fs.ErrInvalid`
+* `fs.ErrExists`
+* `fs.ErrNotExists`
+
+### Functions
+
+* `fs.ValidPath`

--- a/fs/README.md
+++ b/fs/README.md
@@ -1,0 +1,1 @@
+# Helpers to work with fs.FS

--- a/fs/README.md
+++ b/fs/README.md
@@ -8,6 +8,12 @@ delimiters
 
 * `Glob` a type alias to keep the import-space clean
 * `GlobCompile` compiles a list of patterns
+* `GlobFS` walks a [fs.FS] and returns all matches of the specified patterns.
+  If no pattern is provided all entries not giving a `fs.Stat` error will be
+  returned.
+* `MatchFS` is similar to `GlobFS` but it takes a root value, which will be cleaned,
+  and a list of compiled `Glob` patterns. it will only fail if the root gives an error.
+* `MatchFuncFS` is an alternative to `MatchFS` which actually receives a checker function.
 
 ## Paths
 

--- a/fs/README.md
+++ b/fs/README.md
@@ -8,3 +8,13 @@ delimiters
 
 * `Glob` a type alias to keep the import-space clean
 * `GlobCompile` compiles a list of patterns
+
+## Paths
+
+### `Clean`
+
+We offer an alternative to the standard [fs.Clean] which optionally supports
+paths starting with `/`, and also returns if the cleaned path satisfies [fs.ValidPath].
+
+as leading `../` are supported, it can be used for concatenations and to clean
+absolute OS paths. `/..` will be returned if the reduction lead to that.

--- a/fs/README.md
+++ b/fs/README.md
@@ -1,1 +1,10 @@
 # Helpers to work with fs.FS
+
+## Globing
+
+We use the excellent https://github.com/gobwas/glob to compile
+file listing patterns, and `**` is supported to ignore the `/`
+delimiters
+
+* `Glob` a type alias to keep the import-space clean
+* `GlobCompile` compiles a list of patterns

--- a/fs/clean.go
+++ b/fs/clean.go
@@ -1,0 +1,118 @@
+package fs
+
+import (
+	"strings"
+
+	"github.com/gobwas/glob/util/runes"
+)
+
+// Clean reduces a path and tells if it's a valid root
+// for fs.FS operations.
+func Clean(path string) (string, bool) {
+	var hasRootSlash bool
+
+	switch {
+	case path == "", path == ".":
+		return ".", true
+	case path == "/":
+		return "/", false
+	case path[0] == '/':
+		hasRootSlash = true
+		path = path[1:]
+	}
+
+	s := doClean(path)
+	if hasRootSlash {
+		switch s {
+		case "", ".":
+			return "/", false
+		default:
+			return "/" + s, false
+		}
+	}
+
+	switch s {
+	case "", ".":
+		return ".", true
+	case "..":
+		return s, false
+	default:
+		return s, !strings.HasPrefix(s, "../")
+	}
+}
+
+func doClean(path string) string {
+	s := doCleanRunes([]rune(path))
+
+	switch {
+	case len(s) == 0:
+		// root
+		return "."
+	case len(s) == len(path):
+		// same
+		return path
+	default:
+		// cleaned
+		return string(s)
+	}
+}
+
+func doCleanRunes(path []rune) []rune {
+	buf, rest := make([]rune, 0, len(path)), path
+
+	for len(rest) > 0 {
+		var part []rune
+
+		i := runes.IndexRune(rest, '/')
+		switch {
+		case i < 0:
+			// last
+			part, rest = rest, nil
+			buf = cleanRunesApply(buf, part)
+		default:
+			// next
+			part, rest = rest[:i], rest[i+1:]
+			buf = cleanRunesApply(buf, part)
+		}
+	}
+
+	return buf
+}
+
+func cleanRunesApply(buf, next []rune) []rune {
+	var dotdot, dot = []rune(".."), []rune{'.'}
+
+	switch {
+	case len(next) == 0, runes.Equal(next, dot):
+		// ignore "" and "."
+		return buf
+	case runes.Equal(next, dotdot):
+		// dot dot
+		return cleanRunesDotDot(buf)
+	default:
+		// anything else, append
+		return joinRunes(buf, next)
+	}
+}
+
+func cleanRunesDotDot(buf []rune) []rune {
+	var dotdot = []rune("..")
+
+	if len(buf) == 0 || runes.Equal(buf, dotdot) {
+		// ".." or "../.."
+		return joinRunes(buf, dotdot)
+	}
+
+	i := runes.IndexLastRune(buf, '/')
+	switch {
+	case i < 0:
+		// "foo/.." → ""
+		return buf[:0]
+	case runes.Equal(buf[i+1:], dotdot):
+		// "../../.."
+		return joinRunes(buf, dotdot)
+	default:
+		// "a/b/.."
+		return buf[:i]
+	}
+}

--- a/fs/clean_test.go
+++ b/fs/clean_test.go
@@ -1,0 +1,44 @@
+package fs
+
+import "testing"
+
+func TestClean(t *testing.T) {
+	tests := []struct {
+		path string
+		out  string
+		ok   bool
+	}{
+		{"", ".", true},
+		{".", ".", true},
+		{"..", "..", false},
+		{"../", "..", false},
+		{"../.", "..", false},
+		{"../a", "../a", false},
+		{"a", "a", true},
+		{"/", "/", false},
+		{"/a", "/a", false},
+		{"/a/..", "/", false},
+		{"/../..//", "/../..", false},
+		{"a/b", "a/b", true},
+		{"a//b", "a/b", true},
+		{"a/..", ".", true},
+		{"a/../b", "b", true},
+		{"a/b/..", "a", true},
+		{"a/b/../foo", "a/foo", true},
+	}
+
+	for i, tc := range tests {
+		s, ok := Clean(tc.path)
+
+		if s == tc.out && ok == tc.ok {
+			t.Logf("[%v/%v] Clean(%q) → %q %v",
+				i, len(tests), tc.path,
+				s, ok)
+		} else {
+			t.Errorf("[%v/%v] ERROR: Clean(%q) → %q %v (expected %q %v)",
+				i, len(tests), tc.path,
+				s, ok,
+				tc.out, tc.ok)
+		}
+	}
+}

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -1,0 +1,2 @@
+// Package fs provides tools to work with [fs.FS]
+package fs

--- a/fs/glob.go
+++ b/fs/glob.go
@@ -1,0 +1,24 @@
+package fs
+
+import (
+	"github.com/gobwas/glob"
+)
+
+// Glob is a compiled globbing pattern from https://github.com/gobwas/glob
+type Glob = glob.Glob
+
+// GlobCompile compiles a list of file globbing patterns using
+// https://github.com/gobwas/glob
+func GlobCompile(patterns ...string) ([]Glob, error) {
+	out := make([]Glob, 0, len(patterns))
+
+	for _, pat := range patterns {
+		g, err := glob.Compile(pat, '/')
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, g)
+	}
+
+	return out, nil
+}

--- a/fs/glob.go
+++ b/fs/glob.go
@@ -1,7 +1,11 @@
 package fs
 
 import (
+	"io/fs"
+
 	"github.com/gobwas/glob"
+
+	"darvaza.org/core"
 )
 
 // Glob is a compiled globbing pattern from https://github.com/gobwas/glob
@@ -21,4 +25,69 @@ func GlobCompile(patterns ...string) ([]Glob, error) {
 	}
 
 	return out, nil
+}
+
+// GlobFS returns all entries matching any of the given patterns.
+func GlobFS(fSys fs.FS, patterns ...string) ([]string, error) {
+	g, err := GlobCompile(patterns...)
+	if err != nil {
+		return nil, err
+	}
+
+	return MatchFS(fSys, ".", g...)
+}
+
+// MatchFS returns all entries matching any of the given compiled glob patterns.
+func MatchFS(fSys fs.FS, root string, globs ...Glob) ([]string, error) {
+	return MatchFuncFS(fSys, root, newCheckerMatchAnyFS(globs))
+}
+
+func newCheckerMatchAnyFS(globs []Glob) func(string, fs.DirEntry) bool {
+	if len(globs) == 0 {
+		return nil
+	}
+
+	return func(path string, _ fs.DirEntry) bool {
+		for _, g := range globs {
+			if g.Match(path) {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+// MatchFuncFS returns all entries satisfying the given checker function.
+// If no function is provided, all entries will be listed.
+// Entries giving Stat error will be ignored.
+func MatchFuncFS(fSys fs.FS, root string, check func(string, fs.DirEntry) bool) ([]string, error) {
+	var out []string
+
+	dir, ok := Clean(root)
+	if !ok {
+		err := &fs.PathError{
+			Op:   "readdir",
+			Path: root,
+			Err:  fs.ErrInvalid,
+		}
+		return nil, err
+	}
+
+	if check == nil {
+		check = func(string, fs.DirEntry) bool { return true }
+	}
+
+	err := fs.WalkDir(fSys, dir, func(path string, di fs.DirEntry, err error) error {
+		switch {
+		case err != nil:
+			// only pass root errors
+			return core.IIf(dir == path, err, nil)
+		case check(path, di):
+			// match
+			out = append(out, path)
+		}
+		return nil
+	})
+
+	return out, err
 }

--- a/fs/go.mod
+++ b/fs/go.mod
@@ -2,4 +2,12 @@ module darvaza.org/x/fs
 
 go 1.19
 
-require github.com/gobwas/glob v0.2.3
+require (
+	darvaza.org/core v0.13.3
+	github.com/gobwas/glob v0.2.3
+)
+
+require (
+	golang.org/x/net v0.20.0 // indirect
+	golang.org/x/text v0.14.0 // indirect
+)

--- a/fs/go.mod
+++ b/fs/go.mod
@@ -1,3 +1,5 @@
 module darvaza.org/x/fs
 
 go 1.19
+
+require github.com/gobwas/glob v0.2.3

--- a/fs/go.mod
+++ b/fs/go.mod
@@ -1,0 +1,3 @@
+module darvaza.org/x/fs
+
+go 1.19

--- a/fs/go.sum
+++ b/fs/go.sum
@@ -1,0 +1,2 @@
+github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
+github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=

--- a/fs/go.sum
+++ b/fs/go.sum
@@ -1,2 +1,9 @@
+darvaza.org/core v0.13.3 h1:DOsidY49WXsWiJulOIxDq578h/3ekgx0trWxbvgv5bc=
+darvaza.org/core v0.13.3/go.mod h1:47Ydh67KnzjLNu1mzX3r2zpphbxQqEaihMsUq5GflQ4=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
+golang.org/x/exp v0.0.0-20240112132812-db7319d0e0e3 h1:hNQpMuAJe5CtcUqCXaWga3FHu+kQvCqcsoVaQgSV60o=
+golang.org/x/net v0.20.0 h1:aCL9BSgETF1k+blQaYUBx9hJ9LOGP3gAVemcZlf1Kpo=
+golang.org/x/net v0.20.0/go.mod h1:z8BVo6PvndSri0LbOE3hAn0apkU+1YvI6E70E9jsnvY=
+golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
+golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=

--- a/fs/std.go
+++ b/fs/std.go
@@ -1,0 +1,30 @@
+package fs
+
+import "io/fs"
+
+type (
+	// FileInfo is an alias of the standard [fs.FileInfo] type.
+	FileInfo = fs.FileInfo
+	// DirEntry is an alias of the standard [fs.DirEntry] type.
+	DirEntry = fs.DirEntry
+	// PathError is an alias of the standard [fs.PathError] type.
+	PathError = fs.PathError
+	// StatFS is an alias of the standard [fs.StatFS] type.
+	StatFS = fs.StatFS
+)
+
+var (
+	// ErrInvalid is an alias of the standard [fs.ErrInvalid] constant.
+	ErrInvalid = fs.ErrInvalid
+	// ErrExist is an alias of the standard [fs.ErrExist] constant.
+	ErrExist = fs.ErrExist
+	// ErrNotExist is an alias of the standard [fs.ErrNotExist] constant.
+	ErrNotExist = fs.ErrNotExist
+)
+
+// ValidPath is a proxy to the standard [fs.ValidPath]
+// which reports whether the given path name valid and clean
+// for use in a call to Open().
+func ValidPath(name string) bool {
+	return fs.ValidPath(name)
+}

--- a/fs/utils.go
+++ b/fs/utils.go
@@ -1,0 +1,13 @@
+package fs
+
+func joinRunes(before, after []rune) []rune {
+	switch {
+	case len(after) == 0:
+		return before
+	case len(before) == 0:
+		return append(before, after...)
+	default:
+		s := append(before, '/')
+		return append(s, after...)
+	}
+}


### PR DESCRIPTION
adds `GlobCompile()`/`GlobFS()`/`MatchFS()`/`MatchFuncFS()` using github.com/gobwas/glob for `**`
and a better fs.Clean()