### PR TITLE
tls/x509utils/certpool: cached Export() and non-sharing Copy()

### DIFF
--- a/tls/x509utils/certpool/certpool.go
+++ b/tls/x509utils/certpool/certpool.go
@@ -2,6 +2,7 @@
 package certpool
 
 import (
+	"crypto/x509"
 	"sync"
 
 	"darvaza.org/x/tls/x509utils"
@@ -15,6 +16,7 @@ var (
 type CertPool struct {
 	mu sync.RWMutex
 
+	cache    *x509.CertPool
 	hashed   map[Hash]*certPoolEntry
 	names    map[string]*List[*certPoolEntry]
 	patterns map[string]*List[*certPoolEntry]
@@ -70,6 +72,7 @@ func (s *CertPool) init() {
 }
 
 func (s *CertPool) reset() {
+	s.cache = nil
 	s.hashed = make(map[Hash]*certPoolEntry)
 	s.names = make(map[string]*List[*certPoolEntry])
 	s.patterns = make(map[string]*List[*certPoolEntry])

--- a/tls/x509utils/certpool/certpool_copy.go
+++ b/tls/x509utils/certpool/certpool_copy.go
@@ -9,16 +9,43 @@ import (
 // Export assembles a [x509.CertPool] with all the certificates
 // contained in the store.
 func (s *CertPool) Export() *x509.CertPool {
-	out := x509.NewCertPool()
-	if s != nil {
-		s.mu.RLock()
-		defer s.mu.RUnlock()
+	if s == nil {
+		return x509.NewCertPool()
+	}
 
-		for _, ce := range s.hashed {
-			out.AddCert(ce.cert)
-		}
+	// RO
+	s.mu.RLock()
+	out := s.cache
+	s.mu.RUnlock()
+
+	if out != nil {
+		// cached
+		return out
+	}
+
+	// RW
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	out = s.cache
+	if out == nil {
+		// assemble and store
+		out = s.unsafeExport()
+		s.cache = out
 	}
 	return out
+}
+
+func (s *CertPool) unsafeExport() *x509.CertPool {
+	out := x509.NewCertPool()
+	for _, ce := range s.hashed {
+		out.AddCert(ce.cert)
+	}
+	return out
+}
+
+func (s *CertPool) unsafeInvalidateCache() {
+	s.cache = nil
 }
 
 // Copy creates a copy of the [CertPool] store, optionally

--- a/tls/x509utils/certpool/certpool_copy.go
+++ b/tls/x509utils/certpool/certpool_copy.go
@@ -30,31 +30,44 @@ func (s *CertPool) Copy(out *CertPool, caOnly bool) *CertPool {
 			out = New()
 		}
 		return out
-	case out == nil:
-		return s.doClone(caOnly)
 	case out == s:
 		// avoid copying to itself
 		return s
 	default:
-		return s.doCopy(out, caOnly)
+		cond := newCertPoolEntryCondFn(caOnly)
+
+		if out == nil {
+			return s.doClone(cond)
+		}
+
+		return s.doCopy(out, cond)
 	}
 }
 
-//revive:disable:flag-parameter
-func (s *CertPool) doCopy(out *CertPool, caOnly bool) *CertPool {
-	//revive:enable:flag-parameter
+func (s *CertPool) doCopy(out *CertPool, cond func(*certPoolEntry) bool) *CertPool {
+	// extend condition to exclude those
+	// already present
+	cond2 := func(ce *certPoolEntry) bool {
+		if !cond(ce) {
+			// not wanted
+			return false
+		}
+		_, found := out.hashed[ce.hash]
+		return !found
+	}
+
+	// clone creates a copy of acceptable entries
+	clone := newCertPoolEntryCopyFn(cond2)
+
 	out.mu.Lock()
 	defer out.mu.Unlock()
 
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	for hash, ce := range s.hashed {
-		if !caOnly || ce.IsCA() {
-			if _, found := out.hashed[hash]; !found {
-				// new
-				out.unsafeAddCertEntry(ce)
-			}
+	for _, ce := range s.hashed {
+		if ce2, ok := clone(ce); ok {
+			out.unsafeAddCertEntry(ce2)
 		}
 	}
 
@@ -67,16 +80,14 @@ func (s *CertPool) Clone() x509utils.CertPool {
 		return nil
 	}
 
-	return s.doClone(false)
+	return s.doClone(certPoolEntryValid)
 }
 
-func (s *CertPool) doClone(caOnly bool) *CertPool {
+func (s *CertPool) doClone(cond func(*certPoolEntry) bool) *CertPool {
+	fn := newCertPoolEntryCopyFn(cond)
+
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-
-	fn := func(ce *certPoolEntry) (*certPoolEntry, bool) {
-		return ce, !caOnly || ce.IsCA()
-	}
 
 	return &CertPool{
 		hashed:   copyMap(s.hashed, fn),

--- a/tls/x509utils/certpool/certpool_entry.go
+++ b/tls/x509utils/certpool/certpool_entry.go
@@ -1,6 +1,10 @@
 package certpool
 
-import "crypto/x509"
+import (
+	"crypto/x509"
+
+	"darvaza.org/core"
+)
 
 type certPoolEntry struct {
 	cert *x509.Certificate
@@ -8,6 +12,19 @@ type certPoolEntry struct {
 	hash     Hash
 	names    []string
 	patterns []string
+}
+
+func (ce *certPoolEntry) Clone() *certPoolEntry {
+	if !ce.Valid() {
+		return nil
+	}
+
+	return &certPoolEntry{
+		cert:     ce.cert,
+		hash:     ce.hash,
+		names:    core.SliceCopy(ce.names),
+		patterns: core.SliceCopy(ce.patterns),
+	}
 }
 
 func (ce *certPoolEntry) Equal(other *certPoolEntry) bool {
@@ -21,21 +38,52 @@ func (ce *certPoolEntry) Equal(other *certPoolEntry) bool {
 	}
 }
 
+func (ce *certPoolEntry) Valid() bool {
+	return ce != nil && ce.cert != nil
+}
+
 func (ce *certPoolEntry) Hash() (Hash, bool) {
-	var zero Hash
-	switch {
-	case ce == nil, ce.cert == nil:
-		return zero, false
-	default:
+	if ce.Valid() {
 		return ce.hash, true
 	}
+
+	return Hash{}, false
 }
 
 func (ce *certPoolEntry) IsCA() bool {
-	switch {
-	case ce == nil, ce.cert == nil:
-		return false
-	default:
+	if ce.Valid() {
 		return ce.cert.IsCA
 	}
+	return false
+}
+
+//revive:disable:flag-parameter
+func newCertPoolEntryCondFn(caOnly bool) func(*certPoolEntry) bool {
+	//revive:enable:flag-parameter
+
+	if caOnly {
+		return certPoolEntryIsCA
+	}
+
+	return certPoolEntryValid
+}
+
+func newCertPoolEntryCopyFn(cond func(*certPoolEntry) bool) func(*certPoolEntry) (*certPoolEntry, bool) {
+	if cond == nil {
+		cond = certPoolEntryValid
+	}
+
+	return func(ce *certPoolEntry) (ce2 *certPoolEntry, ok bool) {
+		if cond(ce) {
+			ce2 = ce.Clone()
+		}
+		return ce2, ce2 != nil
+	}
+}
+func certPoolEntryIsCA(ce *certPoolEntry) bool {
+	return ce.IsCA()
+}
+
+func certPoolEntryValid(ce *certPoolEntry) bool {
+	return ce.Valid()
 }

--- a/tls/x509utils/certpool/certpool_reader.go
+++ b/tls/x509utils/certpool/certpool_reader.go
@@ -54,7 +54,9 @@ func (s *CertPool) ForEach(ctx context.Context, fn func(context.Context, *x509.C
 func (s *CertPool) unsafeExportCerts() []*x509.Certificate {
 	out := make([]*x509.Certificate, 0, len(s.hashed))
 	for _, ce := range s.hashed {
-		out = append(out, ce.cert)
+		if ce.Valid() {
+			out = append(out, ce.cert)
+		}
 	}
 	return out
 }

--- a/tls/x509utils/certpool/certpool_writer.go
+++ b/tls/x509utils/certpool/certpool_writer.go
@@ -105,6 +105,7 @@ func (s *CertPool) unsafeDeleteCerts(hashes ...Hash) int {
 }
 
 func (s *CertPool) unsafeDeleteCertEntry(ce *certPoolEntry) {
+	s.unsafeInvalidateCache()
 	delete(s.hashed, ce.hash)
 
 	eq := func(p *certPoolEntry) bool {
@@ -240,11 +241,13 @@ func (s *CertPool) unsafeAddCertName(ce *certPoolEntry, name string) bool {
 	}
 
 	ce.names = append(ce.names, name)
+	s.unsafeInvalidateCache()
 	appendMapList(s.names, name, ce)
 	return true
 }
 
 func (s *CertPool) unsafeAddCertEntry(ce *certPoolEntry) {
+	s.unsafeInvalidateCache()
 	s.hashed[ce.hash] = ce
 	for _, name := range ce.names {
 		appendMapList(s.names, name, ce)

--- a/tls/x509utils/certpool/certpool_writer.go
+++ b/tls/x509utils/certpool/certpool_writer.go
@@ -121,7 +121,7 @@ func (s *CertPool) Import(ctx context.Context, src x509utils.CertPool) (int, err
 		return 0, ErrNilReceiver
 	} else if err := ctx.Err(); err != nil {
 		return 0, err
-	} else if src == nil {
+	} else if src == nil || src == s {
 		return 0, nil
 	}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced `CertPool` structure to include a caching mechanism for improved performance.
	- New methods for cloning and validating certificate entries.

- **Bug Fixes**
	- Improved error handling and logic in certificate import and deletion processes.
	- Ensured only valid certificates are exported.

- **Refactor**
	- Streamlined methods for better readability and efficiency, including updates to the `Delete` and `Import` methods.
	- Updated logic in the `Export` and `Copy` methods to utilize the cache effectively.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->