### PR TITLE
web: fix redirect factories and improve 400/405/500 factories

### DIFF
--- a/web/errors.go
+++ b/web/errors.go
@@ -7,14 +7,6 @@ import (
 	"darvaza.org/x/web/consts"
 )
 
-// NewStatusBadRequest returns a 400 HTTP error.
-func NewStatusBadRequest(err error) *HTTPError {
-	return &HTTPError{
-		Code: http.StatusBadRequest,
-		Err:  err,
-	}
-}
-
 // NewStatusMethodNotAllowed returns a 405 HTTP error
 func NewStatusMethodNotAllowed(allowed ...string) *HTTPError {
 	hdr := make(http.Header)

--- a/web/errors.go
+++ b/web/errors.go
@@ -2,6 +2,7 @@ package web
 
 import (
 	"net/http"
+	"strings"
 
 	"darvaza.org/x/web/consts"
 )
@@ -16,6 +17,12 @@ func NewStatusBadRequest(err error) *HTTPError {
 
 // NewStatusMethodNotAllowed returns a 405 HTTP error
 func NewStatusMethodNotAllowed(allowed ...string) *HTTPError {
+	hdr := make(http.Header)
+
+	if s := strings.Join(allowed, ", "); s != "" {
+		hdr[consts.Allow] = []string{s}
+	}
+
 	return &HTTPError{
 		Code: http.StatusMethodNotAllowed,
 		Hdr: http.Header{

--- a/web/errors_gen.go
+++ b/web/errors_gen.go
@@ -113,16 +113,26 @@ func NewStatusPermanentRedirect(dest string, args ...any) *HTTPError {
 	}
 }
 
-// NewStatusBadRequest returns a 400 HTTP error.
+// NewStatusBadRequest returns a 400 HTTP error,
+// unless the given error is already qualified.
 func NewStatusBadRequest(err error) *HTTPError {
+	if e, ok := err.(*HTTPError); ok {
+		return e
+	}
+
 	return &HTTPError{
 		Code: http.StatusBadRequest,
 		Err:  err,
 	}
 }
 
-// NewStatusInternalServerError returns a 500 HTTP error.
+// NewStatusInternalServerError returns a 500 HTTP error,
+// unless the given error is already qualified.
 func NewStatusInternalServerError(err error) *HTTPError {
+	if e, ok := err.(*HTTPError); ok {
+		return e
+	}
+
 	return &HTTPError{
 		Code: http.StatusInternalServerError,
 		Err:  err,

--- a/web/errors_gen.go
+++ b/web/errors_gen.go
@@ -7,6 +7,7 @@ package web
 import (
 	"fmt"
 	"net/http"
+	"strings"
 
 	"darvaza.org/x/fs"
 	"darvaza.org/x/web/consts"
@@ -18,7 +19,11 @@ func NewStatusMovedPermanently(dest string, args ...any) *HTTPError {
 		dest = fmt.Sprintf(dest, args...)
 	}
 
+	trailing := strings.HasSuffix(dest, "/")
 	dest, _ = fs.Clean(dest)
+	if trailing && !strings.HasSuffix(dest, "/") {
+		dest += "/"
+	}
 
 	return &HTTPError{
 		Code: http.StatusMovedPermanently,
@@ -34,7 +39,11 @@ func NewStatusFound(dest string, args ...any) *HTTPError {
 		dest = fmt.Sprintf(dest, args...)
 	}
 
+	trailing := strings.HasSuffix(dest, "/")
 	dest, _ = fs.Clean(dest)
+	if trailing && !strings.HasSuffix(dest, "/") {
+		dest += "/"
+	}
 
 	return &HTTPError{
 		Code: http.StatusFound,
@@ -50,7 +59,11 @@ func NewStatusSeeOther(dest string, args ...any) *HTTPError {
 		dest = fmt.Sprintf(dest, args...)
 	}
 
+	trailing := strings.HasSuffix(dest, "/")
 	dest, _ = fs.Clean(dest)
+	if trailing && !strings.HasSuffix(dest, "/") {
+		dest += "/"
+	}
 
 	return &HTTPError{
 		Code: http.StatusSeeOther,
@@ -66,7 +79,11 @@ func NewStatusTemporaryRedirect(dest string, args ...any) *HTTPError {
 		dest = fmt.Sprintf(dest, args...)
 	}
 
+	trailing := strings.HasSuffix(dest, "/")
 	dest, _ = fs.Clean(dest)
+	if trailing && !strings.HasSuffix(dest, "/") {
+		dest += "/"
+	}
 
 	return &HTTPError{
 		Code: http.StatusTemporaryRedirect,
@@ -82,7 +99,11 @@ func NewStatusPermanentRedirect(dest string, args ...any) *HTTPError {
 		dest = fmt.Sprintf(dest, args...)
 	}
 
+	trailing := strings.HasSuffix(dest, "/")
 	dest, _ = fs.Clean(dest)
+	if trailing && !strings.HasSuffix(dest, "/") {
+		dest += "/"
+	}
 
 	return &HTTPError{
 		Code: http.StatusPermanentRedirect,

--- a/web/errors_gen.go
+++ b/web/errors_gen.go
@@ -113,6 +113,22 @@ func NewStatusPermanentRedirect(dest string, args ...any) *HTTPError {
 	}
 }
 
+// NewStatusBadRequest returns a 400 HTTP error.
+func NewStatusBadRequest(err error) *HTTPError {
+	return &HTTPError{
+		Code: http.StatusBadRequest,
+		Err:  err,
+	}
+}
+
+// NewStatusInternalServerError returns a 500 HTTP error.
+func NewStatusInternalServerError(err error) *HTTPError {
+	return &HTTPError{
+		Code: http.StatusInternalServerError,
+		Err:  err,
+	}
+}
+
 // NewStatusNotModified returns a 304 HTTP error.
 func NewStatusNotModified() *HTTPError {
 	return &HTTPError{

--- a/web/errors_gen.go
+++ b/web/errors_gen.go
@@ -146,6 +146,20 @@ func NewStatusNotModified() *HTTPError {
 	}
 }
 
+// NewStatusUnauthorized returns a 401 HTTP error.
+func NewStatusUnauthorized() *HTTPError {
+	return &HTTPError{
+		Code: http.StatusUnauthorized,
+	}
+}
+
+// NewStatusForbidden returns a 403 HTTP error.
+func NewStatusForbidden() *HTTPError {
+	return &HTTPError{
+		Code: http.StatusForbidden,
+	}
+}
+
 // NewStatusNotFound returns a 404 HTTP error.
 func NewStatusNotFound() *HTTPError {
 	return &HTTPError{

--- a/web/errors_gen.sh
+++ b/web/errors_gen.sh
@@ -62,6 +62,28 @@ func NewStatus$name(dest string, args ...any) *HTTPError {
 EOT
 done
 
+# wrappers
+#
+for x in \
+	BadRequest=400 \
+	InternalServerError=500 \
+	; do
+
+	name=${x%=*}
+	code=${x#*=}
+
+	cat <<EOT
+
+// NewStatus$name returns a $code HTTP error.
+func NewStatus$name(err error) *HTTPError {
+	return &HTTPError{
+		Code: http.Status$name,
+		Err:  err,
+	}
+}
+EOT
+done
+
 # basic
 #
 for x in \

--- a/web/errors_gen.sh
+++ b/web/errors_gen.sh
@@ -93,6 +93,8 @@ done
 #
 for x in \
 	NotModified=304 \
+	Unauthorized=401 \
+	Forbidden=403 \
 	NotFound=404 \
 	NotAcceptable=406 \
 	; do

--- a/web/errors_gen.sh
+++ b/web/errors_gen.sh
@@ -18,6 +18,7 @@ package $GOPACKAGE
 import (
 	"fmt"
 	"net/http"
+	"strings"
 
 	"darvaza.org/x/fs"
 	"darvaza.org/x/web/consts"
@@ -45,7 +46,11 @@ func NewStatus$name(dest string, args ...any) *HTTPError {
 		dest = fmt.Sprintf(dest, args...)
 	}
 
+	trailing := strings.HasSuffix(dest, "/")
 	dest, _ = fs.Clean(dest)
+	if trailing && !strings.HasSuffix(dest, "/") {
+		dest += "/"
+	}
 
 	return &HTTPError{
 		Code: http.Status$name,

--- a/web/errors_gen.sh
+++ b/web/errors_gen.sh
@@ -74,8 +74,13 @@ for x in \
 
 	cat <<EOT
 
-// NewStatus$name returns a $code HTTP error.
+// NewStatus$name returns a $code HTTP error,
+// unless the given error is already qualified.
 func NewStatus$name(err error) *HTTPError {
+	if e, ok := err.(*HTTPError); ok {
+		return e
+	}
+
 	return &HTTPError{
 		Code: http.Status$name,
 		Err:  err,


### PR DESCRIPTION
* make sure we preserve explicit trailing slashes on redirect factories
* improve 405 factory to send a single `Allow` header.
* introduce 401, 403 and 500 factory
* change 400 and 500 factories not to wrap other already fully qualified `*HTTPError`s.