### PR TITLE
tls/x509utils/certpool: clean-up, and change CertPool.Copy() to receive a condition function [BREAKING]

### DIFF
--- a/tls/x509utils/certpool/certpool.go
+++ b/tls/x509utils/certpool/certpool.go
@@ -39,6 +39,7 @@ func (s *CertPool) Count() int {
 	var count int
 
 	if s != nil {
+		// RO
 		s.mu.RLock()
 		defer s.mu.RUnlock()
 
@@ -54,6 +55,7 @@ func (s *CertPool) IsCA() bool {
 		return false
 	}
 
+	// RO
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
@@ -62,23 +64,27 @@ func (s *CertPool) IsCA() bool {
 			return false
 		}
 	}
+
 	return true
 }
 
-func (s *CertPool) init() {
-	if s != nil && s.hashed == nil {
+func (s *CertPool) unsafeInit() {
+	if s.hashed == nil {
 		s.unsafeReset()
 	}
 }
 
 // Reset removes all certificates from the store.
-func (s *CertPool) Reset() {
-	if s != nil {
-		s.mu.Lock()
-		defer s.mu.Unlock()
-
-		s.unsafeReset()
+func (s *CertPool) Reset() error {
+	if s == nil {
+		return core.ErrNilReceiver
 	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.unsafeReset()
+	return nil
 }
 
 func (s *CertPool) unsafeReset() {

--- a/tls/x509utils/certpool/certpool.go
+++ b/tls/x509utils/certpool/certpool.go
@@ -5,6 +5,7 @@ import (
 	"crypto/x509"
 	"sync"
 
+	"darvaza.org/core"
 	"darvaza.org/x/tls/x509utils"
 )
 

--- a/tls/x509utils/certpool/certpool_copy.go
+++ b/tls/x509utils/certpool/certpool_copy.go
@@ -49,8 +49,8 @@ func (s *CertPool) unsafeInvalidateCache() {
 }
 
 // Copy creates a copy of the [CertPool] store, optionally
-// receiving the destination.
-func (s *CertPool) Copy(out *CertPool, caOnly bool) *CertPool {
+// receiving the destination and a condition checker.
+func (s *CertPool) Copy(out *CertPool, cond func(*x509.Certificate) bool) *CertPool {
 	switch {
 	case s == nil:
 		if out == nil {
@@ -61,7 +61,7 @@ func (s *CertPool) Copy(out *CertPool, caOnly bool) *CertPool {
 		// avoid copying to itself
 		return s
 	default:
-		cond := newCertPoolEntryCondFn(caOnly)
+		cond := newCertPoolEntryCondFn(cond)
 
 		if out == nil {
 			return s.doClone(cond)
@@ -107,7 +107,7 @@ func (s *CertPool) Clone() x509utils.CertPool {
 		return nil
 	}
 
-	return s.doClone(certPoolEntryValid)
+	return s.doClone(nil)
 }
 
 func (s *CertPool) doClone(cond func(*certPoolEntry) bool) *CertPool {

--- a/tls/x509utils/certpool/certpool_entry.go
+++ b/tls/x509utils/certpool/certpool_entry.go
@@ -34,7 +34,7 @@ func (ce *certPoolEntry) Equal(other *certPoolEntry) bool {
 	case ce == nil, other == nil:
 		return false
 	default:
-		return ce.hash.Equal(other.hash)
+		return ce.cert.Equal(other.cert)
 	}
 }
 

--- a/tls/x509utils/certpool/certpool_entry.go
+++ b/tls/x509utils/certpool/certpool_entry.go
@@ -57,20 +57,21 @@ func (ce *certPoolEntry) IsCA() bool {
 	return false
 }
 
-//revive:disable:flag-parameter
-func newCertPoolEntryCondFn(caOnly bool) func(*certPoolEntry) bool {
-	//revive:enable:flag-parameter
+func newCertPoolEntryCondFn(fn func(*x509.Certificate) bool) func(*certPoolEntry) bool {
+	return func(ce *certPoolEntry) bool {
+		if !ce.Valid() {
+			return false
+		}
 
-	if caOnly {
-		return certPoolEntryIsCA
+		return fn == nil || fn(ce.cert)
 	}
-
-	return certPoolEntryValid
 }
 
 func newCertPoolEntryCopyFn(cond func(*certPoolEntry) bool) func(*certPoolEntry) (*certPoolEntry, bool) {
 	if cond == nil {
-		cond = certPoolEntryValid
+		cond = func(ce *certPoolEntry) bool {
+			return ce.Valid()
+		}
 	}
 
 	return func(ce *certPoolEntry) (ce2 *certPoolEntry, ok bool) {
@@ -79,11 +80,4 @@ func newCertPoolEntryCopyFn(cond func(*certPoolEntry) bool) func(*certPoolEntry)
 		}
 		return ce2, ce2 != nil
 	}
-}
-func certPoolEntryIsCA(ce *certPoolEntry) bool {
-	return ce.IsCA()
-}
-
-func certPoolEntryValid(ce *certPoolEntry) bool {
-	return ce.Valid()
 }

--- a/tls/x509utils/certpool/certpool_find.go
+++ b/tls/x509utils/certpool/certpool_find.go
@@ -18,11 +18,17 @@ func (s *CertPool) getListForName(name string) *List[*certPoolEntry] {
 }
 
 func (s *CertPool) getListForSuffix(name string) *List[*certPoolEntry] {
+	if name[0] == '[' {
+		// skip IP Addresses
+		return nil
+	}
+
 	if suffix, ok := x509utils.NameAsSuffix(name); ok {
 		if l, ok := s.patterns[suffix]; ok {
 			return l
 		}
 	}
+
 	return nil
 }
 

--- a/tls/x509utils/certpool/certpool_writer.go
+++ b/tls/x509utils/certpool/certpool_writer.go
@@ -198,7 +198,7 @@ func (*CertPool) checkImportError(ctx context.Context, err error) error {
 // AddCert adds a certificate to the store if it wasn't known
 // already.
 func (s *CertPool) AddCert(cert *x509.Certificate) bool {
-	if s != nil && cert != nil {
+	if s != nil {
 		hash, ok := HashCert(cert)
 		if ok {
 			s.mu.Lock()

--- a/tls/x509utils/certpool/certpool_writer.go
+++ b/tls/x509utils/certpool/certpool_writer.go
@@ -17,39 +17,38 @@ var (
 // Put inserts a certificate into the store, optionally including a reference name.
 // The name will be appended to those included in the certificate.
 func (s *CertPool) Put(ctx context.Context, name string, cert *x509.Certificate) error {
-	sn, ok := x509utils.SanitizeName(name)
-	if !ok {
-		// invalid name
-		return core.Wrapf(core.ErrInvalid, "invalid argument: %s: %q", "name", name)
-	}
-
-	hash, ok := HashCert(cert)
-	if !ok {
-		// invalid cert
-		return core.Wrapf(core.ErrInvalid, "invalid argument: %s", "cert")
-	}
-
-	if err := ctx.Err(); err != nil {
-		// cancelled
+	name, hash, err := s.checkPut(ctx, name, cert)
+	if err != nil {
 		return err
 	}
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if s.unsafeAddCert(hash, sn, cert) {
-		return nil
+	return s.unsafeAddCert(hash, name, cert)
+}
+
+func (s *CertPool) checkPut(ctx context.Context, name string, cert *x509.Certificate) (string, Hash, error) {
+	sn, ok := x509utils.SanitizeName(name)
+	if !ok {
+		return "", Hash{}, core.Wrapf(core.ErrInvalid, "%s: %q", "name", name)
 	}
-	return core.ErrExists
+
+	hash, ok := HashCert(cert)
+	switch {
+	case !ok:
+		return "", Hash{}, core.Wrap(core.ErrInvalid, "cert")
+	case s == nil:
+		return "", hash, core.ErrNilReceiver
+	default:
+		return sn, hash, ctx.Err()
+	}
 }
 
 // Delete remove from the store all certificates associated to the given name
 func (s *CertPool) Delete(ctx context.Context, name string) error {
-	sn, ok := x509utils.SanitizeName(name)
-	if !ok || s == nil {
-		return core.ErrInvalid
-	}
-	if err := ctx.Err(); err != nil {
+	sn, err := s.checkDelete(ctx, name)
+	if err != nil {
 		return err
 	}
 
@@ -70,14 +69,26 @@ func (s *CertPool) Delete(ctx context.Context, name string) error {
 	return core.Wrap(core.ErrNotExists, name)
 }
 
+func (s *CertPool) checkDelete(ctx context.Context, name string) (string, error) {
+	sn, ok := x509utils.SanitizeName(name)
+	switch {
+	case !ok:
+		return "", core.Wrapf(core.ErrInvalid, "%s: %q", "name", name)
+	case s == nil:
+		return "", core.ErrNilReceiver
+	default:
+		return sn, ctx.Err()
+	}
+}
+
 // DeleteCert removes a certificate, by raw DER hash, from the store.
 func (s *CertPool) DeleteCert(ctx context.Context, cert *x509.Certificate) error {
 	hash, ok := HashCert(cert)
-	if !ok || s == nil {
-		return core.ErrInvalid
-	}
-
-	if err := ctx.Err(); err != nil {
+	if !ok {
+		return core.Wrap(core.ErrInvalid, "cert")
+	} else if s == nil {
+		return core.ErrNilReceiver
+	} else if err := ctx.Err(); err != nil {
 		return err
 	}
 
@@ -198,21 +209,20 @@ func (*CertPool) checkImportError(ctx context.Context, err error) error {
 // AddCert adds a certificate to the store if it wasn't known
 // already.
 func (s *CertPool) AddCert(cert *x509.Certificate) bool {
-	if s != nil {
-		hash, ok := HashCert(cert)
-		if ok {
-			s.mu.Lock()
-			defer s.mu.Unlock()
+	hash, ok := HashCert(cert)
+	if ok && s != nil {
+		s.mu.Lock()
+		defer s.mu.Unlock()
 
-			return s.unsafeAddCert(hash, "", cert)
-		}
+		err := s.unsafeAddCert(hash, "", cert)
+		return err == nil
 	}
 
 	return false
 }
 
-func (s *CertPool) unsafeAddCert(hash Hash, name string, cert *x509.Certificate) bool {
-	s.init()
+func (s *CertPool) unsafeAddCert(hash Hash, name string, cert *x509.Certificate) error {
+	s.unsafeInit()
 
 	if ce, found := s.hashed[hash]; found && name != "" {
 		return s.unsafeAddCertName(ce, name)
@@ -231,19 +241,19 @@ func (s *CertPool) unsafeAddCert(hash Hash, name string, cert *x509.Certificate)
 	}
 
 	s.unsafeAddCertEntry(ce)
-	return true
+	return nil
 }
 
-func (s *CertPool) unsafeAddCertName(ce *certPoolEntry, name string) bool {
+func (s *CertPool) unsafeAddCertName(ce *certPoolEntry, name string) error {
 	if name == "" || core.SliceContains(ce.names, name) {
 		// nothing to add
-		return false
+		return core.ErrExists
 	}
 
 	ce.names = append(ce.names, name)
 	s.unsafeInvalidateCache()
 	appendMapList(s.names, name, ce)
-	return true
+	return nil
 }
 
 func (s *CertPool) unsafeAddCertEntry(ce *certPoolEntry) {

--- a/tls/x509utils/certpool/hash.go
+++ b/tls/x509utils/certpool/hash.go
@@ -38,23 +38,23 @@ func (hash Hash) IsZero() bool {
 
 // HashCert produces a blake3 digest of the DER representation of a Certificate
 func HashCert(cert *x509.Certificate) (Hash, bool) {
-	if cert == nil || len(cert.Raw) == 0 {
-		return Hash{}, false
+	if validCert(cert) {
+		return Sum(cert.Raw), true
 	}
-	return Sum(cert.Raw), true
+	return Hash{}, false
 }
 
 // HashSubject produces a blake3 digest of the raw subject of the Certificate
 func HashSubject(cert *x509.Certificate) (Hash, bool) {
-	if cert == nil || len(cert.RawSubject) == 0 {
-		return Hash{}, false
+	if validCert(cert) {
+		return Sum(cert.RawSubject), true
 	}
-	return Sum(cert.RawSubject), true
+	return Hash{}, false
 }
 
 // HashSubjectPublicKey produces a blake3 digest of the PublicKey of the Certificate
 func HashSubjectPublicKey(cert *x509.Certificate) (Hash, bool) {
-	if cert != nil && cert.PublicKey != nil {
+	if validCert(cert) {
 		if b, err := x509utils.SubjectPublicKeyBytes(cert.PublicKey); err == nil {
 			return Sum(b), true
 		}

--- a/tls/x509utils/certpool/utils.go
+++ b/tls/x509utils/certpool/utils.go
@@ -2,12 +2,24 @@ package certpool
 
 import (
 	"context"
+	"crypto/x509"
 	"encoding/pem"
 	"io/fs"
 
 	"darvaza.org/core"
 	"darvaza.org/x/tls/x509utils"
 )
+
+func validCert(cert *x509.Certificate) bool {
+	switch {
+	case cert == nil, cert.PublicKey == nil:
+		return false
+	case len(cert.Raw) == 0, len(cert.RawSubject) == 0:
+		return false
+	default:
+		return true
+	}
+}
 
 func copyMap[K comparable, V any](m map[K]V, fn func(V) (V, bool)) map[K]V {
 	if fn == nil {


### PR DESCRIPTION
CertPool.Reset() is also changed to return an error when used against a nil receiver

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced a new validation function for X.509 certificates, enhancing reliability in certificate handling.
  - Updated the `Copy` method to allow custom conditions for certificate selection.
  - Added conditional filtering for CA certificates in the `SystemCertPool` function.

- **Bug Fixes**
  - Improved error handling in the `Reset` method of the `CertPool`.

- **Improvements**
  - Streamlined logic in the `AddCert` method for certificate addition.
  - Enhanced equality checks for certificate entries.
  - Updated certificate hashing functions to consolidate validation logic.
  - Adjusted the `getListForSuffix` method to improve wildcard search behavior for IP addresses.
  
- **Documentation**
  - Clarified method usage with comments indicating read-only access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->