### PR TITLE
fs/fssyscall: change Open()'s signature to mimic syscall.Open()

### DIFF
--- a/fs/flock/flock.go
+++ b/fs/flock/flock.go
@@ -2,19 +2,22 @@
 package flock
 
 import (
+	"os"
+
 	syscall "darvaza.org/x/fs/fssyscall"
 )
 
 // LockEx locks a file by name
 func LockEx(filename string) (syscall.Handle, error) {
-	zero := syscall.ZeroHandle
+	const zero = syscall.ZeroHandle
 
-	h, err := syscall.Open(filename)
+	h, err := syscall.Open(filename, os.O_RDONLY, 0)
 	if err != nil {
 		return zero, err
 	}
 
-	if err = syscall.LockEx(h); err != nil {
+	err = syscall.LockEx(h)
+	if err != nil {
 		_ = h.Close()
 		return zero, err
 	}

--- a/fs/fssyscall/syscall.go
+++ b/fs/fssyscall/syscall.go
@@ -3,13 +3,13 @@
 package fssyscall
 
 import (
-	"os"
+	"io/fs"
 	"syscall"
 )
 
 // Open performs [syscall.Open] returning a [Handle]
-func Open(filename string) (Handle, error) {
-	h, err := syscall.Open(filename, os.O_RDONLY, 0)
+func Open(filename string, mode int, perm fs.FileMode) (Handle, error) {
+	h, err := syscall.Open(filename, mode, uint32(perm))
 	if err != nil {
 		return ZeroHandle, err
 	}


### PR DESCRIPTION
BREAKING

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced file opening flexibility by allowing specification of mode and permissions in the file system operations.

- **Bug Fixes**
	- Improved error handling clarity in file locking operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->