### PR TITLE
tls/store/basic: introduce CertList and CertSet

### DIFF
--- a/tls/store/basic/cert_list.go
+++ b/tls/store/basic/cert_list.go
@@ -1,0 +1,99 @@
+package basic
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+
+	"darvaza.org/x/tls/x509utils/certpool"
+)
+
+// CertList is a double-linked list of [tls.Certificate]s.
+type CertList certpool.List[*tls.Certificate]
+
+// NewCertList creates a List optionally taking its init content as argument.
+func NewCertList(certs ...*tls.Certificate) *CertList {
+	l := new(CertList)
+	for _, cert := range certs {
+		if cert != nil {
+			l.PushBack(cert)
+		}
+	}
+	return l
+}
+
+// Sys returns the underlying [certpool.List].
+func (l *CertList) Sys() *certpool.List[*tls.Certificate] {
+	if l == nil {
+		return nil
+	}
+
+	return (*certpool.List[*tls.Certificate])(l)
+}
+
+// PushBack appends a certificate at the end of the list.
+// nil values are ignored.
+func (l *CertList) PushBack(cert *tls.Certificate) {
+	if cert != nil {
+		l.Sys().PushBack(cert)
+	}
+}
+
+// PushFront inserts a certificate at the beginning of the list.
+// nil values are ignored.
+func (l *CertList) PushFront(cert *tls.Certificate) {
+	if cert != nil {
+		l.Sys().PushFront(cert)
+	}
+}
+
+// Contains tells if the [CertList] contains a [tls.Certificate]
+// matching the given [x509.Certificate].
+func (l *CertList) Contains(leaf *x509.Certificate) bool {
+	_, found := l.Get(leaf)
+	return found
+}
+
+// Get returns the [tls.Certificate] matching the given [x509.Certificate].
+func (l *CertList) Get(leaf *x509.Certificate) (*tls.Certificate, bool) {
+	var out *tls.Certificate
+
+	if l == nil || leaf == nil {
+		// no-op
+		return nil, false
+	}
+
+	l.ForEach(func(c *tls.Certificate) bool {
+		if leaf.Equal(c.Leaf) {
+			out = c
+		}
+		return out == nil // continue until one is found
+	})
+
+	return out, out != nil
+}
+
+// ForEach calls a function for each certificate in the list until
+// it returns false.
+func (l *CertList) ForEach(fn func(*tls.Certificate) bool) {
+	if l == nil || fn == nil {
+		return
+	}
+
+	l.Sys().ForEach(fn)
+}
+
+// Len returns the number of entries in the [CertList].
+func (l *CertList) Len() int {
+	if l == nil {
+		return 0
+	}
+	return l.Sys().Len()
+}
+
+// Export returns all certificates in the [CertList].
+func (l *CertList) Export() []*tls.Certificate {
+	if l == nil {
+		return nil
+	}
+	return l.Sys().Values()
+}

--- a/tls/store/basic/cert_set.go
+++ b/tls/store/basic/cert_set.go
@@ -1,0 +1,161 @@
+package basic
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+
+	"darvaza.org/x/tls/x509utils/certpool"
+)
+
+// CertSet keeps a unique set of [tls.Certificate]s.
+type CertSet map[certpool.Hash]*CertList
+
+// NewCertSet creates a [CertSet] optionally taking its initial content as argument.
+func NewCertSet(certs ...*tls.Certificate) CertSet {
+	set := make(CertSet)
+	for _, cert := range certs {
+		set.Push(cert)
+	}
+
+	return set
+}
+
+// Sys returns the underlying map.
+func (set CertSet) Sys() map[certpool.Hash]*CertList {
+	if set == nil {
+		return nil
+	}
+
+	return (map[certpool.Hash]*CertList)(set)
+}
+
+// Hash tells if the certificate are usable, and returns the
+// hash for the certificate.
+func (CertSet) Hash(cert *tls.Certificate) (certpool.Hash, bool) {
+	if cert == nil {
+		return certpool.Hash{}, false
+	}
+	return certpool.HashCert(cert.Leaf)
+}
+
+// HashLeaf tells if the certificate are usable, and returns the
+// hash for the certificate.
+func (CertSet) HashLeaf(leaf *x509.Certificate) (certpool.Hash, bool) {
+	return certpool.HashCert(leaf)
+}
+
+// Push attempts to add a [tls.Certificate] to the [CertSet], and
+// returns true if succeeded, but also the unique certificate if found.
+func (set CertSet) Push(cert *tls.Certificate) (*tls.Certificate, bool) {
+	if set == nil || cert == nil {
+		return nil, false
+	}
+
+	hash, ok := set.Hash(cert)
+	if !ok {
+		return nil, false
+	}
+
+	l, ok := set[hash]
+	if !ok {
+		set[hash] = NewCertList(cert)
+		return cert, true
+	}
+
+	if c, _ := l.Get(cert.Leaf); c != nil {
+		return c, false
+	}
+
+	l.PushFront(cert)
+	return cert, true
+}
+
+// Pop removes from the [CertSet] the [tls.Certificate] matching the given
+// [x509.Certificate].
+func (set CertSet) Pop(leaf *x509.Certificate) (*tls.Certificate, bool) {
+	if set == nil || leaf == nil {
+		// nothing
+		return nil, false
+	}
+
+	hash, ok := set.HashLeaf(leaf)
+	if !ok {
+		// bad
+		return nil, false
+	}
+
+	l, ok := set[hash]
+	if !ok {
+		// not found
+		return nil, false
+	}
+
+	return l.Sys().PopFirstMatchFn(func(c *tls.Certificate) bool {
+		return leaf.Equal(c.Leaf)
+	})
+}
+
+// Get attempts to find in the [CertSet] the [tls.Certificate] for the given leaf.
+func (set CertSet) Get(cert *x509.Certificate) (*tls.Certificate, bool) {
+	if set == nil || cert == nil {
+		return nil, false
+	}
+
+	hash, ok := set.HashLeaf(cert)
+	if !ok {
+		return nil, false
+	}
+
+	l, ok := set[hash]
+	if !ok {
+		return nil, false
+	}
+
+	return l.Get(cert)
+}
+
+// ForEach calls a function for each certificate in the set until
+// it returns false.
+func (set CertSet) ForEach(fn func(*tls.Certificate) bool) {
+	if set == nil || fn == nil {
+		return
+	}
+
+	cont := true
+	for _, l := range set {
+		l.ForEach(func(c *tls.Certificate) bool {
+			cont = fn(c)
+			return cont
+		})
+
+		if !cont {
+			break
+		}
+	}
+}
+
+// Len returns an estimate of the number of certificates in the [CertSet].
+//
+// Len returns the number of buckets in the hash table, which could be empty,
+// or have more than one certificate if there is conflicting [certpool.Hash].
+// Only returning 0 is certain, 1+ is an educated guess.
+func (set CertSet) Len() int {
+	if set == nil {
+		return 0
+	}
+	return len(set)
+}
+
+// Export returns all certificates in the [CertSet].
+func (set CertSet) Export() []*tls.Certificate {
+	if set == nil {
+		return nil
+	}
+
+	vv := make([][]*tls.Certificate, 0, len(set))
+	for _, l := range set {
+		vv = append(vv, l.Export())
+	}
+
+	return join(vv)
+}

--- a/tls/store/basic/store.go
+++ b/tls/store/basic/store.go
@@ -1,0 +1,2 @@
+// Package basic implements a generic programmable TLS store
+package basic

--- a/tls/store/basic/utils.go
+++ b/tls/store/basic/utils.go
@@ -1,0 +1,14 @@
+package basic
+
+func join[T any](vv [][]T) []T {
+	var count int
+	for _, v := range vv {
+		count += len(v)
+	}
+
+	out := make([]T, 0, count)
+	for _, v := range vv {
+		out = append(out, v...)
+	}
+	return out
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced `CertList` and `CertSet` types for improved management of TLS certificates.
	- Added a new package `basic` for a programmable TLS store.
	- Implemented a generic function `join` for converting two-dimensional slices to one-dimensional slices.

- **Bug Fixes**
	- Enhanced error handling for nil values in certificate management methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->