### PR TITLE
tls/x509utils/certpool: introduce List.PushFront(), List.FirstMatchFn() and List.PopFirstMatchFn()

### DIFF
--- a/tls/x509utils/certpool/list.go
+++ b/tls/x509utils/certpool/list.go
@@ -30,6 +30,13 @@ func (*List[T]) Zero() T {
 	return zero
 }
 
+// PushFront adds a value at the beginning of the list.
+func (l *List[T]) PushFront(v T) {
+	if l != nil {
+		l.Sys().PushFront(v)
+	}
+}
+
 // PushBack adds a value at the end of the list.
 func (l *List[T]) PushBack(v T) {
 	if l != nil {

--- a/tls/x509utils/certpool/list.go
+++ b/tls/x509utils/certpool/list.go
@@ -104,6 +104,29 @@ func (l *List[T]) DeleteMatchFn(fn func(T) bool) {
 	}
 }
 
+// PopFirstMatchFn removes and returns the first match, iterating from
+// front to back.
+func (l *List[T]) PopFirstMatchFn(fn func(T) bool) (T, bool) {
+	var out T
+	var found bool
+
+	if l != nil && fn != nil {
+		cb := func(elem *list.Element, v T) bool {
+			if fn(v) {
+				out = v
+				found = true
+				l.Sys().Remove(elem)
+				return false
+			}
+			return true
+		}
+
+		l.unsafeForEachElement(cb)
+	}
+
+	return out, found
+}
+
 // FirstMatchFn returns the first element that satisfies the given function from
 // the front to the back.
 func (l *List[T]) FirstMatchFn(fn func(T) bool) (T, bool) {

--- a/tls/x509utils/certpool/list.go
+++ b/tls/x509utils/certpool/list.go
@@ -104,6 +104,28 @@ func (l *List[T]) DeleteMatchFn(fn func(T) bool) {
 	}
 }
 
+// FirstMatchFn returns the first element that satisfies the given function from
+// the front to the back.
+func (l *List[T]) FirstMatchFn(fn func(T) bool) (T, bool) {
+	var out T
+	var found bool
+
+	if l != nil && fn != nil {
+		cb := func(_ *list.Element, v T) bool {
+			if fn(v) {
+				out = v
+				found = true
+				return false
+			}
+			return true
+		}
+
+		l.unsafeForEachElement(cb)
+	}
+
+	return out, found
+}
+
 func (l *List[T]) unsafeForEachElement(fn func(*list.Element, T) bool) {
 	var next *list.Element
 	for elem := l.Sys().Front(); elem != nil; elem = next {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a `PushFront` method for adding elements to the beginning of the list.
	- Added a `FirstMatchFn` method to find the first matching element based on a provided function.
	- Implemented a `PopFirstMatchFn` method to remove and return the first matching element from the list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->