### PR TITLE
build-sys: remove `column -o`, deprecate `-tags tools` and introduce `GOUP_PACKAGES`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,8 @@ TOOLSDIR := $(CURDIR)/internal/build
 TMPDIR ?= $(CURDIR)/.tmp
 OUTDIR ?= $(TMPDIR)
 
-GOLANGCI_LINT_VERSION ?= v1.59.1
-REVIVE_VERSION ?= v1.3.7
+GOLANGCI_LINT_VERSION ?= $(shell $(TOOLSDIR)/get_version.sh 1.21 v1.59 v1.60)
+REVIVE_VERSION ?= $(shell $(TOOLSDIR)/get_version.sh 1.21 v1.4 )
 
 GOLANGCI_LINT_URL ?= github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
 GOLANGCI_LINT ?= $(GO) run $(GOLANGCI_LINT_URL)

--- a/config/go.mod
+++ b/config/go.mod
@@ -3,7 +3,7 @@ module darvaza.org/x/config
 go 1.21
 
 require (
-	darvaza.org/core v0.14.8
+	darvaza.org/core v0.14.9
 	github.com/amery/defaults v0.1.0
 )
 

--- a/config/go.sum
+++ b/config/go.sum
@@ -1,5 +1,5 @@
-darvaza.org/core v0.14.8 h1:sQ3+jWjvqtF3sSW2kAGCFT7zWKcLfyhy1mCV2QU7pzs=
-darvaza.org/core v0.14.8/go.mod h1:KCXKssntfqEfuzJa6KMa7F1ShU/lYh1TKt2f4cmEdO0=
+darvaza.org/core v0.14.9 h1:PFUMctIwlAYEOpue/Ph+xm3Ui2PWbXg3enIJfRVhLuM=
+darvaza.org/core v0.14.9/go.mod h1:KCXKssntfqEfuzJa6KMa7F1ShU/lYh1TKt2f4cmEdO0=
 github.com/amery/defaults v0.1.0 h1:4AhTgLUnj8BPjVRBzg4+/cSCwPWPT6+yWCM4rD6Feyc=
 github.com/amery/defaults v0.1.0/go.mod h1:duOYkvd60q8XOL1+vdSHx5ABTGDMU2iFKr5xJnMEpBk=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/fs/go.mod
+++ b/fs/go.mod
@@ -3,7 +3,7 @@ module darvaza.org/x/fs
 go 1.21
 
 require (
-	darvaza.org/core v0.14.8
+	darvaza.org/core v0.14.9
 	github.com/gobwas/glob v0.2.3
 )
 

--- a/fs/go.sum
+++ b/fs/go.sum
@@ -1,5 +1,5 @@
-darvaza.org/core v0.14.8 h1:sQ3+jWjvqtF3sSW2kAGCFT7zWKcLfyhy1mCV2QU7pzs=
-darvaza.org/core v0.14.8/go.mod h1:KCXKssntfqEfuzJa6KMa7F1ShU/lYh1TKt2f4cmEdO0=
+darvaza.org/core v0.14.9 h1:PFUMctIwlAYEOpue/Ph+xm3Ui2PWbXg3enIJfRVhLuM=
+darvaza.org/core v0.14.9/go.mod h1:KCXKssntfqEfuzJa6KMa7F1ShU/lYh1TKt2f4cmEdO0=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 golang.org/x/net v0.29.0 h1:5ORfpBpCs4HzDYoodCDBbwHzdR5UrLBZ3sOnUJmFoHo=

--- a/internal/build/gen_mk.sh
+++ b/internal/build/gen_mk.sh
@@ -78,7 +78,6 @@ gen_files_lists() {
 	cat <<EOT
 GO_FILES = \$(shell find * \\
 	-type d -name node_modules -prune -o \\
-	-path internal/build -prune -o \\
 	-type f -name '*.go' -print )
 
 EOT
@@ -155,35 +154,7 @@ gen_make_targets() {
 			cd="cd '$dir'; "
 		fi
 
-		if [ "$name" = root ]; then
-			# special case
-			case "$cmd" in
-			get)
-				cmdx="get -tags tools -v ./..."
-				;;
-			up)
-				cmdx="get -tags tools -u \$(GOUP_FLAGS) \$(GOUP_PACKAGES)"
-				;;
-			*)
-				cmdx=
-				;;
-			esac
-
-			case "$cmd" in
-			up)
-				callx="$cmdx
-\$(GO) mod tidy"
-				;;
-			get)
-				callx="$cmdx"
-				;;
-			*)
-				callx="$call"
-				;;
-			esac
-		else
-			callx="$call"
-		fi
+		callx="$call"
 
 		if [ "build" = "$cmd" ]; then
 			# special build flags for cmd/*

--- a/internal/build/gen_mk.sh
+++ b/internal/build/gen_mk.sh
@@ -129,7 +129,7 @@ gen_make_targets() {
 		depsx="fmt"
 		;;
 	up)
-		call="\$(GO) get -u -v ./...
+		call="\$(GO) get -u \$(GOUP_FLAGS) \$(GOUP_PACKAGES)
 \$(GO) mod tidy"
 		;;
 	test)
@@ -159,17 +159,15 @@ gen_make_targets() {
 			# special case
 			case "$cmd" in
 			get)
-				cmdx="get -tags tools"
+				cmdx="get -tags tools -v ./..."
 				;;
 			up)
-				cmdx="get -tags tools -u"
+				cmdx="get -tags tools -u \$(GOUP_FLAGS) \$(GOUP_PACKAGES)"
 				;;
 			*)
 				cmdx=
 				;;
 			esac
-
-			[ -z "$cmdx" ] || cmdx="\$(GO) $cmdx -v ./..."
 
 			case "$cmd" in
 			up)

--- a/internal/build/gen_mk.sh
+++ b/internal/build/gen_mk.sh
@@ -102,7 +102,7 @@ EOT
 		cat <<-EOT
 		$files$TAB=$TAB$files_cmd
 		EOT
-	done < "$INDEX" | column -t -s "$TAB" -o " "
+	done < "$INDEX" | column -t -s "$TAB"
 }
 
 gen_make_targets() {

--- a/internal/build/get_version.sh
+++ b/internal/build/get_version.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+set -eu
+GO_VERSION=$(${GO:-go} version| sed -ne 's|.* go\([0-9][^ ]\+\)[ $].*|\1|p')
+
+if [ $# -eq 0 ]; then
+	echo "$GO_VERSION"
+	exit 0
+fi
+
+GO_MAJOR=$(echo "$GO_VERSION" | cut -d. -f1)
+GO_MINOR=$(echo "$GO_VERSION" | cut -d. -f2)
+GO_VER=$(( GO_MAJOR * 1000 + GO_MINOR ))
+
+X=$(echo "$1" | cut -d. -f1)
+Y=$(echo "$1" | cut -d. -f2)
+VER=$(( X * 1000 + Y))
+
+shift
+
+if [ $GO_VER -ge $VER -a $# -gt 0 ]; then
+	for ver; do
+		[ $GO_VER -gt $VER ] || break
+
+		VER=$(( VER + 1 ))
+	done
+
+	echo "$ver"
+	exit 0
+fi
+
+echo "unknown"
+exit 1

--- a/internal/build/tools.go
+++ b/internal/build/tools.go
@@ -1,3 +1,0 @@
-//go:build tools
-
-package build

--- a/net/go.mod
+++ b/net/go.mod
@@ -3,7 +3,7 @@ module darvaza.org/x/net
 go 1.21
 
 require (
-	darvaza.org/core v0.14.8
+	darvaza.org/core v0.14.9
 	darvaza.org/slog v0.5.10
 	darvaza.org/slog/handlers/discard v0.4.13
 	darvaza.org/x/fs v0.3.1

--- a/net/go.sum
+++ b/net/go.sum
@@ -1,5 +1,5 @@
-darvaza.org/core v0.14.8 h1:sQ3+jWjvqtF3sSW2kAGCFT7zWKcLfyhy1mCV2QU7pzs=
-darvaza.org/core v0.14.8/go.mod h1:KCXKssntfqEfuzJa6KMa7F1ShU/lYh1TKt2f4cmEdO0=
+darvaza.org/core v0.14.9 h1:PFUMctIwlAYEOpue/Ph+xm3Ui2PWbXg3enIJfRVhLuM=
+darvaza.org/core v0.14.9/go.mod h1:KCXKssntfqEfuzJa6KMa7F1ShU/lYh1TKt2f4cmEdO0=
 darvaza.org/slog v0.5.10 h1:93UKGr7emVjDH2p0/gHI+YtxgrjRhmf2GFSaewUuwjM=
 darvaza.org/slog v0.5.10/go.mod h1:aYpac2hRymuxsw6nB5LIiZnMgj8hX2FzEl26dsQAGLM=
 darvaza.org/slog/handlers/discard v0.4.13 h1:MsEaFB41j/G+aQ5NWkQhWQHRoqmh1C947AVvnHT7Prg=

--- a/tls/go.mod
+++ b/tls/go.mod
@@ -3,7 +3,7 @@ module darvaza.org/x/tls
 go 1.21
 
 require (
-	darvaza.org/core v0.14.8
+	darvaza.org/core v0.14.9
 	darvaza.org/slog v0.5.10
 )
 

--- a/tls/go.sum
+++ b/tls/go.sum
@@ -1,5 +1,5 @@
-darvaza.org/core v0.14.8 h1:sQ3+jWjvqtF3sSW2kAGCFT7zWKcLfyhy1mCV2QU7pzs=
-darvaza.org/core v0.14.8/go.mod h1:KCXKssntfqEfuzJa6KMa7F1ShU/lYh1TKt2f4cmEdO0=
+darvaza.org/core v0.14.9 h1:PFUMctIwlAYEOpue/Ph+xm3Ui2PWbXg3enIJfRVhLuM=
+darvaza.org/core v0.14.9/go.mod h1:KCXKssntfqEfuzJa6KMa7F1ShU/lYh1TKt2f4cmEdO0=
 darvaza.org/slog v0.5.10 h1:93UKGr7emVjDH2p0/gHI+YtxgrjRhmf2GFSaewUuwjM=
 darvaza.org/slog v0.5.10/go.mod h1:aYpac2hRymuxsw6nB5LIiZnMgj8hX2FzEl26dsQAGLM=
 golang.org/x/crypto v0.27.0 h1:GXm2NjJrPaiv/h1tb2UH8QfgC/hOf/+z0p6PT8o1w7A=

--- a/web/go.mod
+++ b/web/go.mod
@@ -3,7 +3,7 @@ module darvaza.org/x/web
 go 1.21
 
 require (
-	darvaza.org/core v0.14.8
+	darvaza.org/core v0.14.9
 	darvaza.org/x/fs v0.3.1
 )
 

--- a/web/go.sum
+++ b/web/go.sum
@@ -1,5 +1,5 @@
-darvaza.org/core v0.14.8 h1:sQ3+jWjvqtF3sSW2kAGCFT7zWKcLfyhy1mCV2QU7pzs=
-darvaza.org/core v0.14.8/go.mod h1:KCXKssntfqEfuzJa6KMa7F1ShU/lYh1TKt2f4cmEdO0=
+darvaza.org/core v0.14.9 h1:PFUMctIwlAYEOpue/Ph+xm3Ui2PWbXg3enIJfRVhLuM=
+darvaza.org/core v0.14.9/go.mod h1:KCXKssntfqEfuzJa6KMa7F1ShU/lYh1TKt2f4cmEdO0=
 darvaza.org/x/fs v0.3.1 h1:REQbS2vjpmwHtyfEWpUmtR598Q8s57vFcFu35Ccck+A=
 darvaza.org/x/fs v0.3.1/go.mod h1:nUenMGryeLgm7BuIu46xpPBTBnWTrzZOTukROBAoK/I=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated the `darvaza.org/core` dependency to version `v0.14.9` across multiple modules, enhancing performance and stability.
  
- **Bug Fixes**
	- Removed unnecessary whitespace handling in the Makefile generation process, streamlining output formatting.
	- Enhanced logic for the `build` command to ensure proper handling of project directories.

- **Chores**
	- Removed the `internal/build/tools.go` file, eliminating outdated build configurations.
	- Added a new script to dynamically retrieve and compare Go versions for improved version management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->