### PR TITLE
fs: improve Glob/Match to work when ReadDir() isn't supported 

### DIFF
--- a/fs/utils.go
+++ b/fs/utils.go
@@ -1,5 +1,7 @@
 package fs
 
+import "strings"
+
 // joinRunes appends a clean path to another in a []rune buffer.
 func joinRunes(before, after []rune) []rune {
 	switch {
@@ -10,5 +12,24 @@ func joinRunes(before, after []rune) []rune {
 	default:
 		before = append(before, '/')
 		return append(before, after...)
+	}
+}
+
+func unsafeCutRoot(name, root string) (string, bool) {
+	switch {
+	case root == name:
+		return ".", true
+	case root == ".":
+		return name, name != "."
+	default:
+		s, ok := strings.CutPrefix(name, root+"/")
+		switch {
+		case !ok:
+			return "", false
+		case s == "":
+			return ".", true
+		default:
+			return s, true
+		}
 	}
 }


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced enhanced file system entry matching capabilities, allowing for better handling of different file system types.
	- Added a utility function for manipulating file paths by removing specified roots.

- **Bug Fixes**
	- Improved error handling and output consistency in file matching functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->