### PR TITLE
tls/store/basic: introduce KeyList and KeySet

### DIFF
--- a/tls/store/basic/errors.go
+++ b/tls/store/basic/errors.go
@@ -1,0 +1,10 @@
+package basic
+
+import "darvaza.org/core"
+
+var (
+	// ErrInvalid is an alias of [core.ErrInvalid].
+	ErrInvalid = core.ErrInvalid
+	// ErrNotExists is an alias of [core.ErrNotExists].
+	ErrNotExists = core.ErrNotExists
+)

--- a/tls/store/basic/key_list.go
+++ b/tls/store/basic/key_list.go
@@ -1,0 +1,90 @@
+package basic
+
+import (
+	"crypto"
+
+	"darvaza.org/x/tls/x509utils"
+	"darvaza.org/x/tls/x509utils/certpool"
+)
+
+// KeyList is a double-linked list of private keys.
+type KeyList certpool.List[crypto.Signer]
+
+// NewKeyList creates a KeyList optionally taking its initial content as argument.
+func NewKeyList(keys ...crypto.Signer) *KeyList {
+	l := new(KeyList)
+	for _, key := range keys {
+		if key != nil {
+			l.PushBack(key)
+		}
+	}
+	return l
+}
+
+// Sys returns the underlying [certpool.List].
+func (l *KeyList) Sys() *certpool.List[crypto.Signer] {
+	if l == nil {
+		return nil
+	}
+
+	return (*certpool.List[crypto.Signer])(l)
+}
+
+// PushBack appends a key at the end of the list.
+// nil values are ignored.
+func (l *KeyList) PushBack(key crypto.Signer) {
+	if key != nil {
+		l.Sys().PushBack(key)
+	}
+}
+
+// PushFront inserts a key at the beginning of the list.
+// nil values are ignored.
+func (l *KeyList) PushFront(key crypto.Signer) {
+	if key != nil {
+		l.Sys().PushFront(key)
+	}
+}
+
+// Contains tells if the [KeyList] contains a [crypto.Signer]
+// matching the given [crypto.PublicKey].
+func (l *KeyList) Contains(pub crypto.PublicKey) bool {
+	_, found := l.Get(pub)
+	return found
+}
+
+// Get returns the [crypto.Signer] matching the given
+// [crypto.PublicKey].
+func (l *KeyList) Get(pub crypto.PublicKey) (crypto.Signer, bool) {
+	var out crypto.Signer
+
+	if l == nil || pub == nil {
+		// no-op
+		return nil, false
+	}
+
+	pk, ok := pub.(x509utils.PublicKey)
+	if !ok {
+		// invalid key
+		return nil, false
+	}
+
+	l.ForEach(func(key crypto.Signer) bool {
+		if pk.Equal(key.Public()) {
+			out = key
+		}
+		return out == nil // continue until one is found.
+	})
+
+	return out, out != nil
+}
+
+// ForEach calls a function for each private key in the list until
+// it returns false.
+func (l *KeyList) ForEach(fn func(crypto.Signer) bool) {
+	if l == nil || fn == nil {
+		return
+	}
+
+	l.Sys().ForEach(fn)
+}

--- a/tls/store/basic/key_set.go
+++ b/tls/store/basic/key_set.go
@@ -1,0 +1,141 @@
+package basic
+
+import (
+	"crypto"
+
+	"darvaza.org/core"
+
+	"darvaza.org/x/tls/x509utils"
+	"darvaza.org/x/tls/x509utils/certpool"
+)
+
+// KeySet keeps a unique set of [x509utils.PrivateKey].
+type KeySet map[certpool.Hash]*KeyList
+
+// NewKeySet creates a KeySet optionally taking its initial content as argument.
+func NewKeySet(keys ...crypto.Signer) KeySet {
+	set := make(KeySet)
+	for _, key := range keys {
+		set.Push(key)
+	}
+	return set
+}
+
+// Sys returns the underlying map.
+func (set KeySet) Sys() map[certpool.Hash]*KeyList {
+	if set == nil {
+		return nil
+	}
+
+	return (map[certpool.Hash]*KeyList)(set)
+}
+
+// Hash tells if the public key is usable, and returns the hash for it.
+func (KeySet) Hash(pub crypto.PublicKey) (certpool.Hash, bool) {
+	if pub == nil {
+		// bad
+		return certpool.Hash{}, false
+	}
+
+	b, err := x509utils.SubjectPublicKeyBytes(pub)
+	if err != nil {
+		// bad
+		return certpool.Hash{}, false
+	}
+
+	hash := certpool.Sum(b)
+	return hash, true
+}
+
+// Push adds a [crypto.Signer] to the set.
+// It returns a singleton reference to the key in the set, and
+// if the key is newly added or it existed before.
+func (set KeySet) Push(key crypto.Signer) (crypto.Signer, bool) {
+	if set == nil || key == nil {
+		// bad
+		return nil, false
+	}
+
+	hash, ok := set.Hash(key.Public())
+	if !ok {
+		// bad
+		return nil, false
+	}
+
+	l, ok := set[hash]
+	if !ok {
+		// new
+		set[hash] = NewKeyList(key)
+		return key, true
+	}
+
+	if k, _ := l.Get(key.Public()); k != nil {
+		// found
+		return k, false
+	}
+
+	// new
+	l.PushBack(key)
+	return key, true
+}
+
+// Get returns the [crypto.Signer] matching the given [crypto.PublicKey].
+func (set KeySet) Get(pub crypto.PublicKey) (crypto.Signer, error) {
+	switch {
+	case set == nil:
+		return nil, core.ErrNilReceiver
+	case pub == nil:
+		// invalid public key
+		return nil, ErrInvalid
+	}
+
+	hash, ok := set.Hash(pub)
+	if !ok {
+		// invalid public key
+		return nil, ErrInvalid
+	}
+
+	l, ok := set[hash]
+	if !ok {
+		// miss
+		return nil, ErrNotExists
+	}
+
+	if k, _ := l.Get(pub); k != nil {
+		// found
+		return k, nil
+	}
+
+	// miss
+	return nil, ErrNotExists
+}
+
+// Copy copies all keys in the [KeySet] to another.
+// If no destination is provided, a new one is created.
+func (set KeySet) Copy(dst KeySet) KeySet {
+	if dst == nil {
+		dst = make(KeySet)
+	}
+
+	for hash, l1 := range set {
+		l2, ok := dst[hash]
+		if !ok {
+			l2 = NewKeyList()
+			dst[hash] = l2
+		}
+
+		set.doCopy(l1, l2)
+	}
+
+	return dst
+}
+
+func (KeySet) doCopy(l1, l2 *KeyList) {
+	l1.ForEach(func(key crypto.Signer) bool {
+		if !l2.Contains(key.Public()) {
+			l2.PushBack(key)
+		}
+
+		return true
+	})
+}

--- a/tls/store/basic/store.go
+++ b/tls/store/basic/store.go
@@ -1,0 +1,2 @@
+// Package basic implements a generic programmable TLS store
+package basic


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a `KeyList` type for managing private keys with various manipulation methods.
	- Added a `KeySet` type for maintaining a unique collection of cryptographic keys with error handling.
	- Launched a new `basic` package for a programmable TLS store.

- **Bug Fixes**
	- Implemented error handling in key management methods to ensure robustness.

- **Documentation**
	- Enhanced documentation for new types and methods to improve usability and understanding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->