### PR TITLE
net/reconnect: Client: introduce OnSocket and OnConnect callbacks

### DIFF
--- a/net/reconnect/client.go
+++ b/net/reconnect/client.go
@@ -30,6 +30,7 @@ type Client struct {
 	writeTimeout time.Duration
 
 	waitReconnect func(context.Context) error
+	onConnect     func(context.Context, net.Conn) error
 	onSession     func(context.Context) error
 	onDisconnect  func(context.Context, net.Conn) error
 	onError       func(context.Context, net.Conn, error) error
@@ -104,6 +105,7 @@ func New(cfg *Config, options ...OptionFunc) (*Client, error) {
 		writeTimeout: cfg.WriteTimeout,
 
 		waitReconnect: cfg.WaitReconnect,
+		onConnect:     cfg.OnConnect,
 		onSession:     cfg.OnSession,
 		onDisconnect:  cfg.OnDisconnect,
 		onError:       cfg.OnError,
@@ -137,6 +139,13 @@ func (c *Client) getWaitReconnect() func(context.Context) error {
 	defer c.mu.Unlock()
 
 	return c.waitReconnect
+}
+
+func (c *Client) getOnConnect() func(context.Context, net.Conn) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return c.onConnect
 }
 
 func (c *Client) getOnSession() func(context.Context) error {

--- a/net/reconnect/config.go
+++ b/net/reconnect/config.go
@@ -53,6 +53,9 @@ type Config struct {
 	// OnSocket is called, when defined, against the raw socket before attempting to
 	// connect
 	OnSocket func(context.Context, syscall.RawConn) error
+	// OnConnect is called, when defined, immediately after the connection is established
+	// but before the session is created.
+	OnConnect func(context.Context, net.Conn) error
 
 	// OnSession is expected to block until it's done.
 	OnSession func(context.Context) error

--- a/net/std.go
+++ b/net/std.go
@@ -7,10 +7,16 @@ import (
 type (
 	// Addr is an alias of the standard net.Addr type
 	Addr = net.Addr
+	// TCPAddr is an alias of the standard net.TCPAddr type
+	TCPAddr = net.TCPAddr
 	// Conn is an alias of the standard net.Conn type
 	Conn = net.Conn
-	// IP is an alias of the stadnard net.IP type
+	// TCPConn is an alias of the standard net.TCPConn type
+	TCPConn = net.TCPConn
+	// IP is an alias of the standard net.IP type
 	IP = net.IP
 	// Listener is an alias of the standard net.Listener type
 	Listener = net.Listener
+	// TCPListener is an alias of the standard net.TCPListener type
+	TCPListener = net.TCPListener
 )


### PR DESCRIPTION
to configure the socket before dialling and the TCPConn before starting the session