### PR TITLE
tls: introduce Verify() helper and ClientHelloInfo alias

### DIFF
--- a/tls/std.go
+++ b/tls/std.go
@@ -7,6 +7,9 @@ type (
 	// Certificate is an alias of the standard [tls.Certificate]
 	Certificate = tls.Certificate
 
+	// ClientHelloInfo is an alias of the standard [tls.ClientHelloInfo].
+	ClientHelloInfo = tls.ClientHelloInfo
+
 	// Config is an alias of the standard [tls.Config]
 	Config = tls.Config
 )

--- a/tls/verify.go
+++ b/tls/verify.go
@@ -1,0 +1,80 @@
+package tls
+
+import (
+	"bytes"
+	"crypto/tls"
+	"crypto/x509"
+	"time"
+
+	"darvaza.org/core"
+	"darvaza.org/x/tls/x509utils"
+)
+
+// Verify checks if a [tls.Certificate] is good to use.
+// If roots is provided, the chain will also be verified.
+func Verify(cert *tls.Certificate, roots *x509.CertPool) error {
+	switch {
+	case cert == nil:
+		return &x509utils.ErrInvalidCert{
+			Reason: "none provided",
+		}
+	case cert.Leaf == nil || len(cert.Certificate) == 0:
+		return &x509utils.ErrInvalidCert{
+			Reason: "missing leaf certificate",
+		}
+	case len(cert.Leaf.Raw) == 0,
+		cert.Leaf.NotAfter.Before(time.Now()),
+		cert.Leaf.NotBefore.After(time.Now()),
+		!bytes.Equal(cert.Leaf.Raw, cert.Certificate[0]):
+		return &x509utils.ErrInvalidCert{
+			Reason: "invalid leaf certificate",
+		}
+	case cert.PrivateKey == nil:
+		return &x509utils.ErrInvalidCert{
+			Reason: "missing private key",
+		}
+	case !x509utils.ValidCertKeyPair(cert.Leaf, cert.PrivateKey):
+		return &x509utils.ErrInvalidCert{
+			Reason: "invalid private key",
+		}
+	case roots != nil:
+		return doVerifyRoots(cert, roots)
+	default:
+		return doVerifyNoRoots(cert)
+	}
+}
+
+func doVerifyRoots(cert *tls.Certificate, roots *x509.CertPool) error {
+	opt := x509.VerifyOptions{
+		Roots:         roots,
+		Intermediates: x509.NewCertPool(),
+	}
+	for i, der := range cert.Certificate[1:] {
+		c, err := doVerifyDERCert(i+1, der)
+		if err != nil {
+			return core.Wrap(err, "ReadCertificate")
+		}
+
+		opt.Intermediates.AddCert(c)
+	}
+	_, err := cert.Leaf.Verify(opt)
+	return err
+}
+
+func doVerifyNoRoots(cert *tls.Certificate) error {
+	for i, der := range cert.Certificate {
+		_, err := doVerifyDERCert(i, der)
+		if err != nil {
+			return core.Wrap(err, "ReadCertificate")
+		}
+	}
+	return nil
+}
+
+func doVerifyDERCert(slot int, der []byte) (*x509.Certificate, error) {
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		return nil, core.Wrapf(err, "bad certificate in slot %v", slot)
+	}
+	return cert, nil
+}

--- a/tls/verify.go
+++ b/tls/verify.go
@@ -13,6 +13,8 @@ import (
 // Verify checks if a [tls.Certificate] is good to use.
 // If roots is provided, the chain will also be verified.
 func Verify(cert *tls.Certificate, roots *x509.CertPool) error {
+	now := time.Now().UTC()
+
 	switch {
 	case cert == nil:
 		return &x509utils.ErrInvalidCert{
@@ -23,8 +25,8 @@ func Verify(cert *tls.Certificate, roots *x509.CertPool) error {
 			Reason: "missing leaf certificate",
 		}
 	case len(cert.Leaf.Raw) == 0,
-		cert.Leaf.NotAfter.Before(time.Now()),
-		cert.Leaf.NotBefore.After(time.Now()),
+		cert.Leaf.NotAfter.Before(now),
+		cert.Leaf.NotBefore.After(now),
 		!bytes.Equal(cert.Leaf.Raw, cert.Certificate[0]):
 		return &x509utils.ErrInvalidCert{
 			Reason: "invalid leaf certificate",
@@ -38,19 +40,20 @@ func Verify(cert *tls.Certificate, roots *x509.CertPool) error {
 			Reason: "invalid private key",
 		}
 	case roots != nil:
-		return doVerifyRoots(cert, roots)
+		return doVerifyRoots(cert, roots, now)
 	default:
-		return doVerifyNoRoots(cert)
+		return doVerifyNoRoots(cert, now)
 	}
 }
 
-func doVerifyRoots(cert *tls.Certificate, roots *x509.CertPool) error {
+func doVerifyRoots(cert *tls.Certificate, roots *x509.CertPool, now time.Time) error {
 	opt := x509.VerifyOptions{
 		Roots:         roots,
 		Intermediates: x509.NewCertPool(),
+		CurrentTime:   now,
 	}
 	for i, der := range cert.Certificate[1:] {
-		c, err := doVerifyDERCert(i+1, der)
+		c, err := doVerifyDERCert(i+1, der, nil)
 		if err != nil {
 			return core.Wrap(err, "ReadCertificate")
 		}
@@ -58,12 +61,15 @@ func doVerifyRoots(cert *tls.Certificate, roots *x509.CertPool) error {
 		opt.Intermediates.AddCert(c)
 	}
 	_, err := cert.Leaf.Verify(opt)
-	return err
+	if err != nil {
+		return core.Wrap(err, "failed to validate certificates chain")
+	}
+	return nil
 }
 
-func doVerifyNoRoots(cert *tls.Certificate) error {
+func doVerifyNoRoots(cert *tls.Certificate, now time.Time) error {
 	for i, der := range cert.Certificate {
-		_, err := doVerifyDERCert(i, der)
+		_, err := doVerifyDERCert(i, der, &now)
 		if err != nil {
 			return core.Wrap(err, "ReadCertificate")
 		}
@@ -71,10 +77,17 @@ func doVerifyNoRoots(cert *tls.Certificate) error {
 	return nil
 }
 
-func doVerifyDERCert(slot int, der []byte) (*x509.Certificate, error) {
+func doVerifyDERCert(slot int, der []byte, now *time.Time) (*x509.Certificate, error) {
 	cert, err := x509.ParseCertificate(der)
 	if err != nil {
 		return nil, core.Wrapf(err, "bad certificate in slot %v", slot)
 	}
+
+	if now != nil {
+		if now.After(cert.NotAfter) || now.Before(cert.NotBefore) {
+			return nil, core.Wrapf(core.ErrInvalid, "expired certificate in slot %v", slot)
+		}
+	}
+
 	return cert, nil
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new type alias for easier reference to `tls.ClientHelloInfo`.
	- Added comprehensive functions for verifying TLS certificates, enhancing security checks and error handling.

- **Bug Fixes**
	- Improved error handling during certificate validation to ensure robustness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->