### PR TITLE
BREAKING: web/resource: fixed Resource[T] to not force pointers.

### DIFF
--- a/web/resource/README.md
+++ b/web/resource/README.md
@@ -30,7 +30,7 @@ when using the `DefaultChecker`
 
 The recommended workflow is to use `Check` to return a resource data pointer using
 ```go
-Check(*http.Request) (*http.Request, *T, error)
+Check(*http.Request) (*http.Request, T, error)
 ```
 but one with implicit `nil` data is also tested for.
 ```go
@@ -39,7 +39,7 @@ Check(*http.Request) (*http.Request, error)
 
 The data pointer can then be received by the FOO method handler via
 ```go
-Foo(http.ResponseWriter, *http.Request, *T) error
+Foo(http.ResponseWriter, *http.Request, T) error
 ```
 
 but one without data pointer is also tested for.

--- a/web/resource/checker.go
+++ b/web/resource/checker.go
@@ -14,22 +14,24 @@ type Checker interface {
 // TChecker is a resource that knows how validate its requests,
 // and returns the relevant data
 type TChecker[T any] interface {
-	Check(*http.Request) (*http.Request, *T, error)
+	Check(*http.Request) (*http.Request, T, error)
 }
 
 // CheckerFunc is the signature of a function that pre-validates
 // requests and returns relevant data
-type CheckerFunc[T any] func(*http.Request) (*http.Request, *T, error)
+type CheckerFunc[T any] func(*http.Request) (*http.Request, T, error)
 
 // DefaultChecker is happy with any request that can resolve a
 // valid path but it doesn't do any alteration to the request
 // or its context.
-func DefaultChecker[T any](req *http.Request) (*http.Request, *T, error) {
+func DefaultChecker[T any](req *http.Request) (*http.Request, T, error) {
+	var zero T
+
 	_, err := web.Resolve(req)
 	if err != nil {
-		return nil, nil, err
+		return nil, zero, err
 	}
-	return req, nil, nil
+	return req, zero, nil
 }
 
 func checkerOf[T any](x any) (CheckerFunc[T], bool) {
@@ -37,9 +39,10 @@ func checkerOf[T any](x any) (CheckerFunc[T], bool) {
 	case TChecker[T]:
 		return v.Check, true
 	case Checker:
-		fn := func(req *http.Request) (*http.Request, *T, error) {
+		fn := func(req *http.Request) (*http.Request, T, error) {
+			var zero T
 			req2, err := v.Check(req)
-			return req2, nil, err
+			return req2, zero, err
 		}
 		return fn, true
 	default:

--- a/web/resource/methods.go
+++ b/web/resource/methods.go
@@ -12,12 +12,12 @@ import (
 
 // HandlerFunc represents a function [web.HandlerFunc] but taking a data
 // parameter.
-type HandlerFunc[T any] func(http.ResponseWriter, *http.Request, *T) error
+type HandlerFunc[T any] func(http.ResponseWriter, *http.Request, T) error
 
 // AsHandlerFunc wraps a [web.HandlerFunc] into a [HandlerFunc], discarding
 // the data pointer.
 func AsHandlerFunc[T any](fn web.HandlerFunc) HandlerFunc[T] {
-	return func(rw http.ResponseWriter, req *http.Request, _ *T) error {
+	return func(rw http.ResponseWriter, req *http.Request, _ T) error {
 		return fn(rw, req)
 	}
 }
@@ -29,7 +29,7 @@ type Getter interface {
 
 // TGetter represents a resource that handles GET requests with a data field.
 type TGetter[T any] interface {
-	Get(http.ResponseWriter, *http.Request, *T) error
+	Get(http.ResponseWriter, *http.Request, T) error
 }
 
 func getterOf[T any](x any) (HandlerFunc[T], bool) {
@@ -50,7 +50,7 @@ type Peeker interface {
 
 // TPeeker represents a resource that handles HEAD requests with a data field.
 type TPeeker[T any] interface {
-	Head(http.ResponseWriter, *http.Request, *T) error
+	Head(http.ResponseWriter, *http.Request, T) error
 }
 
 func peekerOf[T any](x any) (HandlerFunc[T], bool) {
@@ -71,7 +71,7 @@ type Poster interface {
 
 // TPoster represents a resource that handles POST requests with a data field.
 type TPoster[T any] interface {
-	Post(http.ResponseWriter, *http.Request, *T) error
+	Post(http.ResponseWriter, *http.Request, T) error
 }
 
 func posterOf[T any](x any) (HandlerFunc[T], bool) {
@@ -92,7 +92,7 @@ type Putter interface {
 
 // TPutter represents a resource that handles PUT requests with a data field.
 type TPutter[T any] interface {
-	Put(http.ResponseWriter, *http.Request, *T) error
+	Put(http.ResponseWriter, *http.Request, T) error
 }
 
 func putterOf[T any](x any) (HandlerFunc[T], bool) {
@@ -113,7 +113,7 @@ type Deleter interface {
 
 // TDeleter represents a resource that handles DELETE requests with a data field.
 type TDeleter[T any] interface {
-	Delete(http.ResponseWriter, *http.Request, *T) error
+	Delete(http.ResponseWriter, *http.Request, T) error
 }
 
 func deleterOf[T any](x any) (HandlerFunc[T], bool) {
@@ -134,7 +134,7 @@ type Optioner interface {
 
 // TOptioner represents a resource that handles OPTIONS requests with a data field.
 type TOptioner[T any] interface {
-	Options(http.ResponseWriter, *http.Request, *T) error
+	Options(http.ResponseWriter, *http.Request, T) error
 }
 
 func optionerOf[T any](x any) (HandlerFunc[T], bool) {
@@ -155,7 +155,7 @@ type Patcher interface {
 
 // TPatcher represents a resource that handles PATCH requests with a data field.
 type TPatcher[T any] interface {
-	Patch(http.ResponseWriter, *http.Request, *T) error
+	Patch(http.ResponseWriter, *http.Request, T) error
 }
 
 func patcherOf[T any](x any) (HandlerFunc[T], bool) {

--- a/web/resource/methods.sh
+++ b/web/resource/methods.sh
@@ -37,12 +37,12 @@ import (
 
 // HandlerFunc represents a function [web.HandlerFunc] but taking a data
 // parameter.
-type HandlerFunc[T any] func(http.ResponseWriter, *http.Request, *T) error
+type HandlerFunc[T any] func(http.ResponseWriter, *http.Request, T) error
 
 // AsHandlerFunc wraps a [web.HandlerFunc] into a [HandlerFunc], discarding
 // the data pointer.
 func AsHandlerFunc[T any](fn web.HandlerFunc) HandlerFunc[T] {
-	return func(rw http.ResponseWriter, req *http.Request, _ *T) error {
+	return func(rw http.ResponseWriter, req *http.Request, _ T) error {
 		return fn(rw, req)
 	}
 }
@@ -75,7 +75,7 @@ type $iface interface {
 
 // T${iface} represents a resource that handles $verb requests with a data field.
 type T${iface}[T any] interface {
-	$fn(http.ResponseWriter, *http.Request, *T) error
+	$fn(http.ResponseWriter, *http.Request, T) error
 }
 
 func ${accessor}[T any](x any) (HandlerFunc[T], bool) {

--- a/web/resource/render.go
+++ b/web/resource/render.go
@@ -28,14 +28,14 @@ func RenderFunc[T any](fn func(http.ResponseWriter, *http.Request, any) error) H
 		return nil
 	}
 
-	return func(rw http.ResponseWriter, req *http.Request, data *T) error {
+	return func(rw http.ResponseWriter, req *http.Request, data T) error {
 		return fn(rw, req, data)
 	}
 }
 
 // Render uses the Accept header to choose what renderer to use. If nothing acceptable
 // is supported, but an "identity" type has been set, that will be used.
-func (r *Resource[T]) Render(rw http.ResponseWriter, req *http.Request, data *T) error {
+func (r *Resource[T]) Render(rw http.ResponseWriter, req *http.Request, data T) error {
 	h, err := r.getRendererForRequest(req)
 	if err != nil {
 		return err

--- a/web/resource/render_html.go
+++ b/web/resource/render_html.go
@@ -8,7 +8,7 @@ import (
 
 func htmlRendererOf[T any](x any) (HandlerFunc[T], bool) {
 	if v, ok := x.(interface {
-		RenderHTML(http.ResponseWriter, *http.Request, *T) error
+		RenderHTML(http.ResponseWriter, *http.Request, T) error
 	}); ok {
 		return v.RenderHTML, true
 	}

--- a/web/resource/render_json.go
+++ b/web/resource/render_json.go
@@ -8,7 +8,7 @@ import (
 
 func jsonRendererOf[T any](x any) (HandlerFunc[T], bool) {
 	if v, ok := x.(interface {
-		RenderJSON(http.ResponseWriter, *http.Request, *T) error
+		RenderJSON(http.ResponseWriter, *http.Request, T) error
 	}); ok {
 		return v.RenderJSON, true
 	}

--- a/web/resource/render_txt.go
+++ b/web/resource/render_txt.go
@@ -4,7 +4,7 @@ import "net/http"
 
 func txtRendererOf[T any](x any) (HandlerFunc[T], bool) {
 	if v, ok := x.(interface {
-		RenderTXT(http.ResponseWriter, *http.Request, *T) error
+		RenderTXT(http.ResponseWriter, *http.Request, T) error
 	}); ok {
 		return v.RenderTXT, true
 	}

--- a/web/resource/resource.go
+++ b/web/resource/resource.go
@@ -83,11 +83,11 @@ func (r *Resource[T]) getMethodHandler(req *http.Request) (HandlerFunc[T], strin
 	return nil, "", r.err405()
 }
 
-func (r *Resource[T]) checkRequest(req *http.Request) (*http.Request, *T, error) {
+func (r *Resource[T]) checkRequest(req *http.Request) (*http.Request, T, error) {
 	req2, data, err := r.check(req)
 	switch {
 	case err != nil:
-		return nil, nil, web.AsError(err)
+		return nil, data, web.AsError(err)
 	case req2 != nil:
 		return req2, data, nil
 	default:
@@ -109,7 +109,7 @@ func (r *Resource[T]) Methods() []string {
 	return out
 }
 
-func (r *Resource[T]) serveOptions(rw http.ResponseWriter, _ *http.Request, _ *T) error {
+func (r *Resource[T]) serveOptions(rw http.ResponseWriter, _ *http.Request, _ T) error {
 	rw.Header()["Allow"] = r.methods
 	rw.WriteHeader(http.StatusNoContent)
 	return nil


### PR DESCRIPTION
things like `*any` are nasty. use `T` instead of `*T`  and let the user choose if they want a pointer or not.