### PR TITLE
container/set: optimize Set.Copy() for the case when both have the same [Config].

### DIFF
--- a/container/set/config.go
+++ b/container/set/config.go
@@ -1,6 +1,10 @@
 package set
 
-import "darvaza.org/core"
+import (
+	"reflect"
+
+	"darvaza.org/core"
+)
 
 // Config defines the callbacks used by a [Set].
 type Config[K, H comparable, T any] struct {
@@ -57,4 +61,38 @@ func (cfg Config[K, H, T]) Must(items ...T) *Set[K, H, T] {
 		core.Panic(err)
 	}
 	return set
+}
+
+// Equal determines if two Config instances use exactly the same callback functions
+// by comparing their memory addresses using reflection. This is used to optimize
+// Set operations like Copy() when configs are identical.
+//
+// Equal isn't cheap but it saves Copy() from performing unnecessary rehashing.
+func (cfg Config[K, H, T]) Equal(other Config[K, H, T]) bool {
+	switch {
+	case !equalFuncPointer(cfg.Hash, other.Hash):
+		return false
+	case !equalFuncPointer(cfg.ItemKey, other.ItemKey):
+		return false
+	case !equalFuncPointer(cfg.ItemMatch, other.ItemMatch):
+		return false
+	default:
+		return true
+	}
+}
+
+func equalFuncPointer[T any](f1, f2 T) bool {
+	v1 := reflect.ValueOf(f1)
+	v2 := reflect.ValueOf(f2)
+	nil1 := v1.IsNil()
+	nil2 := v2.IsNil()
+
+	switch {
+	case nil1 && nil2:
+		return true
+	case nil1, nil2:
+		return false
+	default:
+		return v1.Pointer() == v2.Pointer()
+	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a method to compare configuration instances for equality.
	- Enhanced the `Set` structure for more efficient copying and appending of elements.
	- Added functionality to prevent duplicates during the appending process.

- **Bug Fixes**
	- Improved integrity of data in the `Set` structure by ensuring no duplicate values are appended.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->