### PR TITLE
tls/x509utils: add helpers to check names against certificates

### DIFF
--- a/tls/x509utils/names.go
+++ b/tls/x509utils/names.go
@@ -1,0 +1,52 @@
+package x509utils
+
+import (
+	"crypto/x509"
+	"fmt"
+	"net"
+	"net/netip"
+	"strings"
+
+	"darvaza.org/core"
+)
+
+// Names returns a list of exact names and patterns the certificate
+// supports
+func Names(cert *x509.Certificate) ([]string, []string) {
+	names, patterns := splitDNSNames(cert.DNSNames)
+	names = appendIPAddresses(names, cert.IPAddresses)
+
+	// deduplicate
+	names = core.SliceUnique(names)
+	patterns = core.SliceUnique(patterns)
+
+	return names, patterns
+}
+
+func splitDNSNames(dnsNames []string) (names []string, patterns []string) {
+	for _, s := range dnsNames {
+		s = strings.ToLower(s)
+
+		if strings.HasPrefix(s, "*.") {
+			// pattern
+			patterns = append(patterns, s[1:])
+		} else if s != "" {
+			// literal
+			names = append(names, s)
+		}
+	}
+
+	return names, patterns
+}
+
+func appendIPAddresses(names []string, addrs []net.IP) []string {
+	for _, ip := range addrs {
+		if addr, ok := netip.AddrFromSlice(ip); ok {
+			if addr.IsValid() {
+				name := fmt.Sprintf("[%s]", addr.String())
+				names = append(names, name)
+			}
+		}
+	}
+	return names
+}

--- a/tls/x509utils/names.go
+++ b/tls/x509utils/names.go
@@ -100,3 +100,13 @@ func NameAsIP(name string) (string, bool) {
 	}
 	return "", false
 }
+
+// NameAsSuffix prepares a sanitised hostname for matching
+// certificate patterns
+func NameAsSuffix(name string) (string, bool) {
+	if idx := strings.IndexRune(name, '.'); idx > 0 {
+		name = name[idx:]
+		return name, len(name) > 1
+	}
+	return "", false
+}

--- a/tls/x509utils/names.go
+++ b/tls/x509utils/names.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"net/netip"
+	"net/url"
 	"strings"
 
 	"darvaza.org/core"
@@ -49,6 +50,11 @@ func appendIPAddresses(names []string, addrs []net.IP) []string {
 		}
 	}
 	return names
+}
+
+// Hostname returns a sanitised hostname for a parsed URL
+func Hostname(u *url.URL) (string, bool) {
+	return SanitizeName(u.Host)
 }
 
 // SanitizeName takes a Hostname and returns the name (or address)

--- a/tls/x509utils/names.go
+++ b/tls/x509utils/names.go
@@ -91,3 +91,12 @@ func removeZone(name string) string {
 	}
 	return name[:idx]
 }
+
+// NameAsIP prepares a sanitised IP address name for matching certificates
+func NameAsIP(name string) (string, bool) {
+	if addr, err := core.ParseAddr(name); err == nil {
+		s := fmt.Sprintf("[%s]", addr)
+		return s, true
+	}
+	return "", false
+}

--- a/tls/x509utils/names.go
+++ b/tls/x509utils/names.go
@@ -50,3 +50,38 @@ func appendIPAddresses(names []string, addrs []net.IP) []string {
 	}
 	return names
 }
+
+// SanitizeName takes a Hostname and returns the name (or address)
+// we will use for matching certificates
+func SanitizeName(name string) (string, bool) {
+	if name != "" {
+		// validate and remove port and brackets if present
+		if host, _, err := core.SplitHostPort(name); err == nil {
+			return doSanitizeName(host)
+		}
+	}
+	return "", false
+}
+
+func doSanitizeName(name string) (string, bool) {
+	if addr, err := core.ParseAddr(name); err == nil {
+		// IP
+		addr = addr.Unmap()
+		addr = addr.WithZone("")
+		name = addr.String()
+	} else {
+		// Name
+		name = removeZone(name)
+	}
+	return name, len(name) > 0
+}
+
+func removeZone(name string) string {
+	idx := strings.LastIndexFunc(name, func(r rune) bool {
+		return r == '%'
+	})
+	if idx < 0 {
+		return name
+	}
+	return name[:idx]
+}

--- a/tls/x509utils/names_test.go
+++ b/tls/x509utils/names_test.go
@@ -1,0 +1,31 @@
+package x509utils
+
+import (
+	"testing"
+
+	"darvaza.org/core"
+)
+
+type nameAsTest struct {
+	Name     string
+	Expected string
+	Ok       bool
+}
+
+func TestNameAsIP(t *testing.T) {
+	var entries = []nameAsTest{
+		{"a.b.c", "", false},
+		{"0", "[0.0.0.0]", true},
+		{"1.2.3.4", "[1.2.3.4]", true},
+		{"1.2.3.400", "", false},
+		{"::", "[::]", true},
+		{"foo.example.org", "", false},
+	}
+
+	for _, entry := range entries {
+		s, ok := NameAsIP(entry.Name)
+		if s != entry.Expected || ok != entry.Ok {
+			t.Errorf("NameAsIP(%q) -> %q, %v", entry.Name, s, ok)
+		}
+	}
+}

--- a/tls/x509utils/names_test.go
+++ b/tls/x509utils/names_test.go
@@ -2,8 +2,6 @@ package x509utils
 
 import (
 	"testing"
-
-	"darvaza.org/core"
 )
 
 type nameAsTest struct {
@@ -26,6 +24,26 @@ func TestNameAsIP(t *testing.T) {
 		s, ok := NameAsIP(entry.Name)
 		if s != entry.Expected || ok != entry.Ok {
 			t.Errorf("NameAsIP(%q) -> %q, %v", entry.Name, s, ok)
+		}
+	}
+}
+
+func TestNameAsSuffix(t *testing.T) {
+	var entries = []nameAsTest{
+		{"foo.example.com", ".example.com", true},
+		{".example.com", "", false},
+		{"a.b.c", ".b.c", true},
+		{".b.c", "", false},
+		{"b.c", ".c", true},
+		{".c", "", false},
+		{"c", "", false},
+		{"", "", false},
+	}
+
+	for _, entry := range entries {
+		s, ok := NameAsSuffix(entry.Name)
+		if s != entry.Expected || ok != entry.Ok {
+			t.Errorf("NameAsSuffix(%q) -> %q, %v", entry.Name, s, ok)
 		}
 	}
 }


### PR DESCRIPTION
imported from darvaza.org/darvaza/shared/x509utils

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced functions for handling and sanitizing names associated with X.509 certificates.
	- Added capabilities to extract and format DNS names and IP addresses from certificates.
	- Implemented hostname sanitization for improved URL handling.
	- Enhanced functionality for stripping zone information from names.

- **Tests**
	- Added unit tests for `NameAsIP` and `NameAsSuffix` functions to ensure correct behavior across various scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->