### PR TITLE
feat(container/slices): Set: add Purge() alternative to Clear()

### DIFF
--- a/container/slices/set.go
+++ b/container/slices/set.go
@@ -18,8 +18,13 @@ type Set[T any] interface {
 	// Elements that do not exist in the set are ignored and do not contribute to the return value.
 	Remove(...T) int
 
-	// Clear removes all elements from the set, leaving it empty.
+	// Clear removes all elements from the set, leaving it empty. Total capacity remains.
 	Clear()
+
+	// Purge removes all elements from the set, leaving it with zero capacity. It returns the elements
+	// the Set contained.
+	Purge() []T
+
 	// Export returns a copy of the elements currently in the set as a new slice.
 	// The order of elements in the returned slice is not necessarily the same as the order in which
 	// they were added.

--- a/container/slices/set_fn.go
+++ b/container/slices/set_fn.go
@@ -279,6 +279,22 @@ func (set *CustomSet[T]) Clear() {
 	set.s = set.s[:0]
 }
 
+// Purge removes and returns all elements from the set, resetting it to an empty state.
+// If the set is nil, it returns nil. The method is thread-safe and efficiently
+// transfers ownership of the underlying slice to the caller.
+func (set *CustomSet[T]) Purge() []T {
+	if set == nil {
+		return nil
+	}
+
+	set.mu.Lock()
+	defer set.mu.Unlock()
+
+	out := set.s
+	set.s = []T{}
+	return out
+}
+
 // Export returns a copy of the set's underlying slice, ensuring thread-safe access.
 // If the set is nil, it returns nil. The returned slice is a new slice with the same
 // elements as the set, preventing direct modification of the set's internal state.


### PR DESCRIPTION
returning the removed elements for further processing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new option to completely clear a set while returning all its items, effectively resetting its capacity.
  
- **Documentation**
  - Updated the description for the existing clearing operation to indicate that it removes all items without altering the set’s reserved capacity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->