### PR TITLE
tls: add Clone and Copy methods to certpool.CertSet, and fix basic.KeySet's Copy()

### DIFF
--- a/tls/store/basic/key_set.go
+++ b/tls/store/basic/key_set.go
@@ -31,14 +31,17 @@ func (*KeySet) Public(key x509utils.PrivateKey) x509utils.PublicKey {
 // If a condition function isn't provided, all keys not present in the destination
 // will be added.
 func (ks *KeySet) Copy(dst *KeySet, cond func(x509utils.PrivateKey) bool) *KeySet {
+	if ks == nil {
+		if dst == nil {
+			dst = MustKeySet()
+		}
+		return dst
+	}
+
 	if dst == nil {
 		dst = new(KeySet)
 	}
-
-	if ks != nil {
-		ks.Set.Copy(&dst.Set, cond)
-	}
-
+	ks.Set.Copy(&dst.Set, cond)
 	return dst
 }
 

--- a/tls/x509utils/certpool/cert_set.go
+++ b/tls/x509utils/certpool/cert_set.go
@@ -12,6 +12,35 @@ type CertSet struct {
 	set.Set[*x509.Certificate, Hash, *x509.Certificate]
 }
 
+// Copy copies all certificates satisfying the optional condition to the destination
+// unless they are already there.
+// If a destination isn't provided one will be created.
+func (cs *CertSet) Copy(dst *CertSet, cond func(*x509.Certificate) bool) *CertSet {
+	if cs == nil {
+		if dst == nil {
+			dst = MustCertSet()
+		}
+		return dst
+	}
+
+	if dst == nil {
+		dst = new(CertSet)
+	}
+	cs.Set.Copy(&dst.Set, cond)
+	return dst
+}
+
+// Clone makes a copy of the [CertSet].
+func (cs *CertSet) Clone() *CertSet {
+	if cs == nil {
+		return nil
+	}
+
+	dst := new(CertSet)
+	cs.Set.Copy(&dst.Set, nil)
+	return dst
+}
+
 // NewCertSet creates a [CertSet] optionally taking its initial content as argument.
 func NewCertSet(certs ...*x509.Certificate) (*CertSet, error) {
 	out := new(CertSet)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced `Copy` and `Clone` methods for the `CertSet` type, allowing users to duplicate and conditionally copy certificates.
	- Enhanced the `Copy` method for the `KeySet` struct to improve handling of `nil` values, ensuring more robust operations.

- **Bug Fixes**
	- Improved logic in the `Copy` method of `KeySet` to prevent operations on `nil` receivers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->