### PR TITLE
tls/x509utils: introduce options for `ReadStringPEM()`

### DIFF
--- a/tls/x509utils/pem_read.go
+++ b/tls/x509utils/pem_read.go
@@ -178,7 +178,7 @@ func (r *readOptions) readDirPEM(s string) error {
 		return &fs.PathError{
 			Op:   "Read",
 			Path: s,
-			Err:  fs.ErrNotExist,
+			Err:  core.Wrap(core.ErrInvalid, "directories support disabled"),
 		}
 	case r.fs == nil:
 		return ReadDirPEM(os.DirFS(s), ".", r.cb)

--- a/tls/x509utils/pem_read.go
+++ b/tls/x509utils/pem_read.go
@@ -238,3 +238,16 @@ func ReadWithoutDirs() ReadOption {
 		return nil
 	}
 }
+
+// ReadWithDirs allows [ReadStringPEM] to scan directories.
+// This is the default.
+func ReadWithDirs() ReadOption {
+	return func(r *readOptions) error {
+		if r == nil {
+			return core.ErrNilReceiver
+		}
+
+		r.dirs = true
+		return nil
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced configurability for reading PEM data with new options.
	- Introduced functions to specify reading behavior: `ReadWithFS`, `ReadWithoutDirs`, and `ReadWithDirs`.

- **Refactor**
	- Updated the `ReadStringPEM` method to accept additional configuration options.
	- Modularized the PEM reading process through the new `readOptions` struct.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->