### PR TITLE
web/assets: AssetHandler: fix dynamic Content-Type handling

### DIFF
--- a/web/assets/assets.go
+++ b/web/assets/assets.go
@@ -165,7 +165,8 @@ func (h *AssetHandler) init() error {
 	defer h.mu.Unlock()
 
 	if h.parsedCT == nil {
-		ct, err := getContentType(h.Asset, "")
+		name, _ := getFileName(h.Asset)
+		ct, err := getContentType(h.Asset, name)
 		switch {
 		case err != nil:
 			return err

--- a/web/assets/assets.go
+++ b/web/assets/assets.go
@@ -177,6 +177,7 @@ func (h *AssetHandler) init() error {
 				return err
 			}
 
+			h.ct = ct
 			h.parsedCT = []qlist.QualityValue{qv}
 		}
 	}

--- a/web/assets/file.go
+++ b/web/assets/file.go
@@ -165,6 +165,13 @@ func getETagsSetter(v any) (ETagsSetter, bool) {
 	return nil, false
 }
 
+func getFileName(v any) (string, bool) {
+	if fi, ok := tryStat(v); ok {
+		return fi.Name(), true
+	}
+	return "", false
+}
+
 func serve500(rw http.ResponseWriter, req *http.Request, err error) {
 	h := &web.HTTPError{
 		Code: http.StatusInternalServerError,


### PR DESCRIPTION
when `embed.FS` hasn't pre-computed it