### PR TITLE
net/bind: extend Config to configure default listeners

### DIFF
--- a/net/bind/bind.go
+++ b/net/bind/bind.go
@@ -2,8 +2,10 @@
 package bind
 
 import (
+	"context"
 	"net"
 	"net/netip"
+	"time"
 
 	"darvaza.org/core"
 )
@@ -32,8 +34,13 @@ type Config struct {
 	PortStrict bool
 	// PortAttempts indicates how many times we will try finding a port
 	PortAttempts int
-	// Defaultport indicates the port to try on the first attempt if Port is zero
+	// DefaultPort indicates the port to try on the first attempt if Port is zero
 	DefaultPort uint16
+
+	// Context specifies the context to be used by the default listeners.
+	Context context.Context
+	// KeepAlive specifies the keep-alive period used by the default listeners.
+	KeepAlive time.Duration
 
 	// OnlyTCP tells Bind to skip listening UDP ports
 	OnlyTCP bool
@@ -64,11 +71,8 @@ func (cfg *Config) SetDefaults() error {
 	}
 
 	// Callbacks
-	if cfg.ListenTCP == nil {
-		cfg.ListenTCP = net.ListenTCP
-	}
-	if cfg.ListenUDP == nil {
-		cfg.ListenUDP = net.ListenUDP
+	if cfg.ListenTCP == nil || cfg.ListenUDP == nil {
+		cfg.setDefaultListener()
 	}
 
 	// Addresses
@@ -80,6 +84,27 @@ func (cfg *Config) SetDefaults() error {
 		cfg.Addresses = addresses
 	}
 	return nil
+}
+
+func (cfg *Config) setDefaultListener() {
+	if cfg.Context == nil {
+		cfg.Context = context.Background()
+	}
+
+	lc := ListenConfig{
+		ListenConfig: net.ListenConfig{
+			KeepAlive: cfg.KeepAlive,
+		},
+		Context: cfg.Context,
+	}
+
+	if cfg.ListenTCP == nil {
+		cfg.ListenTCP = lc.ListenTCP
+	}
+
+	if cfg.ListenUDP == nil {
+		cfg.ListenUDP = lc.ListenUDP
+	}
 }
 
 func (cfg *Config) getStringIPAddresses() ([]string, error) {

--- a/net/bind/control.go
+++ b/net/bind/control.go
@@ -1,0 +1,16 @@
+package bind
+
+import "syscall"
+
+func reuseAddrControl(_, _ string, conn syscall.RawConn) error {
+	var e2 error
+
+	e1 := conn.Control(func(fd uintptr) {
+		e2 = controlSetReuseAddr(fd)
+	})
+
+	if e1 != nil {
+		return e1
+	}
+	return e2
+}

--- a/net/bind/control_unix.go
+++ b/net/bind/control_unix.go
@@ -1,0 +1,11 @@
+//go:build !windows
+
+package bind
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+func controlSetReuseAddr(fd uintptr) error {
+	return unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_REUSEADDR, 1)
+}

--- a/net/bind/control_unix.go
+++ b/net/bind/control_unix.go
@@ -7,5 +7,9 @@ import (
 )
 
 func controlSetReuseAddr(fd uintptr) error {
-	return unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_REUSEADDR, 1)
+	err := unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_REUSEADDR, 1)
+	if err != nil {
+		return err
+	}
+	return unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_REUSEPORT, 1)
 }

--- a/net/bind/control_windows.go
+++ b/net/bind/control_windows.go
@@ -1,0 +1,11 @@
+//go:build windows
+
+package bind
+
+import (
+	"golang.org/x/sys/windows"
+)
+
+func controlSetReuseAddr(fd uintptr) error {
+	return windows.SetsockoptInt(windows.Handle(fd), windows.SOL_SOCKET, windows.SO_REUSEADDR, 1)
+}

--- a/net/go.mod
+++ b/net/go.mod
@@ -10,7 +10,10 @@ require (
 	github.com/amery/defaults v0.1.0
 )
 
-require golang.org/x/net v0.31.0
+require (
+	golang.org/x/net v0.31.0
+	golang.org/x/sys v0.27.0
+)
 
 require (
 	github.com/gobwas/glob v0.2.3 // indirect

--- a/net/go.sum
+++ b/net/go.sum
@@ -12,5 +12,7 @@ github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 golang.org/x/net v0.31.0 h1:68CPQngjLL0r2AlUKiSxtQFKvzRVbnzLwMUn5SzcLHo=
 golang.org/x/net v0.31.0/go.mod h1:P4fl1q7dY2hnZFxEk4pPSkDHF+QqjitcnDjUQyMM+pM=
+golang.org/x/sys v0.27.0 h1:wBqf8DvsY9Y/2P8gAfPDEYNuS30J4lPHJxXSb/nJZ+s=
+golang.org/x/sys v0.27.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/text v0.20.0 h1:gK/Kv2otX8gz+wn7Rmb3vT96ZwuoxnQlY+HlJVj7Qug=
 golang.org/x/text v0.20.0/go.mod h1:D4IsuqiFMhST5bX19pQ9ikHC2GsaKyk/oF+pn3ducp4=


### PR DESCRIPTION
Three parameters added to Config{} used when defining the default listeners.

* `Context`
* `KeepAlive`
* `ReusePort` (`SO_REUSEADDR`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced configurability for TCP and UDP listeners with new options: `ReusePort`, `Context`, and `KeepAlive`.
	- Introduced platform-specific functions to manage socket options for both Windows and non-Windows systems.

- **Bug Fixes**
	- Improved error handling in listener configuration.

- **Chores**
	- Updated dependency management in the `go.mod` file for better organization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->