### PR TITLE
tls/x509utils: introduce CertPool and CertPoolWriter interfaces

### DIFF
--- a/tls/x509utils/types.go
+++ b/tls/x509utils/types.go
@@ -2,10 +2,12 @@
 package x509utils
 
 import (
+	"context"
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/ed25519"
 	"crypto/rsa"
+	"crypto/x509"
 )
 
 var (
@@ -27,4 +29,26 @@ type PrivateKey interface {
 // PublicKey implements what crypto.PublicKey should have
 type PublicKey interface {
 	Equal(crypto.PublicKey) bool
+}
+
+// A CertPool contains x509 certificates and allows individual
+// access to them which the standard [x509.CertPool] doesn't.
+type CertPool interface {
+	Get(ctx context.Context, name string) (*x509.Certificate, error)
+	ForEach(ctx context.Context, fn func(context.Context, *x509.Certificate) bool)
+
+	Clone() CertPool
+	Export() *x509.CertPool
+}
+
+// A CertPoolWriter extends the CertPool interface with write capabilities.
+type CertPoolWriter interface {
+	CertPool
+
+	Put(ctx context.Context, name string, cert *x509.Certificate) error
+	Delete(ctx context.Context, name string) error
+	DeleteCert(ctx context.Context, cert *x509.Certificate) error
+
+	Import(ctx context.Context, src CertPool) (int, error)
+	ImportPEM(ctx context.Context, b []byte) (int, error)
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new interfaces for enhanced certificate management: `CertPool` for accessing x509 certificates and `CertPoolWriter` for modifying the certificate pool.
	- Added methods for retrieving, iterating, cloning, and exporting certificates, as well as adding, removing, and importing certificates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->