### PR TITLE
tls/store: move sets from basic to buffer, and introduce KeySet.GetFromCertificate()

### DIFF
--- a/tls/store/buffer/buffer.go
+++ b/tls/store/buffer/buffer.go
@@ -1,0 +1,3 @@
+// Package buffer provides helpers to decode PEM files, populate a [tls.StoreWriter],
+// and work with key and cert sets
+package buffer

--- a/tls/store/buffer/cert_set.go
+++ b/tls/store/buffer/cert_set.go
@@ -1,4 +1,4 @@
-package basic
+package buffer
 
 import (
 	"crypto/tls"

--- a/tls/store/buffer/key_set.go
+++ b/tls/store/buffer/key_set.go
@@ -1,6 +1,8 @@
 package buffer
 
 import (
+	"crypto/x509"
+
 	"darvaza.org/core"
 	"darvaza.org/x/container/set"
 
@@ -25,6 +27,20 @@ func (*KeySet) Public(key x509utils.PrivateKey) x509utils.PublicKey {
 	return nil
 }
 
+// GetFromCertificate is like Get but uses the public key associated with the
+// given certificate.
+func (ks *KeySet) GetFromCertificate(cert *x509.Certificate) (x509utils.PrivateKey, error) {
+	if ks == nil {
+		return nil, core.ErrNilReceiver
+	}
+
+	if pub := x509utils.PublicKeyFromCertificate(cert); pub != nil {
+		return ks.Get(pub)
+	}
+
+	return nil, core.Wrap(core.ErrInvalid, "invalid certificate provided")
+}
+
 // Copy copies all keys that satisfy the condition to the destination [KeySet]
 // unless they are already there.
 // If a destination isn't provided one will be created.
@@ -41,6 +57,7 @@ func (ks *KeySet) Copy(dst *KeySet, cond func(x509utils.PrivateKey) bool) *KeySe
 	if dst == nil {
 		dst = new(KeySet)
 	}
+
 	ks.Set.Copy(&dst.Set, cond)
 	return dst
 }

--- a/tls/store/buffer/key_set.go
+++ b/tls/store/buffer/key_set.go
@@ -1,4 +1,4 @@
-package basic
+package buffer
 
 import (
 	"darvaza.org/core"

--- a/tls/x509utils/utils.go
+++ b/tls/x509utils/utils.go
@@ -1,0 +1,34 @@
+package x509utils
+
+import (
+	"crypto"
+	"crypto/x509"
+)
+
+// PublicKeyFromPrivateKey attempts to extract the [PublicKey] from the given
+// [crypto.PrivateKey]. Returns nil if the private key or the public key are
+// nil or they don't implement the required interfaces.
+func PublicKeyFromPrivateKey(key crypto.PrivateKey) PublicKey {
+	if k, ok := key.(PrivateKey); ok {
+		if pub, ok := k.Public().(PublicKey); ok {
+			return pub
+		}
+	}
+
+	return nil
+}
+
+// PublicKeyFromCertificate attempts to extract the [PublicKey] from the given
+// [x509.Certificate]. Returns nil if the certificate or public key are nil or
+// they don't implement the required interfaces.
+func PublicKeyFromCertificate(cert *x509.Certificate) PublicKey {
+	if cert == nil || cert.PublicKey == nil {
+		return nil
+	}
+
+	if pub, ok := cert.PublicKey.(PublicKey); ok {
+		return pub
+	}
+
+	return nil
+}


### PR DESCRIPTION
moved to avoid circular dependencies 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new `buffer` package for enhanced TLS operations, including utility functions for managing keys and certificates.
	- Added a method to the `KeySet` struct for retrieving private keys associated with certificates.
	- Introduced functions for extracting public keys from private keys and certificates.

- **Refactor**
	- Renamed the package from `basic` to `buffer`, restructuring the organization without altering existing functionalities.

These updates improve the handling of cryptographic materials and enhance error management within the TLS framework.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->