### PR TITLE
tls/x509utils/certpool: use ErrNilReceiver from darvaza.org/core

### DIFF
--- a/tls/go.mod
+++ b/tls/go.mod
@@ -3,7 +3,7 @@ module darvaza.org/x/tls
 go 1.21
 
 require (
-	darvaza.org/core v0.15.1
+	darvaza.org/core v0.15.2
 	darvaza.org/slog v0.5.12
 )
 

--- a/tls/go.sum
+++ b/tls/go.sum
@@ -1,5 +1,5 @@
-darvaza.org/core v0.15.1 h1:OxAeTM1HnbpkGzalk2HmZiEsRKeOZrgoeQyHokEKVMA=
-darvaza.org/core v0.15.1/go.mod h1:zvFshV8ncuQcvZxjPsHfBgBvVtwa+bHAWDpMQ3N/Ajc=
+darvaza.org/core v0.15.2 h1:reSkWMHTkqCjhDJox89+gObadAikKDjddRbzS+5/wIQ=
+darvaza.org/core v0.15.2/go.mod h1:zvFshV8ncuQcvZxjPsHfBgBvVtwa+bHAWDpMQ3N/Ajc=
 darvaza.org/slog v0.5.12 h1:458qJGNShIx9gqUqLoouo6Hnp5OhHzeoab5Z297FfxY=
 darvaza.org/slog v0.5.12/go.mod h1:PQfXbRaX8pGYhD5Xi+vAJBCUlHcmajNjMZGAfrcu7/E=
 github.com/klauspost/cpuid/v2 v2.2.8 h1:+StwCXwm9PdpiEkPyzBXIy+M9KUb4ODm0Zarf1kS5BM=

--- a/tls/x509utils/certpool/certpool_reader.go
+++ b/tls/x509utils/certpool/certpool_reader.go
@@ -12,7 +12,7 @@ import (
 func (s *CertPool) Get(ctx context.Context, name string) (*x509.Certificate, error) {
 	if s == nil {
 		// invalid
-		return nil, ErrNilReceiver
+		return nil, core.ErrNilReceiver
 	}
 
 	sn, ok := x509utils.SanitizeName(name)

--- a/tls/x509utils/certpool/certpool_writer.go
+++ b/tls/x509utils/certpool/certpool_writer.go
@@ -119,7 +119,7 @@ func (s *CertPool) unsafeDeleteCertEntry(ce *certPoolEntry) {
 // Import certificates from another CertPool.
 func (s *CertPool) Import(ctx context.Context, src x509utils.CertPool) (int, error) {
 	if s == nil {
-		return 0, ErrNilReceiver
+		return 0, core.ErrNilReceiver
 	} else if err := ctx.Err(); err != nil {
 		return 0, err
 	} else if src == nil || src == s {
@@ -153,7 +153,7 @@ func (s *CertPool) doImport(ctx context.Context, src x509utils.CertPool) (int, e
 // ImportPEM adds x509 certificates contained in the PEM encoded data.
 func (s *CertPool) ImportPEM(ctx context.Context, b []byte) (int, error) {
 	if s == nil {
-		return 0, ErrNilReceiver
+		return 0, core.ErrNilReceiver
 	} else if err := ctx.Err(); err != nil {
 		return 0, err
 	} else if len(b) == 0 {

--- a/tls/x509utils/certpool/errors.go
+++ b/tls/x509utils/certpool/errors.go
@@ -3,11 +3,6 @@ package certpool
 import "darvaza.org/core"
 
 var (
-	// ErrNilReceiver indicates a method was called over an undefined object.
-	//
-	// TODO: move to core.
-	ErrNilReceiver = core.Wrap(core.ErrInvalid, "nil receiver")
-
 	// ErrNoCertificatesFound indicates we didn't find any certificate.
 	ErrNoCertificatesFound = core.Wrap(core.ErrNotExists, "no certificates found")
 )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated error handling in the `Get`, `Import`, and `ImportPEM` methods to provide more consistent error messages.
	- Removed the `ErrNilReceiver` variable to streamline error reporting.

- **Chores**
	- Updated the dependency version for `darvaza.org/core` to ensure compatibility and access to the latest features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->