### PR TITLE
tls/x509utils: SubjectPublicKeyBytes() and SHA1/SHA224/SHA256 shortcuts

### DIFF
--- a/tls/x509utils/spki.go
+++ b/tls/x509utils/spki.go
@@ -33,6 +33,17 @@ func SubjectPublicKeySHA224(pub crypto.PublicKey) (hash [sha256.Size224]byte, er
 	return sha256.Sum224(b), nil
 }
 
+// SubjectPublicKeySHA256 returns the SHA256 hash of the SubjectPublicKey
+// of a [crypto.PublicKey]
+func SubjectPublicKeySHA256(pub crypto.PublicKey) (hash [sha256.Size]byte, err error) {
+	b, err := SubjectPublicKeyBytes(pub)
+	if err != nil {
+		return hash, err
+	}
+
+	return sha256.Sum256(b), nil
+}
+
 // SubjectPublicKeyBytes extracts the SubjectPublicKey bytes
 // from a [crypto.PublicKey]
 func SubjectPublicKeyBytes(pub crypto.PublicKey) ([]byte, error) {

--- a/tls/x509utils/spki.go
+++ b/tls/x509utils/spki.go
@@ -3,6 +3,7 @@ package x509utils
 import (
 	"crypto"
 	"crypto/sha1"
+	"crypto/sha256"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/asn1"
@@ -19,6 +20,17 @@ func SubjectPublicKeySHA1(pub crypto.PublicKey) (hash [sha1.Size]byte, err error
 	}
 
 	return sha1.Sum(b), nil
+}
+
+// SubjectPublicKeySHA224 returns the SHA224 hash of the SubjectPublicKey
+// of a [crypto.PublicKey]
+func SubjectPublicKeySHA224(pub crypto.PublicKey) (hash [sha256.Size224]byte, err error) {
+	b, err := SubjectPublicKeyBytes(pub)
+	if err != nil {
+		return hash, err
+	}
+
+	return sha256.Sum224(b), nil
 }
 
 // SubjectPublicKeyBytes extracts the SubjectPublicKey bytes

--- a/tls/x509utils/spki.go
+++ b/tls/x509utils/spki.go
@@ -1,0 +1,45 @@
+package x509utils
+
+import (
+	"crypto"
+	"crypto/sha1"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+
+	"darvaza.org/core"
+)
+
+// SubjectPublicKeySHA1 returns the SHA1 hash of the SubjectPublicKey
+// of a [crypto.PublicKey]
+func SubjectPublicKeySHA1(pub crypto.PublicKey) (hash [sha1.Size]byte, err error) {
+	b, err := SubjectPublicKeyBytes(pub)
+	if err != nil {
+		return hash, err
+	}
+
+	return sha1.Sum(b), nil
+}
+
+// SubjectPublicKeyBytes extracts the SubjectPublicKey bytes
+// from a [crypto.PublicKey]
+func SubjectPublicKeyBytes(pub crypto.PublicKey) ([]byte, error) {
+	spkiASN1, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		err = core.Wrap(err, "failed to encode public key")
+		return nil, err
+	}
+
+	var spki struct {
+		Algorithm        pkix.AlgorithmIdentifier
+		SubjectPublicKey asn1.BitString
+	}
+
+	_, err = asn1.Unmarshal(spkiASN1, &spki)
+	if err != nil {
+		err = core.Wrap(err, "failed to decode public key")
+		return nil, err
+	}
+
+	return spki.SubjectPublicKey.Bytes, nil
+}


### PR DESCRIPTION
to index and compare public keys

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new function to compute the SHA256 hash of the Subject Public Key.
	- Enhanced functionality for handling Subject Public Keys with SHA1 and SHA224 hashing.
	- Added functionality to extract raw bytes of the Subject Public Key.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->