### PR TITLE
fix submodule editorconfig and vscode settings support

### DIFF
--- a/config/.editorconfig
+++ b/config/.editorconfig
@@ -1,0 +1,1 @@
+root = false

--- a/config/.vscode/settings.json
+++ b/config/.vscode/settings.json
@@ -1,6 +1,5 @@
 {
   "cSpell.words": [
-    "certpool",
     "darvaza"
   ]
 }

--- a/container/.editorconfig
+++ b/container/.editorconfig
@@ -1,0 +1,1 @@
+root = false

--- a/container/.vscode/settings.json
+++ b/container/.vscode/settings.json
@@ -1,6 +1,5 @@
 {
   "cSpell.words": [
-    "certpool",
     "darvaza"
   ]
 }

--- a/fs/.editorconfig
+++ b/fs/.editorconfig
@@ -1,0 +1,1 @@
+root = false

--- a/fs/.vscode/settings.json
+++ b/fs/.vscode/settings.json
@@ -1,6 +1,5 @@
 {
   "cSpell.words": [
-    "certpool",
     "darvaza"
   ]
 }

--- a/net/.editorconfig
+++ b/net/.editorconfig
@@ -1,0 +1,1 @@
+root = false

--- a/net/.vscode/settings.json
+++ b/net/.vscode/settings.json
@@ -1,6 +1,5 @@
 {
   "cSpell.words": [
-    "certpool",
     "darvaza"
   ]
 }

--- a/tls/.editorconfig
+++ b/tls/.editorconfig
@@ -1,0 +1,1 @@
+root = false

--- a/tls/.vscode/settings.json
+++ b/tls/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-    "cSpell.words": [
-        "certpool"
-    ]
+  "cSpell.words": [
+    "certpool"
+  ]
 }

--- a/web/.editorconfig
+++ b/web/.editorconfig
@@ -1,0 +1,1 @@
+root = false

--- a/web/.vscode/settings.json
+++ b/web/.vscode/settings.json
@@ -1,6 +1,5 @@
 {
   "cSpell.words": [
-    "certpool",
     "darvaza"
   ]
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new configuration file for Visual Studio Code settings to recognize "darvaza" as a valid word in spell checking across multiple directories.
  
- **Configuration Updates**
  - Added `root = false` to `.editorconfig` files to allow parent configurations to be considered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->