### PR TITLE
tls/x509utils: introduce ValidCertKeyPair()

### DIFF
--- a/tls/x509utils/pair.go
+++ b/tls/x509utils/pair.go
@@ -1,0 +1,18 @@
+package x509utils
+
+import "crypto/x509"
+
+// ValidCertKeyPair confirms the given key can use the given certificate.
+func ValidCertKeyPair(cert *x509.Certificate, key PrivateKey) bool {
+	if cert == nil || key == nil {
+		// missing
+		return false
+	}
+	pub, ok := cert.PublicKey.(PublicKey)
+	if !ok {
+		// invalid - unreachable
+		return false
+	}
+
+	return pub.Equal(key.Public())
+}


### PR DESCRIPTION
to verify the certificate has the same public key as the given private key

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new function to validate the correspondence between a private key and a certificate, enhancing security checks for users managing certificates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->