### PR TITLE
build-sys: introduce GOTEST_FLAGS for `make test`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ GOFMT_FLAGS = -w -l -s
 GOGENERATE_FLAGS = -v
 GOUP_FLAGS ?= -v
 GOUP_PACKAGES ?= ./...
+GOTEST_FLAGS ?=
 
 TOOLSDIR := $(CURDIR)/internal/build
 TMPDIR ?= $(CURDIR)/.tmp

--- a/internal/build/gen_mk.sh
+++ b/internal/build/gen_mk.sh
@@ -132,7 +132,7 @@ gen_make_targets() {
 \$(GO) mod tidy"
 		;;
 	test)
-		call="\$(GO) $cmd ./..."
+		call="\$(GO) $cmd \$(GOTEST_FLAGS) ./..."
 		;;
 	*)
 		call="\$(GO) $cmd -v ./..."


### PR DESCRIPTION
allowing `make test GOTEST_FLAGS=-v` to see T.Logf()s

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new variable for test flags in the build configuration, allowing for future enhancements in testing.
	- Updated the testing command to include additional configuration options.

- **Bug Fixes**
	- Improved command handling and output generation for Go projects, enhancing the testing process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->