### PR TITLE
ci: sort out deepsource-go reported issues

### DIFF
--- a/config/expand/file.go
+++ b/config/expand/file.go
@@ -51,7 +51,7 @@ func FromFile(filename string, getEnv func(string) string) (string, error) {
 	} else if file, err := os.Open(filename); err != nil {
 		return "", err
 	} else {
-		defer file.Close()
+		defer func() { _ = file.Close() }()
 		f = file
 	}
 

--- a/config/expand/file.go
+++ b/config/expand/file.go
@@ -38,7 +38,7 @@ func FromReader(f io.Reader, getEnv func(string) string) (string, error) {
 		return "", err
 	}
 
-	return FromString(string(b[:]), getEnv)
+	return FromString(string(b), getEnv)
 }
 
 // FromFile reads a file and expands shell-style variable

--- a/config/loader.go
+++ b/config/loader.go
@@ -88,7 +88,7 @@ func (l *Loader[T]) doReadDecode(fSys fs.FS, name string) (*T, error) {
 	}
 
 	if d, ok := dec.(io.Closer); ok {
-		defer d.Close()
+		defer func() { _ = d.Close() }()
 	}
 
 	return dec.Decode(name, data)

--- a/fs/utils.go
+++ b/fs/utils.go
@@ -1,5 +1,6 @@
 package fs
 
+// joinRunes appends a clean path to another in a []rune buffer.
 func joinRunes(before, after []rune) []rune {
 	switch {
 	case len(after) == 0:
@@ -7,7 +8,7 @@ func joinRunes(before, after []rune) []rune {
 	case len(before) == 0:
 		return append(before, after...)
 	default:
-		s := append(before, '/')
-		return append(s, after...)
+		before = append(before, '/')
+		return append(before, after...)
 	}
 }

--- a/tls/sni/chi.go
+++ b/tls/sni/chi.go
@@ -50,6 +50,8 @@ func ReadClientHelloInfo(ctx context.Context,
 
 	conn := readOnlyConn{reader: f}
 	conf := &tls.Config{
+		MinVersion: tls.VersionTLS12,
+		MaxVersion: tls.VersionTLS13,
 		GetConfigForClient: func(chi *tls.ClientHelloInfo) (*tls.Config, error) {
 			// copy
 			out = new(tls.ClientHelloInfo)

--- a/tls/sni/dispatcher.go
+++ b/tls/sni/dispatcher.go
@@ -140,7 +140,7 @@ func (d *Dispatcher) handle(conn net.Conn) error {
 	if d.OnAccept != nil {
 		conn2, err := d.OnAccept(conn)
 		if err != nil {
-			defer conn.Close()
+			_ = conn.Close()
 			return err
 		}
 		conn = conn2
@@ -161,7 +161,7 @@ func (d *Dispatcher) handleCHI(conn net.Conn) error {
 	// Get ClientHelloInfo
 	chi, conn2, err := PeekClientHelloInfo(d.ctx, conn)
 	if err != nil {
-		defer conn.Close()
+		_ = conn.Close()
 		return err
 	}
 


### PR DESCRIPTION
only the change to `tls/sni.ReadClientHelloInfo()` affects behaviour, preventing handshakes lower than TLS 1.2.