### PR TITLE
tls/x509utils: Change ReadPEM to fail with ErrEmpty when no data is provided.

### DIFF
--- a/tls/x509utils/certpool/system_linux.go
+++ b/tls/x509utils/certpool/system_linux.go
@@ -3,7 +3,6 @@
 package certpool
 
 import (
-	"errors"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -58,27 +57,18 @@ func loadCertsFirstFile(pool *CertPool, errs *core.CompoundError, files ...strin
 
 func loadCertsFile(addFn x509utils.DecodePEMBlockFunc, fileName string) error {
 	b, err := os.ReadFile(fileName)
-	switch {
-	case err != nil:
+	if err != nil {
 		return err
-	case len(b) == 0:
-		// empty file:
-		return &fs.PathError{
-			Op:   "read",
-			Path: fileName,
-			Err:  errors.New("empty certificates file"),
-		}
-	default:
-		if err := x509utils.ReadPEM(b, addFn); err != nil {
-			// bad content
-			return &fs.PathError{
-				Op:   "pem.Decode",
-				Path: fileName,
-				Err:  err,
-			}
-		}
-		return nil
 	}
+	if err := x509utils.ReadPEM(b, addFn); err != nil {
+		// bad content
+		return &fs.PathError{
+			Op:   "pem.Decode",
+			Path: fileName,
+			Err:  err,
+		}
+	}
+	return nil
 }
 
 func loadCertsDir(pool *CertPool, dir string) error {

--- a/tls/x509utils/pem_block.go
+++ b/tls/x509utils/pem_block.go
@@ -10,7 +10,10 @@ import (
 )
 
 var (
-	// ErrIgnored is used when we ask the user to try a different function instead
+	// ErrEmpty indicates the file, string or bytes slice is empty.
+	ErrEmpty = errors.New("empty")
+
+	// ErrIgnored is used when we ask the user to try a different function instead.
 	ErrIgnored = errors.New("type of value out of scope")
 
 	// ErrNotSupported indicates the type of [PrivateKey] or [PublicKey] isn't

--- a/tls/x509utils/pem_read.go
+++ b/tls/x509utils/pem_read.go
@@ -16,7 +16,10 @@ type DecodePEMBlockFunc func(fSys fs.FS, filename string, block *pem.Block) bool
 // ReadPEM invoques a callback for each PEM block found
 // it can receive raw PEM data
 func ReadPEM(b []byte, cb DecodePEMBlockFunc) error {
-	if len(b) == 0 || cb == nil {
+	switch {
+	case len(b) == 0:
+		return ErrEmpty
+	case cb == nil:
 		// nothing do
 		return nil
 	}


### PR DESCRIPTION
BREAKING CHANGE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new error variable `ErrEmpty` to indicate empty inputs in the `x509utils` package.

- **Bug Fixes**
	- Enhanced error handling in the `ReadPEM` function for improved clarity regarding empty inputs.
	- Simplified error handling in the `loadCertsFile` function for better readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->