### PR TITLE
fs: add initial syscall.Flock abstraction

### DIFF
--- a/fs/flock/flock.go
+++ b/fs/flock/flock.go
@@ -1,0 +1,23 @@
+// Package flock provides a wrapper around syscall.Flock
+package flock
+
+import (
+	syscall "darvaza.org/x/fs/fssyscall"
+)
+
+// LockEx locks a file by name
+func LockEx(filename string) (syscall.Handle, error) {
+	zero := syscall.ZeroHandle
+
+	h, err := syscall.Open(filename)
+	if err != nil {
+		return zero, err
+	}
+
+	if err = syscall.LockEx(h); err != nil {
+		_ = h.Close()
+		return zero, err
+	}
+
+	return h, nil
+}

--- a/fs/fssyscall/syscall.go
+++ b/fs/fssyscall/syscall.go
@@ -20,3 +20,9 @@ func Open(filename string) (Handle, error) {
 func (h Handle) Close() error {
 	return syscall.Close(h.Sys())
 }
+
+// IsZero indicates the [Handle] doesn't refer to a possibly valid
+// descriptor
+func (h Handle) IsZero() bool {
+	return h <= ZeroHandle
+}

--- a/fs/fssyscall/syscall.go
+++ b/fs/fssyscall/syscall.go
@@ -1,0 +1,22 @@
+// Package fssyscall abstracts syscall file descriptors
+// across platform.Handles
+package fssyscall
+
+import (
+	"os"
+	"syscall"
+)
+
+// Open performs [syscall.Open] returning a [Handle]
+func Open(filename string) (Handle, error) {
+	h, err := syscall.Open(filename, os.O_RDONLY, 0)
+	if err != nil {
+		return ZeroHandle, err
+	}
+	return Handle(h), nil
+}
+
+// Close attempts to close the file associated to the [Handle]
+func (h Handle) Close() error {
+	return syscall.Close(h.Sys())
+}

--- a/fs/fssyscall/syscall_linux.go
+++ b/fs/fssyscall/syscall_linux.go
@@ -2,6 +2,10 @@
 
 package fssyscall
 
+import (
+	"syscall"
+)
+
 // ZeroHandle represents a closed [Handle]
 const ZeroHandle Handle = -1
 
@@ -10,3 +14,14 @@ type Handle int
 
 // Sys returns the underlying type for syscall operations
 func (h Handle) Sys() int { return int(h) }
+
+// LockEx attempts to create an advisory exclusive lock on
+// the file associated to the given [Handle].
+func LockEx(h Handle) error {
+	return syscall.Flock(h.Sys(), syscall.LOCK_EX)
+}
+
+// UnlockEx releases an advisory lock on the file associated with the given Handle.
+func UnlockEx(h Handle) error {
+	return syscall.Flock(h.Sys(), syscall.LOCK_UN)
+}

--- a/fs/fssyscall/syscall_linux.go
+++ b/fs/fssyscall/syscall_linux.go
@@ -1,0 +1,12 @@
+//go:build linux
+
+package fssyscall
+
+// ZeroHandle represents a closed [Handle]
+const ZeroHandle Handle = -1
+
+// Handle represents a OS specific file descriptor
+type Handle int
+
+// Sys returns the underlying type for syscall operations
+func (h Handle) Sys() int { return int(h) }

--- a/fs/fssyscall/syscall_windows.go
+++ b/fs/fssyscall/syscall_windows.go
@@ -1,0 +1,16 @@
+//go:build windows
+
+package fssyscall
+
+import (
+	"syscall"
+)
+
+// ZeroHandle represents a closed Handle
+const ZeroHandle Handle = 0
+
+// Handle represents a OS specific file descriptor
+type Handle syscall.Handle
+
+// Sys returns the underlying type for syscall operations
+func (h Handle) Sys() syscall.Handle { return syscall.Handle(h) }

--- a/fs/fssyscall/syscall_windows.go
+++ b/fs/fssyscall/syscall_windows.go
@@ -14,3 +14,21 @@ type Handle syscall.Handle
 
 // Sys returns the underlying type for syscall operations
 func (h Handle) Sys() syscall.Handle { return syscall.Handle(h) }
+
+// LockEx is a no-op function that simulates an advisory exclusive lock on the file
+// associated to the given [Handle].
+//
+// Note: This function does not provide actual locking functionality on Windows.
+// It exists for API compatibility with other platforms.
+//
+// TODO: implement
+func LockEx(Handle) error { return nil }
+
+// UnlockEx is a no-op function that releases an advisory lock on the file associated
+// with the given Handle.
+//
+// Note: This function does not provide actual locking functionality on Windows.
+// It exists for API compatibility with other platforms.
+//
+// TODO: implement
+func UnlockEx(Handle) error { return nil }


### PR DESCRIPTION
excluive lock, only only actually implemented for linux.
it will compile and pretend to lock on windows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new `flock` package for file locking functionality across different operating systems (Linux and Windows).
	- Added methods for locking, opening, and closing files to ensure safe access in concurrent environments.

- **Platform-Specific Enhancements**
	- Implemented file locking for Linux systems.
	- Added a placeholder implementation for file locking on Windows systems.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->