### PR TITLE
feat(web): resource: introduce JSONTime for encoding/decoding time

### DIFF
--- a/web/resource/json_time.go
+++ b/web/resource/json_time.go
@@ -25,8 +25,11 @@ func (ts *JSONTime) MarshalJSON() ([]byte, error) {
 		return nil, core.ErrNilReceiver
 	}
 
+	// truncate to milliseconds
+	t2 := ts.Time.Truncate(time.Millisecond)
+
 	// encode quoted
-	return []byte(ts.Format(jsonRFC9557)), nil
+	return []byte(t2.Format(jsonRFC9557)), nil
 }
 
 // UnmarshalJSON decodes the timestamp from JSON.
@@ -51,4 +54,20 @@ func (ts *JSONTime) UnmarshalJSON(b []byte) error {
 	}
 
 	return err
+}
+
+// NewJSONTime returns a new [JSONTime] set
+// to a copy of the given time, or the current
+// UTC timestamp if none is provided.
+func NewJSONTime(tp *time.Time) JSONTime {
+	var t time.Time
+	if tp != nil {
+		t = *tp
+	}
+
+	if t.IsZero() {
+		t = time.Now().UTC()
+	}
+
+	return JSONTime{Time: t}
 }

--- a/web/resource/json_time.go
+++ b/web/resource/json_time.go
@@ -1,0 +1,54 @@
+package resource
+
+import (
+	"time"
+
+	"darvaza.org/core"
+)
+
+// RFC9557 if the formatting used by [JSONTime] when
+// encoding or decoding JSON.
+const RFC9557 = "2006-01-02T15:04:05.999Z07:00"
+
+// jsonRFC9557 is a quoted variant of [RFC9557].
+const jsonRFC9557 = "\"" + RFC9557 + "\""
+
+// JSONTime is a [time.Time] but using an [RFC9557]
+// with millisecond accuracy, compatible with ISO8601.
+type JSONTime struct {
+	time.Time
+}
+
+// MarshalJSON encodes the timestamp for JSON.
+func (ts *JSONTime) MarshalJSON() ([]byte, error) {
+	if ts == nil {
+		return nil, core.ErrNilReceiver
+	}
+
+	// encode quoted
+	return []byte(ts.Format(jsonRFC9557)), nil
+}
+
+// UnmarshalJSON decodes the timestamp from JSON.
+func (ts *JSONTime) UnmarshalJSON(b []byte) error {
+	if ts == nil {
+		return core.ErrNilReceiver
+	}
+
+	s := string(b)
+	// quoted
+	t, err := time.Parse(jsonRFC9557, s)
+	if err == nil {
+		ts.Time = t
+		return nil
+	}
+
+	// unquoted
+	t, err = time.Parse(RFC9557, s)
+	if err == nil {
+		ts.Time = t
+		return nil
+	}
+
+	return err
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new package for handling JSON timestamps with millisecond accuracy.
	- Added support for RFC9557 timestamp format.
	- Implemented robust JSON encoding and decoding for timestamps.
	- Created a constructor for creating new JSON time instances.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->