### PR TITLE
tls: introduce Store instead and NewConfig/WithStore helper

### DIFF
--- a/tls/std.go
+++ b/tls/std.go
@@ -1,0 +1,12 @@
+// Package tls aids working with TLS Certificates
+package tls
+
+import "crypto/tls"
+
+type (
+	// Certificate is an alias of the standard [tls.Certificate]
+	Certificate = tls.Certificate
+
+	// Config is an alias of the standard [tls.Config]
+	Config = tls.Config
+)

--- a/tls/store.go
+++ b/tls/store.go
@@ -1,0 +1,48 @@
+package tls
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+)
+
+// A Store is used to set up a [tls.Config].
+type Store interface {
+	GetCertificate(*tls.ClientHelloInfo) (*tls.Certificate, error)
+	GetCAPool() *x509.CertPool
+}
+
+// WithStore binds a given [Store] to the [tls.Config]
+func WithStore(cfg *tls.Config, store Store) error {
+	if cfg == nil {
+		return fmt.Errorf("missing argument: %s", "cfg")
+	}
+
+	if store == nil {
+		return fmt.Errorf("missing argument: %s", "store")
+	}
+
+	pool := store.GetCAPool()
+	if pool == nil {
+		return fmt.Errorf("missing parameter: %s", "CAPool")
+	}
+
+	cfg.GetCertificate = store.GetCertificate
+	cfg.RootCAs = pool
+	cfg.ClientCAs = pool
+	return nil
+}
+
+// NewConfig returns a basic [tls.Config] optionally configured to use the given Store.
+func NewConfig(store Store) (*tls.Config, error) {
+	cfg := &tls.Config{
+		MinVersion: tls.VersionTLS12,
+	}
+
+	if store != nil {
+		if err := WithStore(cfg, store); err != nil {
+			return nil, err
+		}
+	}
+	return cfg, nil
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced type aliases for easier reference to TLS certificate and configuration types.
	- Added a `Store` interface for managing TLS settings, including methods for retrieving certificates and CA pools.
	- Implemented functions to bind a `Store` instance to TLS configurations and create new TLS configurations with predefined settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->