### PR TITLE
web/assets: CleanETags(), Match(), and new meaning for Setter interfaces

### DIFF
--- a/web/assets/fs.go
+++ b/web/assets/fs.go
@@ -14,6 +14,7 @@ type ContentTypedFS interface {
 
 // ContentTypeSetterFS is the interface implemented by a file system
 // to set a file's MIME Content-Type.
+// On success the new value is returned.
 type ContentTypeSetterFS interface {
 	fs.FS
 
@@ -28,7 +29,8 @@ type ETagedFS interface {
 }
 
 // ETagsSetterFS is the interface implemented by a file system
-// to set a file's ETags
+// to set a file's ETags.
+// On success the new tags is returned.
 type ETagsSetterFS interface {
 	fs.FS
 

--- a/web/assets/http.go
+++ b/web/assets/http.go
@@ -6,7 +6,8 @@ import (
 
 // ContentTypeSetter is the interface that allows a [fs.File] or its
 // [fs.FileInfo] to assign a MIME Content-Type to it.
-// if empty it will be ignored
+// If empty it will be ignored.
+// On success the new value is returned.
 type ContentTypeSetter interface {
 	SetContentType(string) string
 }
@@ -44,9 +45,9 @@ func tryContentType(candidates ...any) string {
 }
 
 // ETagsSetter is the interface that allows a [fs.File] or its
-// [fs.FileInfo] to assign a ETags to it. Previous values will
-// be removed and returned. If none is provided, it will return
-// the current values unmodified.
+// [fs.FileInfo] to assign a ETags to it.
+// Any previous value will be replaced, unless none is provided.
+// The effective ETags set is returned.
 type ETagsSetter interface {
 	SetETags(...string) []string
 }

--- a/web/assets/utils.go
+++ b/web/assets/utils.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"darvaza.org/core"
+	"darvaza.org/x/fs"
 )
 
 // CleanETags removes empty and duplicate tags.
@@ -25,4 +26,19 @@ func doCleanETags(s []string, tag string) (string, bool) {
 		// new
 		return tag, true
 	}
+}
+
+// Match tests if the given path matches any of the given globs.
+// if no matchers are provided, it will be understood as unconditional.
+func Match(path string, globs []fs.Matcher) bool {
+	var match bool
+
+	for _, g := range globs {
+		if g.Match(path) {
+			match = true
+			break
+		}
+	}
+
+	return match || len(globs) == 0
 }

--- a/web/assets/utils.go
+++ b/web/assets/utils.go
@@ -1,0 +1,28 @@
+package assets
+
+import (
+	"strings"
+
+	"darvaza.org/core"
+)
+
+// CleanETags removes empty and duplicate tags.
+// Whitespace before and after the content of each tag is also removed.
+func CleanETags(tags ...string) []string {
+	return core.SliceReplaceFn(tags, doCleanETags)
+}
+
+func doCleanETags(s []string, tag string) (string, bool) {
+	tag = strings.TrimSpace(tag)
+	switch {
+	case tag == "":
+		// empty
+		return "", false
+	case core.SliceContains(s, tag):
+		// duplicate
+		return "", false
+	default:
+		// new
+		return tag, true
+	}
+}

--- a/web/go.mod
+++ b/web/go.mod
@@ -2,11 +2,15 @@ module darvaza.org/x/web
 
 go 1.21
 
-require darvaza.org/core v0.13.3
+require (
+	darvaza.org/core v0.13.3
+	darvaza.org/x/fs v0.2.1
+)
 
 require lukechampine.com/blake3 v1.3.0
 
 require (
+	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/klauspost/cpuid/v2 v2.0.12 // indirect
 	golang.org/x/net v0.26.0 // indirect
 	golang.org/x/text v0.16.0 // indirect

--- a/web/go.sum
+++ b/web/go.sum
@@ -1,5 +1,9 @@
 darvaza.org/core v0.13.3 h1:DOsidY49WXsWiJulOIxDq578h/3ekgx0trWxbvgv5bc=
 darvaza.org/core v0.13.3/go.mod h1:47Ydh67KnzjLNu1mzX3r2zpphbxQqEaihMsUq5GflQ4=
+darvaza.org/x/fs v0.2.1 h1:jVlhrV+DgLlZiQuE1hFYH3qjCHHCjbbA4wmqrDKK7ZU=
+darvaza.org/x/fs v0.2.1/go.mod h1:g1SYeO2j2yCw/z+WO7MIIhx5WJ889wUWPxWRCI0UfVs=
+github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
+github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/klauspost/cpuid/v2 v2.0.12 h1:p9dKCg8i4gmOxtv35DvrYoWqYzQrvEVdjQ762Y0OqZE=
 github.com/klauspost/cpuid/v2 v2.0.12/go.mod h1:g2LTdtYhdyuGPqyWyv7qRAmj1WBqxuObKfj5c0PQa7c=
 golang.org/x/exp v0.0.0-20240112132812-db7319d0e0e3 h1:hNQpMuAJe5CtcUqCXaWga3FHu+kQvCqcsoVaQgSV60o=


### PR DESCRIPTION
introduce Match() and CleanETags() helpers
change meaning of ETagsSetters and ContentTypeSetter interfaces to return the new values instead of the previous.