### PR TITLE
feat(sync): introduce Barrier, Count and CountZero in cond subpackage

### DIFF
--- a/sync/README.md
+++ b/sync/README.md
@@ -212,6 +212,58 @@ or closed to wake up all waiters simultaneously.
 * Provides graceful handling of nil receivers and improper initialisation
 * Returns appropriate errors from the `errors` package for common failure modes
 
+## Count
+
+The `cond` package also provides a `Count` type that combines features of a
+condition variable and an atomic counter.
+
+```go
+type Count struct{}
+```
+
+A `Count` allows atomic operations and waiting on an int32 value until specific
+conditions are met. This enables goroutines to coordinate based on a numeric
+value and user-defined conditions.
+
+Each `Count` instance needs to be initialised and closed properly to avoid
+resource leaks.
+
+### Count Characteristics
+
+* **Atomic counter operations**: Provides thread-safe increment, decrement,
+  and add operations
+* **Conditional waiting**: Supports waiting until the counter reaches specific
+  values or meets custom conditions
+* **Context-aware waiting**: Includes methods that respect context cancellation
+  and timeouts
+* **Broadcast capability**: Can notify all waiting goroutines when conditions
+  are met
+
+### Count core methods
+
+* `Add(n int) int`: Atomically adds n to the counter and returns the new value
+* `Inc() int`: Atomically increments the counter by 1
+* `Dec() int`: Atomically decrements the counter by 1
+* `Value() int`: Returns the current counter value
+* `Wait()`: Blocks until the counter becomes zero
+* `WaitFn(func(int32) bool)`: Blocks until the provided condition function
+  returns true
+* `WaitFnContext(context.Context, func(int32) bool)`: Context-aware waiting
+  with cancellation support
+* `Reset(n int)`: Resets the counter to the specified value and wakes all
+  waiting goroutines
+* `Signal() bool`: Wakes a single waiting goroutine
+* `Broadcast()`: Wakes all waiting goroutines
+
+### Count Implementation
+
+* Uses atomic operations for counter management to ensure thread safety
+* Leverages the `Barrier` type internally for goroutine coordination
+* Supports custom conditions for signalling waiters when specific values
+  are reached
+* Provides robust error handling for nil receivers and uninitialised instances
+* Integrates with Go's context package for cancellation and timeout support
+
 ## Semaphore
 
 The `semaphore` package provides a `Semaphore` type that implements both

--- a/sync/cond/barrier.go
+++ b/sync/cond/barrier.go
@@ -30,10 +30,15 @@ func NewBarrier() *Barrier {
 	return c
 }
 
-// IsNil checks if the Barrier or its underlying channel is nil.
-// Used for lazy initialisation in higher-level primitives.
+// IsNil reports whether the Barrier or its underlying channel is nil.
+// This is used for lazy initialisation in higher-level primitives.
 func (bs *Barrier) IsNil() bool {
 	return bs == nil || bs.b == nil
+}
+
+// IsClosed reports whether the Barrier is no longer usable.
+func (bs *Barrier) IsClosed() bool {
+	return bs == nil || bs.b == nil || bs.closed
 }
 
 // Init initialises the barrier by creating a channel with a capacity

--- a/sync/cond/barrier.go
+++ b/sync/cond/barrier.go
@@ -1,0 +1,191 @@
+package cond
+
+import (
+	"sync"
+
+	"darvaza.org/core"
+	"darvaza.org/x/sync/errors"
+)
+
+// Barrier provides a synchronisation mechanism to coordinate goroutines.
+// It manages a reusable token that can be used to signal state changes
+// and coordinate access to shared resources.
+// Barrier is primarily designed to be used by other synchronisation
+// primitives internally.
+type Barrier struct {
+	_ sync.Mutex // prevent copies
+
+	closed bool
+
+	b chan Token
+}
+
+// NewBarrier creates and initialises a new Barrier, panicking if
+// initialisation fails. It returns a fully initialised Barrier ready for use.
+func NewBarrier() *Barrier {
+	c := &Barrier{}
+	if err := c.Init(); err != nil {
+		core.Panic(err)
+	}
+	return c
+}
+
+// IsNil checks if the Barrier or its underlying channel is nil.
+// Used for lazy initialisation in higher-level primitives.
+func (bs *Barrier) IsNil() bool {
+	return bs == nil || bs.b == nil
+}
+
+// Init initialises the barrier by creating a channel with a capacity
+// of 1 and placing a new Token in it. This should be called before
+// any other methods if the barrier was not properly initialised.
+func (bs *Barrier) Init() error {
+	switch {
+	case bs == nil:
+		return errors.ErrNilReceiver
+	case bs.b != nil:
+		return errors.ErrAlreadyInitialised
+	default:
+		b := make(chan Token, 1)
+		b <- make(Token)
+		bs.b = b
+		return nil
+	}
+}
+
+// Close terminates the Barrier by closing its underlying channel and the
+// current Token. It returns an error if the Barrier is nil, not initialised
+// or already closed. After calling Close, the Barrier cannot be used again.
+func (bs *Barrier) Close() error {
+	switch {
+	case bs == nil:
+		return errors.ErrNilReceiver
+	case bs.b == nil:
+		return errors.ErrNotInitialised
+	case bs.closed:
+		return errors.ErrClosed
+	default:
+		// lock
+		b, ok := <-bs.b
+		if !ok {
+			return errors.ErrClosed
+		}
+
+		bs.closed = true
+		close(b)
+		close(bs.b)
+		return nil
+	}
+}
+
+// Broadcast closes the current Token (signalling all waiters) and creates
+// a new Token. This is typically called when a watched condition is met,
+// to wake up all waiting goroutines and prepare for the next wait cycle.
+func (bs *Barrier) Broadcast() {
+	t, ok := <-bs.b
+	if ok {
+		// omit when closed.
+		close(t)
+		bs.b <- make(Token)
+	}
+}
+
+// Signal attempts to signal the current Token, waking up a single waiting
+// goroutine. It returns true if a goroutine was successfully signalled,
+// and false otherwise. The method ensures the Token is returned to the
+// Barrier after signalling.
+func (bs *Barrier) Signal() bool {
+	b, ok := <-bs.b
+	if !ok {
+		// closed
+		return false
+	}
+	signaled := b.Signal()
+	bs.b <- b
+	return signaled
+}
+
+// Acquire returns a receive-only channel for obtaining the current Token.
+// When a Token is received, the caller has exclusive access until it calls
+// Release with the same Token.
+func (bs *Barrier) Acquire() <-chan Token {
+	return bs.b
+}
+
+// TryAcquire attempts to acquire the token without blocking.
+// Returns the token and true if successful, nil and false otherwise.
+func (bs *Barrier) TryAcquire() (Token, bool) {
+	select {
+	case t, ok := <-bs.b:
+		return t, ok
+	default:
+		return nil, false
+	}
+}
+
+// Release returns the Token to the barrier, allowing other goroutines
+// to acquire it. This should always be called after Acquire to maintain
+// proper barrier operation. It can be safely called with a nil Token.
+func (bs *Barrier) Release(b Token) {
+	if b != nil && !bs.closed {
+		bs.b <- b
+	}
+}
+
+// Token retrieves the current Token without removing it from the barrier.
+// This provides access to the Token for waiting on state changes without
+// exclusive access, used to provide a select-friendly channel that will be
+// closed when a condition is met.
+func (bs *Barrier) Token() Token {
+	b, ok := <-bs.b
+	if !ok {
+		// closed
+		return nil
+	}
+	bs.b <- b
+	return b
+}
+
+// Signaled returns a channel that can be used to wait for the barrier's
+// completion. It provides a select-friendly way to wait for a waiter to be
+// signalled.
+func (bs *Barrier) Signaled() <-chan struct{} {
+	return bs.Token()
+}
+
+// Wait blocks until the barrier's current condition is signalled.
+// It provides a simple way to wait for the barrier to complete its current
+// state.
+func (bs *Barrier) Wait() {
+	<-bs.Signaled()
+}
+
+// Token is a channel of empty structs that serves as a signalling mechanism.
+// When closed, any goroutines waiting on the Token will be unblocked.
+// This type is used for efficient signalling with minimal memory overhead.
+type Token chan struct{}
+
+// Signaled returns the Token as a channel that can be used to wait for the
+// Token's completion. It provides a select-friendly way to wait for the Token
+// to be signalled or closed.
+func (t Token) Signaled() <-chan struct{} {
+	return t
+}
+
+// Wait blocks until the Token is closed, which happens when the condition
+// being monitored (like a counter reaching zero) is satisfied.
+func (t Token) Wait() {
+	<-t
+}
+
+// Signal wakes up a single goroutine waiting on the Token, if there is one.
+// It returns true if a goroutine was woken up, and false otherwise.
+// It does not block if no goroutines are waiting.
+func (t Token) Signal() bool {
+	select {
+	case t <- struct{}{}:
+		return true
+	default:
+		return false
+	}
+}

--- a/sync/cond/barrier_test.go
+++ b/sync/cond/barrier_test.go
@@ -28,6 +28,44 @@ func TestBarrierIsNil(t *testing.T) {
 	})
 }
 
+// TestBarrierIsClosed verifies the behaviour of the IsClosed method
+// under various barrier states.
+func TestBarrierIsClosed(t *testing.T) {
+	t.Run("nil barrier", func(t *testing.T) {
+		var b *Barrier
+		assert.True(t, b.IsClosed(), "nil barrier should return true for IsClosed()")
+	})
+
+	t.Run("uninitialised barrier", func(t *testing.T) {
+		b := &Barrier{}
+		assert.True(t, b.IsClosed(),
+			"uninitialised barrier should return true for IsClosed()")
+	})
+
+	t.Run("initialised barrier", func(t *testing.T) {
+		b := &Barrier{}
+		err := b.Init()
+		assert.NoError(t, err, "Init() should not return an error")
+		assert.False(t, b.IsClosed(),
+			"initialised barrier should return false for IsClosed()")
+	})
+
+	t.Run("closed barrier", func(t *testing.T) {
+		b := NewBarrier()
+		err := b.Close()
+		assert.NoError(t, err, "Close() should not return an error")
+		assert.True(t, b.IsClosed(),
+			"closed barrier should return true for IsClosed()")
+	})
+
+	t.Run("after broadcast", func(t *testing.T) {
+		b := NewBarrier()
+		b.Broadcast()
+		assert.False(t, b.IsClosed(),
+			"barrier should not be closed after Broadcast()")
+	})
+}
+
 func TestBarrierInit(t *testing.T) {
 	b := &Barrier{}
 	err := b.Init()

--- a/sync/cond/barrier_test.go
+++ b/sync/cond/barrier_test.go
@@ -1,0 +1,230 @@
+package cond
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBarrierIsNil(t *testing.T) {
+	t.Run("nil barrier", func(t *testing.T) {
+		var b *Barrier
+		assert.True(t, b.IsNil(), "nil barrier should return true for IsNil()")
+	})
+
+	t.Run("uninitialized barrier", func(t *testing.T) {
+		b := &Barrier{}
+		assert.True(t, b.IsNil(), "uninitialized barrier should return true for IsNil()")
+	})
+
+	t.Run("initialized barrier", func(t *testing.T) {
+		b := &Barrier{}
+		err := b.Init()
+		assert.NoError(t, err, "Init() should not return an error")
+		assert.False(t, b.IsNil(), "initialized barrier should return false for IsNil()")
+	})
+}
+
+func TestBarrierInit(t *testing.T) {
+	b := &Barrier{}
+	err := b.Init()
+	assert.NoError(t, err, "Init() should not return an error")
+
+	// After initialization, we should be able to acquire a token
+	select {
+	case token := <-b.Acquire():
+		b.Release(token)
+		assert.True(t, true, "token was acquired successfully")
+	case <-time.After(100 * time.Millisecond):
+		assert.Fail(t, "failed to acquire token after initialization")
+	}
+}
+
+func TestBarrierAcquireRelease(t *testing.T) {
+	b := &Barrier{}
+	defer b.Close()
+
+	err := b.Init()
+	assert.NoError(t, err, "Init() should not return an error")
+
+	// First acquisition should succeed immediately
+	var token Token
+	select {
+	case token = <-b.Acquire():
+		assert.NotNil(t, token, "acquired token should not be nil")
+	case <-time.After(100 * time.Millisecond):
+		assert.Fail(t, "failed to acquire token")
+		return
+	}
+
+	// Second acquisition should block (we'll test with a goroutine)
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	secondAcquired := false
+	go func() {
+		defer wg.Done()
+		select {
+		case <-b.Acquire():
+			secondAcquired = true
+		case <-time.After(50 * time.Millisecond):
+			// This should timeout as we haven't released yet
+		}
+	}()
+
+	// Wait for the goroutine to finish its attempt
+	wg.Wait()
+	assert.False(t, secondAcquired, "second acquire should not succeed while token is held")
+
+	// Now release the token
+	b.Release(token)
+
+	// Now we should be able to acquire again
+	select {
+	case token = <-b.Acquire():
+		b.Release(token)
+		assert.NotNil(t, token, "token should be acquirable after release")
+	case <-time.After(100 * time.Millisecond):
+		assert.Fail(t, "failed to acquire token after release")
+	}
+}
+
+func TestBarrierToken(t *testing.T) {
+	b := &Barrier{}
+	err := b.Init()
+	assert.NoError(t, err, "Init() should not return an error")
+
+	// Get should not remove the token from the barrier
+	token := b.Token()
+	require.NotNil(t, token, "token should not be nil")
+
+	// We should still be able to acquire after Get
+	select {
+	case acquired := <-b.Acquire():
+		b.Release(acquired)
+		assert.NotNil(t, acquired, "token should be acquirable after Get")
+	case <-time.After(100 * time.Millisecond):
+		assert.Fail(t, "failed to acquire token after Get")
+	}
+}
+
+func TestBarrierReset(t *testing.T) {
+	b := &Barrier{}
+	_ = b.Init()
+
+	// Get the initial token
+	initialToken := b.Token()
+	require.NotNil(t, initialToken, "initial token should not be nil")
+
+	// Set up a goroutine that waits on the token
+	waitComplete := false
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+		initialToken.Wait() // Should block until Reset closes the token
+		waitComplete = true
+	}()
+
+	// Broadcast the barrier to release the goroutine
+	b.Broadcast()
+
+	// Wait for the goroutine to complete
+	wg.Wait()
+	assert.True(t, waitComplete, "Wait() should have completed after Reset()")
+
+	// Get the new token and verify it's different
+	newToken := b.Token()
+	require.NotNil(t, newToken, "new token should not be nil")
+	assert.NotEqual(t, initialToken, newToken, "new token should be different from initial token")
+
+	// Verify the behaviour of the new token
+	var newWg sync.WaitGroup
+	newWaitComplete := false
+	newWg.Add(1)
+
+	go func() {
+		defer newWg.Done()
+		select {
+		case <-newToken:
+			newWaitComplete = true
+		case <-time.After(50 * time.Millisecond):
+			// Should timeout as we haven't reset
+		}
+	}()
+
+	newWg.Wait()
+	assert.False(t, newWaitComplete, "Wait on new token should not complete without Reset")
+}
+
+func TestTokenWait(t *testing.T) {
+	// Create a token
+	token := make(Token)
+
+	// Test waiting with timeout using a channel
+	waitComplete := false
+	timeoutCh := make(chan bool, 1)
+
+	go func() {
+		token.Wait()
+		waitComplete = true
+		timeoutCh <- true
+	}()
+
+	// The wait should block until we close the token
+	select {
+	case <-timeoutCh:
+		assert.Fail(t, "Wait() should block until token is closed")
+	case <-time.After(50 * time.Millisecond):
+		// Expected timeout
+	}
+
+	// Close the token and check that Wait() completes
+	close(token)
+
+	select {
+	case <-timeoutCh:
+		assert.True(t, waitComplete, "Wait() should have completed after token was closed")
+	case <-time.After(100 * time.Millisecond):
+		assert.Fail(t, "Wait() did not complete after token was closed")
+	}
+}
+
+func TestConcurrentBarrierOperations(t *testing.T) {
+	b := &Barrier{}
+	_ = b.Init()
+
+	const numGoroutines = 10
+	var wg sync.WaitGroup
+	wg.Add(numGoroutines)
+
+	for range numGoroutines {
+		go func() {
+			defer wg.Done()
+
+			// Each goroutine will acquire and release the token
+			token := <-b.Acquire()
+
+			// Hold the token briefly
+			time.Sleep(10 * time.Millisecond)
+
+			// Release it
+			b.Release(token)
+		}()
+	}
+
+	wg.Wait()
+
+	// After all goroutines are done, we should still be able to acquire
+	select {
+	case token := <-b.Acquire():
+		assert.NotNil(t, token, "token should be acquirable after concurrent operations")
+		b.Release(token)
+	case <-time.After(100 * time.Millisecond):
+		assert.Fail(t, "failed to acquire token after concurrent operations")
+	}
+}

--- a/sync/cond/cond.go
+++ b/sync/cond/cond.go
@@ -1,0 +1,3 @@
+// Package cond provides condition-based synchronisation primitives
+// on top of the [sync/atomic] package and channels.
+package cond

--- a/sync/cond/count.go
+++ b/sync/cond/count.go
@@ -1,0 +1,374 @@
+package cond
+
+// This file includes a condition variable implementation (Count) that
+// allows goroutines to coordinate and wait for specific conditions to be met
+// on a shared atomic counter.
+
+import (
+	"context"
+	"runtime"
+	"sync/atomic"
+
+	"darvaza.org/core"
+	"darvaza.org/x/sync/errors"
+)
+
+// Count is a synchronisation primitive that allows atomic operations and waiting
+// on an int32 value until a condition is met. It combines features of a
+// condition variable and an atomic counter, allowing goroutines to coordinate
+// based on a numeric value and user-defined conditions.
+//
+// All methods are safe for concurrent use from multiple goroutines.
+//
+// It's based on Roberto Clapis' series on [advanced concurrency patterns].
+//
+// [advanced concurrency patterns]: https://blogtitle.github.io/go-advanced-concurrency-patterns-part-3-channels/
+type Count struct {
+	v int32
+	b Barrier
+
+	m func(int32) bool
+}
+
+// NewCount creates a new Count with an initial value and optional broadcast
+// conditions. It initialises the Count with the given value and optional
+// matching functions. If initialisation fails, it panics with the encountered
+// error, though no errors are anticipated.
+// If no matching functions are provided, every change of value broadcasts.
+// The returned Count is ready for use in concurrent synchronisation scenarios
+// and it's self closing.
+func NewCount(initialValue int, broadcast ...func(int32) bool) *Count {
+	c := new(Count)
+	if err := c.doInit(initialValue, broadcast); err != nil {
+		core.Panic(err)
+	}
+
+	runtime.SetFinalizer(c, func(c *Count) {
+		_ = c.b.Close()
+	})
+
+	return c
+}
+
+// IsNil reports whether the Count is nil or its underlying Barrier is nil or
+// uninitialised. It provides a safe way to check the initialisation status of
+// a Count instance.
+func (c *Count) IsNil() bool {
+	if c == nil {
+		return true
+	}
+	return c.b.IsNil()
+}
+
+// check validates the Count instance, ensuring it is not nil and has been
+// properly initialised. It returns an error if the Count is nil or its
+// underlying Barrier is not initialised.
+func (c *Count) check() error {
+	switch {
+	case c == nil:
+		return errors.ErrNilReceiver
+	case c.b.IsNil():
+		return errors.ErrNotInitialised
+	default:
+		return nil
+	}
+}
+
+// Init initialises the Count with a given initial value and optional broadcast
+// conditions. It sets up the Count for use in concurrent synchronisation
+// scenarios. Returns an error if the receiver is nil or already initialised.
+// Close needs to be called at the end to clear the internal channel.
+func (c *Count) Init(initialValue int, broadcast ...func(int32) bool) error {
+	if c == nil {
+		return errors.ErrNilReceiver
+	}
+
+	return c.doInit(initialValue, broadcast)
+}
+
+func (c *Count) doInit(initialValue int, broadcast []func(int32) bool) error {
+	// barrier
+	if err := c.b.Init(); err != nil {
+		return err
+	}
+
+	c.v = int32(initialValue)
+	c.m = makeAnyMatch(broadcast)
+	return nil
+}
+
+// Reset sets the Count to a new value, validating the Count instance before resetting.
+// It returns an error if the Count is not properly initialised or is nil.
+func (c *Count) Reset(value int) error {
+	if err := c.check(); err != nil {
+		return err
+	}
+
+	return c.doReset(value)
+}
+
+func (c *Count) doReset(value int) error {
+	b, ok := <-c.b.Acquire()
+	if !ok {
+		return errors.ErrClosed
+	}
+
+	// set new value
+	atomic.StoreInt32(&c.v, int32(value))
+	// set new barrier
+	c.b.Release(make(Token))
+
+	// and signal all waiters
+	close(b)
+	return nil
+}
+
+// Close releases the resources associated with the Count.
+// It returns an error if the receiver is nil.
+func (c *Count) Close() error {
+	if c == nil {
+		return errors.ErrNilReceiver
+	}
+
+	return c.b.Close()
+}
+
+// Add atomically adds the given integer to the Cond value and returns the new
+// value. It notifies all waiters about the state change through a broadcast
+// unless custom conditions were specified during initialisation.
+// If n is 0, it simply returns the current value without broadcasting.
+func (c *Count) Add(n int) int {
+	if n == 0 {
+		return int(atomic.LoadInt32(&c.v))
+	}
+
+	return c.doAdd(n)
+}
+
+// doAdd atomically adds n to the value and broadcasts to all waiters
+// unless custom conditions were specified during initialisation.
+// Returns the new value after the addition operation.
+func (c *Count) doAdd(n int) int {
+	v := atomic.AddInt32(&c.v, int32(n))
+	if c.m(v) {
+		// wake all waiters
+		c.b.Broadcast()
+	}
+	return int(v)
+}
+
+// Inc atomically increments the Cond value by 1 and returns the new value.
+// It notifies all waiters unless custom conditions were specified during
+// initialisation.
+func (c *Count) Inc() int {
+	return c.doAdd(1)
+}
+
+// Dec atomically decrements the Cond value by 1 and returns the new value.
+// It notifies all waiters about the state change unless custom conditions
+// were specified during initialisation.
+func (c *Count) Dec() int {
+	return c.doAdd(-1)
+}
+
+// Value atomically returns the current value of the Cond.
+// This operation does not affect waiters.
+func (c *Count) Value() int {
+	return int(atomic.LoadInt32(&c.v))
+}
+
+// WaitFnAbort blocks until the condition function returns true or the abort
+// channel is closed. Returns context.Canceled if aborted, or nil if the
+// condition is met. If until is nil, waits for the value to become zero.
+func (c *Count) WaitFnAbort(abort <-chan struct{}, until func(int32) bool) error {
+	err := c.check()
+	switch {
+	case err != nil:
+		return err
+	case c.doWaitFn(abort, until).IsCancelled():
+		return context.Canceled
+	default:
+		return nil
+	}
+}
+
+func (c *Count) doWaitFn(abort <-chan struct{}, until func(int32) bool) waitResult {
+	switch {
+	case isCancelled(abort):
+		return waitCancelled
+	case c.doMatch(until):
+		return waitSuccess
+	default:
+		return c.doWaitFnLoop(abort, until)
+	}
+}
+
+func (c *Count) doWaitFnLoop(abort <-chan struct{}, until func(int32) bool) waitResult {
+	var b Token
+	var res waitResult
+
+	for res.IsContinue() {
+		if b == nil {
+			b, res = c.doWaitFnPass1(abort, until)
+		} else {
+			res = c.doWaitFnPass2(abort, until, b)
+			b = nil
+		}
+	}
+
+	return res
+}
+
+func (c *Count) doWaitFnPass1(abort <-chan struct{}, until func(int32) bool) (Token, waitResult) {
+	// acquire fresh barrier
+	select {
+	case b, ok := <-c.b.Acquire():
+		var res waitResult
+
+		switch {
+		case !ok, isCancelled(abort):
+			res = waitCancelled
+		case c.doMatch(until):
+			res = waitSuccess
+		default:
+			res = waitContinue
+		}
+		c.b.Release(b)
+
+		if res.IsContinue() {
+			return b, waitContinue
+		}
+
+		// done
+		return nil, res
+	case <-abort:
+		return nil, waitCancelled
+	}
+}
+
+func (c *Count) doWaitFnPass2(abort <-chan struct{}, until func(int32) bool, b Token) waitResult {
+	// wait to be signaled
+	select {
+	case <-b.Signaled():
+		// and check without delay
+		if c.doMatch(until) {
+			return waitSuccess
+		}
+		// try again later.
+		return waitContinue
+	case <-abort:
+		return waitCancelled
+	}
+}
+
+// WaitFnContext blocks until the condition function returns true or the context
+// is cancelled. Returns the context's error if cancelled, or nil if the
+// condition is met. If until is nil, waits for the value to become zero.
+// Returns utils.ErrNilContext if the provided context is nil.
+func (c *Count) WaitFnContext(ctx context.Context, until func(int32) bool) error {
+	err := c.check()
+	switch {
+	case err != nil:
+		return err
+	case ctx == nil:
+		return errors.ErrNilContext
+	case c.doWaitFn(ctx.Done(), until).IsCancelled():
+		return ctx.Err()
+	default:
+		return nil
+	}
+}
+
+// WaitFn blocks the calling goroutine until the provided condition function
+// returns true. If no condition function is provided (nil), it waits until
+// the Count value becomes zero. Panics if the receiver is nil or
+// uninitialised.
+func (c *Count) WaitFn(until func(int32) bool) {
+	if err := c.check(); err != nil {
+		core.Panic(core.NewPanicError(1, err))
+	}
+
+	c.doWaitFn(nil, until)
+}
+
+// Wait blocks the calling goroutine until the Cond value becomes zero.
+// Panics if the receiver is nil or uninitialised.
+func (c *Count) Wait() {
+	if err := c.check(); err != nil {
+		core.Panic(core.NewPanicError(1, err))
+	}
+
+	c.doWaitFn(nil, nil)
+}
+
+// Match tests the value against the given condition function and returns
+// the result. If no condition function is provided, it tests if the Cond
+// value is zero. Panics if the receiver is nil or uninitialised.
+func (c *Count) Match(fn func(int32) bool) bool {
+	if err := c.check(); err != nil {
+		core.Panic(core.NewPanicError(1, err))
+	}
+
+	return c.doMatch(fn)
+}
+
+// doMatch implements the condition check logic.
+// If until is nil, it checks if the value is zero.
+func (c *Count) doMatch(fn func(int32) bool) bool {
+	v := atomic.LoadInt32(&c.v)
+	if fn == nil {
+		return v == 0
+	}
+	return fn(v)
+}
+
+// IsZero checks if the Count value is zero.
+// Panics if the receiver is nil or uninitialised.
+func (c *Count) IsZero() bool {
+	if err := c.check(); err != nil {
+		core.Panic(core.NewPanicError(1, err))
+	}
+
+	return c.doMatch(nil)
+}
+
+// Signal notifies a single waiter about a state change.
+// The waiter is selected at random from the pool of waiting goroutines.
+// Panics if the receiver is nil or uninitialised.
+func (c *Count) Signal() bool {
+	if err := c.check(); err != nil {
+		core.Panic(core.NewPanicError(1, err))
+	}
+
+	return c.b.Signal()
+}
+
+// Broadcast notifies all waiters about a state change.
+// Panics if the receiver is nil or uninitialised.
+func (c *Count) Broadcast() {
+	if err := c.check(); err != nil {
+		core.Panic(core.NewPanicError(1, err))
+	}
+
+	c.b.Broadcast()
+}
+
+// waitResult represents the outcome of a wait operation.
+type waitResult int
+
+const (
+	waitContinue  waitResult = iota
+	waitSuccess              // Counter matched the condition
+	waitCancelled            // Wait was cancelled
+)
+
+// IsCancelled returns true if the wait operation was cancelled.
+func (r waitResult) IsCancelled() bool {
+	return r == waitCancelled
+}
+
+// IsContinue returns true if the wait result indicates a
+// we should try again.
+func (r waitResult) IsContinue() bool {
+	return r == waitContinue
+}

--- a/sync/cond/count.go
+++ b/sync/cond/count.go
@@ -60,6 +60,16 @@ func (c *Count) IsNil() bool {
 	return c.b.IsNil()
 }
 
+// IsClosed reports whether the Count is closed and no longer usable for
+// synchronisation. It returns true if the Count is nil or its underlying
+// Barrier is closed.
+func (c *Count) IsClosed() bool {
+	if c == nil {
+		return true
+	}
+	return c.b.IsClosed()
+}
+
 // check validates the Count instance, ensuring it is not nil and has been
 // properly initialised. It returns an error if the Count is nil or its
 // underlying Barrier is not initialised.

--- a/sync/cond/count_bench_test.go
+++ b/sync/cond/count_bench_test.go
@@ -1,0 +1,78 @@
+package cond
+
+import (
+	"testing"
+)
+
+// BenchmarkCount provides performance measurements for the Count struct.
+//
+//revive:disable-next-line:cognitive-complexity
+func BenchmarkCount(b *testing.B) {
+	// Benchmark Add operation
+	b.Run("Add", func(b *testing.B) {
+		c := NewCount(0)
+		defer c.Close()
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			c.Add(1)
+		}
+	})
+
+	// Benchmark Inc operation
+	b.Run("Inc", func(b *testing.B) {
+		c := NewCount(0)
+		defer c.Close()
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			c.Inc()
+		}
+	})
+
+	// Benchmark Value operation
+	b.Run("Value", func(b *testing.B) {
+		c := NewCount(42)
+		defer c.Close()
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = c.Value()
+		}
+	})
+
+	// Benchmark Signal with no waiters
+	b.Run("Signal_NoWaiters", func(b *testing.B) {
+		c := NewCount(0)
+		defer c.Close()
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			c.Signal()
+		}
+	})
+
+	// Benchmark Broadcast with no waiters
+	b.Run("Broadcast_NoWaiters", func(b *testing.B) {
+		c := NewCount(0)
+		defer c.Close()
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			c.Broadcast()
+		}
+	})
+
+	// Benchmark condition matching
+	b.Run("Match", func(b *testing.B) {
+		c := NewCount(42)
+		defer c.Close()
+
+		isFortyTwo := func(v int32) bool { return v == 42 }
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			c.Match(isFortyTwo)
+		}
+	})
+}

--- a/sync/cond/count_test.go
+++ b/sync/cond/count_test.go
@@ -1,0 +1,1017 @@
+package cond
+
+//revive:disable:cognitive-complexity
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCountInitialisation tests the various ways to initialise a Count.
+func TestCountInitialisation(t *testing.T) {
+	t.Run("NewCount", runTestNewCount)
+	t.Run("Init", runTestInit)
+	t.Run("Nil receiver", runTestNilReceiver)
+}
+
+func runTestNewCount(t *testing.T) {
+	c := NewCount(42)
+	require.NotNil(t, c)
+	assert.Equal(t, 42, c.Value())
+	assert.False(t, c.IsNil())
+	require.NoError(t, c.Close())
+}
+
+func runTestInit(t *testing.T) {
+	c := new(Count)
+	err := c.Init(21)
+	require.NoError(t, err)
+	assert.Equal(t, 21, c.Value())
+	assert.False(t, c.IsNil())
+	require.NoError(t, c.Close())
+}
+
+func runTestNilReceiver(t *testing.T) {
+	var c *Count
+	assert.True(t, c.IsNil())
+	assert.Error(t, c.Init(0))
+	assert.Error(t, c.Close())
+}
+
+// TestCountOperations tests the basic operations on the counter.
+func TestCountOperations(t *testing.T) {
+	t.Run("Add", runTestAdd)
+	t.Run("Inc", runTestInc)
+	t.Run("Dec", runTestDec)
+	t.Run("Value", runTestValue)
+}
+
+func runTestAdd(t *testing.T) {
+	c := NewCount(10)
+	defer c.Close()
+
+	assert.Equal(t, 15, c.Add(5))
+	assert.Equal(t, 15, c.Value())
+	assert.Equal(t, 8, c.Add(-7))
+	assert.Equal(t, 8, c.Value())
+
+	// Add with zero doesn't broadcast
+	assert.Equal(t, 8, c.Add(0))
+}
+
+func runTestInc(t *testing.T) {
+	c := NewCount(41)
+	defer c.Close()
+
+	assert.Equal(t, 42, c.Inc())
+	assert.Equal(t, 42, c.Value())
+}
+
+func runTestDec(t *testing.T) {
+	c := NewCount(43)
+	defer c.Close()
+
+	assert.Equal(t, 42, c.Dec())
+	assert.Equal(t, 42, c.Value())
+}
+
+func runTestValue(t *testing.T) {
+	c := NewCount(42)
+	defer c.Close()
+
+	assert.Equal(t, 42, c.Value())
+	c.Inc()
+	assert.Equal(t, 43, c.Value())
+}
+
+// TestCountConditions tests the condition matching functionality.
+func TestCountConditions(t *testing.T) {
+	t.Run("IsZero", runTestIsZero)
+	t.Run("Match", runTestMatch)
+	t.Run("BroadcastCondition", runTestBroadcastCondition)
+}
+
+func runTestIsZero(t *testing.T) {
+	c := NewCount(0)
+	defer c.Close()
+
+	assert.True(t, c.IsZero())
+	c.Inc()
+	assert.False(t, c.IsZero())
+	c.Dec()
+	assert.True(t, c.IsZero())
+}
+
+func runTestMatch(t *testing.T) {
+	c := NewCount(42)
+	defer c.Close()
+
+	// Test with explicit function
+	isFortyTwo := func(v int32) bool { return v == 42 }
+	assert.True(t, c.Match(isFortyTwo))
+
+	// Test after modifying value
+	c.Inc()
+	assert.False(t, c.Match(isFortyTwo))
+
+	// Test with nil function (equivalent to IsZero)
+	_ = c.Reset(0)
+	assert.True(t, c.Match(nil))
+}
+
+func runTestBroadcastCondition(t *testing.T) {
+	// Only broadcast when value is divisible by 10
+	broadcastOn10 := func(v int32) bool { return v%10 == 0 }
+	c := NewCount(0, broadcastOn10)
+	defer c.Close()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	// The waiter will only be woken when counter becomes 10
+	ready := make(chan struct{})
+	go func() {
+		defer wg.Done()
+		close(ready)
+		c.WaitFn(func(v int32) bool { return v >= 5 })
+	}()
+
+	// Give time for goroutine to start waiting
+	<-ready
+	time.Sleep(10 * time.Millisecond)
+
+	// This increment shouldn't wake up the waiter
+	c.Inc() // 1
+	time.Sleep(10 * time.Millisecond)
+
+	// Continue incrementing to reach the broadcast condition (10)
+	c.Add(9) // 10
+
+	// Wait with timeout to ensure the goroutine completes
+	waitDone := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(waitDone)
+	}()
+
+	select {
+	case <-waitDone:
+		// Success
+	case <-time.After(100 * time.Millisecond):
+		assert.Fail(t, "Waiter was not notified when broadcast condition was met")
+	}
+}
+
+// TestCountWait tests the basic Wait functionality.
+func TestCountWait(t *testing.T) {
+	t.Run("Wait", runTestWait)
+}
+
+func runTestWait(t *testing.T) {
+	c := NewCount(1)
+	defer c.Close()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	// Start a goroutine that waits until counter becomes zero
+	go func() {
+		defer wg.Done()
+		c.Wait() // Will block until value becomes 0
+	}()
+
+	// Allow time for goroutine to start waiting
+	time.Sleep(10 * time.Millisecond)
+
+	// Decrement counter to trigger Wait completion
+	c.Dec()
+
+	// Ensure the Wait function completes
+	waitDone := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(waitDone)
+	}()
+
+	select {
+	case <-waitDone:
+		// Success
+	case <-time.After(100 * time.Millisecond):
+		assert.Fail(t, "Wait did not complete after counter became zero")
+	}
+}
+
+// TestCountWaitFn tests the WaitFn functionality.
+func TestCountWaitFn(t *testing.T) {
+	t.Run("WaitFn", runTestWaitFn)
+}
+
+func runTestWaitFn(t *testing.T) {
+	c := NewCount(5)
+	defer c.Close()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	// Start a goroutine that waits for a specific condition
+	go func() {
+		defer wg.Done()
+		c.WaitFn(func(v int32) bool { return v >= 10 })
+	}()
+
+	// Allow time for goroutine to start waiting
+	time.Sleep(10 * time.Millisecond)
+
+	// Update counter to satisfy condition
+	c.Add(5) // Not enough to satisfy condition
+	time.Sleep(10 * time.Millisecond)
+	c.Add(5) // Now the condition is satisfied
+
+	// Ensure the WaitFn function completes
+	waitDone := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(waitDone)
+	}()
+
+	select {
+	case <-waitDone:
+		// Success
+	case <-time.After(100 * time.Millisecond):
+		assert.Fail(t, "WaitFn did not complete when condition was met")
+	}
+}
+
+// TestCountWaitFnContext tests the WaitFnContext functionality.
+func TestCountWaitFnContext(t *testing.T) {
+	t.Run("WaitFnContext", runTestWaitFnContextEmpty)
+	t.Run("WaitFnContext_Success", runTestWaitFnContextSuccess)
+	t.Run("WaitFnContext_Cancelled", runTestWaitFnContextCancelled)
+}
+
+func runTestWaitFnContextEmpty(t *testing.T) {
+	c := NewCount(1)
+	defer c.Close()
+
+	// Create a context that won't time out during our test
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	// Use a condition that's immediately satisfied (the count is already 1)
+	err := c.WaitFnContext(ctx, func(v int32) bool { return v == 1 })
+
+	// Since the condition is immediately satisfied, this should return without error
+	assert.NoError(t, err, "WaitFnContext should not error when condition is immediately satisfied")
+
+	// Test with nil condition function (should check for zero)
+	err = c.Reset(0)
+	require.NoError(t, err)
+
+	// This should also return immediately without error since counter is 0
+	err = c.WaitFnContext(ctx, nil)
+	assert.NoError(t, err, "WaitFnContext with nil function should not error when count is zero")
+}
+
+func runTestWaitFnContextSuccess(t *testing.T) {
+	c := NewCount(1)
+	defer c.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	errCh := make(chan error, 1)
+
+	go func() {
+		defer wg.Done()
+		errCh <- c.WaitFnContext(ctx, func(v int32) bool { return v == 0 })
+	}()
+
+	// Allow time for goroutine to start waiting
+	time.Sleep(10 * time.Millisecond)
+
+	// Decrement to satisfy the condition
+	c.Dec()
+
+	// Ensure the WaitFnContext completes
+	wg.Wait()
+
+	select {
+	case err := <-errCh:
+		assert.NoError(t, err)
+	default:
+		assert.Fail(t, "No result from WaitFnContext")
+	}
+}
+
+func runTestWaitFnContextCancelled(t *testing.T) {
+	c := NewCount(1)
+	defer c.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	errCh := make(chan error, 1)
+
+	go func() {
+		defer wg.Done()
+		errCh <- c.WaitFnContext(ctx, nil) // Wait for zero
+	}()
+
+	// Allow time for goroutine to start waiting
+	time.Sleep(10 * time.Millisecond)
+
+	// Cancel the context
+	cancel()
+
+	// Ensure the WaitFnContext completes with cancellation error
+	wg.Wait()
+
+	select {
+	case err := <-errCh:
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "canceled")
+	default:
+		assert.Fail(t, "No result from WaitFnContext")
+	}
+}
+
+// TestCountWaitFnAbort tests the WaitFnAbort functionality.
+func TestCountWaitFnAbort(t *testing.T) {
+	t.Run("WaitFnAbort_Success", runTestWaitFnAbortSuccess)
+	t.Run("WaitFnAbort_Aborted", runTestWaitFnAbortAborted)
+}
+
+func runTestWaitFnAbortSuccess(t *testing.T) {
+	c := NewCount(1)
+	defer c.Close()
+
+	abortCh := make(chan struct{})
+	defer close(abortCh)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	errCh := make(chan error, 1)
+
+	go func() {
+		defer wg.Done()
+		errCh <- c.WaitFnAbort(abortCh, func(v int32) bool { return v == 0 })
+	}()
+
+	// Allow time for goroutine to start waiting
+	time.Sleep(10 * time.Millisecond)
+
+	// Decrement to satisfy the condition
+	c.Dec()
+
+	// Ensure the WaitFnAbort completes
+	wg.Wait()
+
+	select {
+	case err := <-errCh:
+		assert.NoError(t, err)
+	default:
+		assert.Fail(t, "No result from WaitFnAbort")
+	}
+}
+
+func runTestWaitFnAbortAborted(t *testing.T) {
+	c := NewCount(1)
+	defer c.Close()
+
+	abortCh := make(chan struct{})
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	errCh := make(chan error, 1)
+
+	go func() {
+		defer wg.Done()
+		errCh <- c.WaitFnAbort(abortCh, nil) // Wait for zero
+	}()
+
+	// Allow time for goroutine to start waiting
+	time.Sleep(10 * time.Millisecond)
+
+	// Close the abort channel
+	close(abortCh)
+
+	// Ensure the WaitFnAbort completes with cancellation error
+	wg.Wait()
+
+	select {
+	case err := <-errCh:
+		assert.Error(t, err)
+		assert.Equal(t, context.Canceled, err)
+	default:
+		assert.Fail(t, "No result from WaitFnAbort")
+	}
+}
+
+// TestCountSignalBroadcast tests the Signal and Broadcast methods.
+func TestCountSignalBroadcast(t *testing.T) {
+	t.Run("Signal", runTestSignal)
+	t.Run("Broadcast", runTestBroadcast)
+}
+
+func runTestSignal(t *testing.T) {
+	c := NewCount(1)
+	defer c.Close()
+
+	// No waiters, signal should return false
+	assert.False(t, c.Signal())
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	ready := make(chan struct{})
+	done := make(chan struct{})
+	var doneClosed sync.Once
+
+	// Start a waiter goroutine
+	go func() {
+		defer wg.Done()
+
+		// Signal that the goroutine is about to wait
+		close(ready)
+
+		// This condition won't be matched, but the signal will wake it up
+		c.WaitFn(func(_ int32) bool {
+			doneClosed.Do(func() { close(done) })
+			return false // Will keep waiting after being signaled
+		})
+	}()
+
+	// Wait for goroutine to signal it's ready
+	<-ready
+
+	// Give time for goroutine to enter wait state
+	time.Sleep(10 * time.Millisecond)
+
+	// Signal should wake up the goroutine
+	assert.True(t, c.Signal())
+
+	// Wait for the goroutine to handle the signal
+	select {
+	case <-done:
+		// Success - our waiter's condition function was called
+	case <-time.After(100 * time.Millisecond):
+		assert.Fail(t, "Waiter was not woken up by Signal")
+	}
+}
+
+func runTestBroadcast(t *testing.T) {
+	c := NewCount(1)
+	defer c.Close()
+
+	const numWaiters = 3
+	// Create a bitmask with 'numWaiters' bits
+	const allNotifiedMask = (1 << numWaiters) - 1
+
+	// Use atomic value to track which waiters were notified via bitmask
+	var notifiedMask atomic.Uint32
+
+	// Use a channel to signal when all waiters have been notified
+	allNotified := make(chan struct{})
+
+	// Use a channel to ensure all waiters are ready before broadcast
+	ready := make(chan struct{})
+
+	// Start multiple waiter goroutines
+	var wg sync.WaitGroup
+	wg.Add(numWaiters)
+
+	for i := range numWaiters {
+		go func(waiterID int) {
+			defer wg.Done()
+
+			// Signal this waiter is ready
+			ready <- struct{}{}
+
+			c.WaitFn(func(_ int32) bool {
+				// Set this waiter's bit in the bitmask
+				if newMask, changed := atomicMaskOr(&notifiedMask, 1<<waiterID); changed {
+					if newMask == allNotifiedMask {
+						close(allNotified)
+					}
+				}
+
+				return false // Continue waiting
+			})
+		}(i)
+	}
+
+	// Wait for all goroutines to enter wait state
+	for range numWaiters {
+		<-ready
+	}
+
+	// Small delay to ensure all goroutines are waiting
+	time.Sleep(10 * time.Millisecond)
+
+	// Broadcast should wake up all waiters
+	c.Broadcast()
+
+	// Wait for all waiters to be notified with timeout
+	select {
+	case <-allNotified:
+		// Success - all waiters were notified
+	case <-time.After(100 * time.Millisecond):
+		assert.Fail(t, "Not all waiters were notified by Broadcast")
+	}
+
+	// Verify the bitmask has all bits set
+	assert.Equal(t, uint32(allNotifiedMask), notifiedMask.Load(),
+		"Bitmask should have all waiters' bits set")
+}
+
+// TestCountErrorHandling tests error handling and edge cases.
+func TestCountErrorHandling(t *testing.T) {
+	t.Run("DoubleInit", runTestDoubleInit)
+	t.Run("NilContext", runTestNilContext)
+	t.Run("Uninitialised", runTestUninitialised)
+	t.Run("PanicRecovery", runTestPanicRecovery)
+}
+
+func runTestDoubleInit(t *testing.T) {
+	c := new(Count)
+
+	err := c.Init(0)
+	require.NoError(t, err)
+	defer c.Close()
+
+	// Second Init should fail
+	err = c.Init(0)
+	assert.Error(t, err)
+}
+
+func runTestNilContext(t *testing.T) {
+	var nilCtx context.Context
+
+	c := NewCount(0)
+	defer c.Close()
+
+	err := c.WaitFnContext(nilCtx, nil)
+	assert.Error(t, err)
+}
+
+func runTestUninitialised(t *testing.T) {
+	c := new(Count)
+
+	// Ensure operations on uninitialised Count return errors
+	assert.Error(t, c.check())
+	assert.True(t, c.IsNil())
+
+	// These should be safe to call but return errors
+	assert.Error(t, c.Close())
+
+	// Context-based waits should return errors
+	ctx := context.Background()
+	assert.Error(t, c.WaitFnContext(ctx, nil))
+
+	abortCh := make(chan struct{})
+	assert.Error(t, c.WaitFnAbort(abortCh, nil))
+}
+
+func runTestPanicRecovery(t *testing.T) {
+	var c *Count
+
+	// These methods should panic for nil receiver
+	assert.Panics(t, func() { c.Wait() })
+	assert.Panics(t, func() { c.WaitFn(nil) })
+	assert.Panics(t, func() { c.IsZero() })
+	assert.Panics(t, func() { c.Match(nil) })
+	assert.Panics(t, func() { c.Signal() })
+	assert.Panics(t, func() { c.Broadcast() })
+
+	// These don't panic but return errors
+	assert.Error(t, c.Init(0))
+	assert.Error(t, c.Close())
+
+	// For an initialised Count, these methods also panic if uninitialised
+	c = new(Count)
+	assert.Panics(t, func() { c.Wait() })
+	assert.Panics(t, func() { c.WaitFn(nil) })
+}
+
+// TestConcurrentAccess tests concurrent access to Count.
+func TestConcurrentAccess(t *testing.T) {
+	t.Run("ConcurrentIncrementDecrement", runTestConcurrentIncrementDecrement)
+}
+
+func runTestConcurrentIncrementDecrement(t *testing.T) {
+	c := NewCount(0)
+	defer c.Close()
+
+	const numGoroutines = 10
+	const numOperations = 100
+
+	var wg sync.WaitGroup
+	wg.Add(numGoroutines * 2) // Half incrementing, half decrementing
+
+	// Start goroutines that increment the counter
+	for range numGoroutines {
+		go func() {
+			defer wg.Done()
+			for range numOperations {
+				c.Inc()
+			}
+		}()
+	}
+
+	// Start goroutines that decrement the counter
+	for i := 0; i < numGoroutines; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < numOperations; j++ {
+				c.Dec()
+			}
+		}()
+	}
+
+	// Wait for all operations to complete
+	wg.Wait()
+
+	// Counter should be back to 0
+	assert.Equal(t, 0, c.Value(),
+		"Counter should return to 0 after equal increments and decrements")
+}
+
+// TestCountWithTimeout tests using Count with various timeout patterns.
+func TestCountWithTimeout(t *testing.T) {
+	t.Run("TimeoutContext", runTestTimeoutContext)
+	t.Run("EnsureNoRace", runTestEnsureNoRace)
+}
+
+func runTestTimeoutContext(t *testing.T) {
+	c := NewCount(1)
+	defer c.Close()
+
+	// Create a context with a short timeout
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	// Wait for a condition that won't be satisfied within the timeout
+	start := time.Now()
+	err := c.WaitFnContext(ctx, func(v int32) bool { return v == 0 })
+	elapsed := time.Since(start)
+
+	// Should fail with timeout error
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "deadline")
+
+	// Elapsed time should be approximately the timeout duration
+	assert.True(t, elapsed >= 45*time.Millisecond,
+		"Should wait at least most of the timeout period")
+}
+
+func runTestEnsureNoRace(_ *testing.T) {
+	c := NewCount(0)
+	defer c.Close()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+
+		// Repeatedly access the counter
+		for range 100 {
+			c.Inc()
+			c.Value()
+			c.Dec()
+		}
+	}()
+
+	// Simultaneously access from this goroutine
+	for range 100 {
+		c.Value()
+		c.Match(func(v int32) bool { return v >= 0 })
+		c.Signal()
+	}
+
+	<-done
+	// If we reach here without the race detector triggering, success
+}
+
+// TestCountStress performs stress testing on the Count implementation.
+func TestCountStress(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping stress tests in short mode")
+	}
+
+	t.Run("MultipleWaitersAndUpdaters", runTestMultipleWaitersAndUpdaters)
+}
+
+func runTestMultipleWaitersAndUpdaters(t *testing.T) {
+	c := NewCount(0)
+	defer c.Close()
+
+	const (
+		numWaiters  = 20
+		numUpdaters = 10
+		numUpdates  = 1000
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var wg sync.WaitGroup
+	wg.Add(numWaiters + numUpdaters)
+
+	// Start waiter goroutines
+	for i := 0; i < numWaiters; i++ {
+		go func(id int) {
+			defer wg.Done()
+
+			// Each waiter watches for a different condition
+			target := int32((id % 10) * 100)
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				default:
+					// Wait until counter reaches or exceeds target
+					err := c.WaitFnContext(ctx, func(v int32) bool {
+						return v >= target
+					})
+					if err != nil {
+						return // Context cancelled
+					}
+
+					// Reset target to a higher value for next wait
+					target += 100
+				}
+			}
+		}(i)
+	}
+
+	// Start updater goroutines
+	for i := 0; i < numUpdaters; i++ {
+		go func() {
+			defer wg.Done()
+
+			for j := 0; j < numUpdates; j++ {
+				select {
+				case <-ctx.Done():
+					return
+				default:
+					c.Inc()
+					time.Sleep(time.Microsecond) // Small delay to reduce contention
+				}
+			}
+		}()
+	}
+
+	// Wait for all goroutines to complete
+	wg.Wait()
+
+	// Final value should be numUpdaters * numUpdates
+	finalValue := c.Value()
+	expectedValue := numUpdaters * numUpdates
+	assert.Equal(t, expectedValue, finalValue,
+		"Expected final value %d, got %d", expectedValue, finalValue)
+}
+
+// TestCountReset tests the Reset functionality.
+func TestCountReset(t *testing.T) {
+	t.Run("BasicReset", runTestBasicReset)
+	t.Run("ResetUninitialized", runTestResetUninitialized)
+	t.Run("ResetNil", runTestResetNil)
+	t.Run("ResetWithWaiters", runTestResetWithWaiters)
+	t.Run("ResetClosed", runTestResetClosed)
+}
+
+func runTestBasicReset(t *testing.T) {
+	c := NewCount(10)
+	defer c.Close()
+
+	assert.Equal(t, 10, c.Value())
+
+	err := c.Reset(42)
+	require.NoError(t, err)
+
+	assert.Equal(t, 42, c.Value())
+}
+
+func runTestResetUninitialized(t *testing.T) {
+	c := new(Count)
+
+	err := c.Reset(42)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not initialised")
+}
+
+func runTestResetNil(t *testing.T) {
+	var c *Count
+
+	err := c.Reset(42)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "nil receiver")
+}
+
+func runTestResetWithWaiters(t *testing.T) {
+	c := NewCount(5)
+	defer c.Close()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	// Start a goroutine that waits for value to be zero
+	go func() {
+		defer wg.Done()
+		c.WaitFn(func(v int32) bool { return v == 0 })
+	}()
+
+	// Give time for goroutine to start waiting
+	time.Sleep(10 * time.Millisecond)
+
+	// Reset to 0, which should wake up the waiter
+	err := c.Reset(0)
+	require.NoError(t, err)
+
+	// Ensure the waiter completes
+	waitDone := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(waitDone)
+	}()
+
+	select {
+	case <-waitDone:
+		// Success - waiter was notified
+	case <-time.After(100 * time.Millisecond):
+		assert.Fail(t, "Waiter was not notified when Reset was called")
+	}
+}
+
+func runTestResetClosed(t *testing.T) {
+	c := NewCount(10)
+
+	// Close the count
+	require.NoError(t, c.Close())
+
+	// Reset after close should fail
+	err := c.Reset(42)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "closed")
+}
+
+// TestCountCustomInitialisation tests initialising Count with various
+// custom broadcast conditions.
+func TestCountCustomInitialisation(t *testing.T) {
+	// Test with multiple broadcast conditions
+	t.Run("MultipleBroadcastConditions", runTestMultipleBroadcastConditions)
+
+	// Test with no broadcast conditions (special case)
+	t.Run("NoBroadcastConditions", runTestNoBroadcastConditions)
+}
+
+func runTestMultipleBroadcastConditions(t *testing.T) {
+	isZero := func(v int32) bool { return v == 0 }
+	isPositive := func(v int32) bool { return v > 0 }
+	isNegative := func(v int32) bool { return v < 0 }
+
+	c := NewCount(0, isZero, isPositive, isNegative)
+
+	var notified atomic.Uint32
+
+	signalCounter := func() {
+		notified.Add(1)
+	}
+
+	// Test each condition triggers broadcast
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		c.WaitFn(func(_ int32) bool {
+			signalCounter()
+			return false // Keep waiting
+		})
+	}()
+	time.Sleep(10 * time.Millisecond)
+
+	// Value is zero - should broadcast
+	prevCount := notified.Load()
+	c.Add(-1) // Should broadcast due to isZero
+	time.Sleep(10 * time.Millisecond)
+	assert.Greater(t, notified.Load(), prevCount,
+		"Notification count should increase when zero broadcast condition is met")
+
+	// Change to positive - should broadcast
+	prevCount = notified.Load()
+	c.Inc() // Now 1
+	assert.Eventually(t, func() bool {
+		return notified.Load() > prevCount
+	}, 20*time.Millisecond, 1*time.Millisecond,
+		"Notification count should increase when positive broadcast condition is met")
+
+	// Change to negative - should broadcast
+	prevCount = notified.Load()
+	c.Add(-2) // Now -1
+	assert.Eventually(t, func() bool {
+		return notified.Load() > prevCount
+	}, 20*time.Millisecond, 1*time.Millisecond,
+		"Notification count should increase when negative broadcast condition is met")
+
+	// Back to zero - should broadcast
+	prevCount = notified.Load()
+	c.Inc() // Now 0
+	assert.Eventually(t, func() bool {
+		return notified.Load() > prevCount
+	}, 20*time.Millisecond, 1*time.Millisecond,
+		"Notification count should increase when zero broadcast condition is met again")
+
+	// Clean up goroutine
+	_ = c.Close()
+	wg.Wait()
+}
+
+func runTestNoBroadcastConditions(t *testing.T) {
+	// Create a Count with an explicit empty broadcast condition list
+	c := NewCount(0, []func(int32) bool{}...)
+
+	// Every value change should broadcast
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	var notified int
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		c.WaitFn(func(_ int32) bool {
+			mu.Lock()
+			notified++
+			mu.Unlock()
+			return false // Keep waiting
+		})
+	}()
+
+	// Wait for goroutine to start waiting
+	time.Sleep(10 * time.Millisecond)
+
+	// Every operation should broadcast
+	mu.Lock()
+	prevCount := notified
+	mu.Unlock()
+	c.Inc()
+	time.Sleep(10 * time.Millisecond)
+	mu.Lock()
+	currentCount := notified
+	mu.Unlock()
+	assert.Greater(t, currentCount, prevCount,
+		"Notification count should increase after Inc() with no broadcast conditions")
+
+	// Similar pattern for all other checks
+	// (add mutex protection for all accesses to notified)
+
+	// Clean up goroutine
+	_ = c.Close()
+	wg.Wait()
+}
+
+// TestWaitResult tests the waitResult type functionality.
+func TestWaitResult(t *testing.T) {
+	// Test IsCancelled method
+	t.Run("IsCancelled", func(t *testing.T) {
+		assert.False(t, waitContinue.IsCancelled())
+		assert.False(t, waitSuccess.IsCancelled())
+		assert.True(t, waitCancelled.IsCancelled())
+	})
+
+	// Test IsContinue method
+	t.Run("IsContinue", func(t *testing.T) {
+		assert.True(t, waitContinue.IsContinue())
+		assert.False(t, waitSuccess.IsContinue())
+		assert.False(t, waitCancelled.IsContinue())
+	})
+}
+
+// atomicMaskOr performs a bitwise OR operation on an atomic uint32 value
+// using a compare-and-swap loop.
+// It attempts to set the specified mask bits atomically and returns
+// the new mask value.
+// The second return value indicates whether the mask was modified (true)
+// or was already set (false).
+func atomicMaskOr(ptr *atomic.Uint32, mask uint32) (uint32, bool) {
+	for {
+		oldMask := ptr.Load()
+		newMask := oldMask | mask
+		if oldMask == newMask {
+			return newMask, false
+		} else if ptr.CompareAndSwap(oldMask, newMask) {
+			return newMask, true
+		}
+	}
+}

--- a/sync/cond/count_zero.go
+++ b/sync/cond/count_zero.go
@@ -1,0 +1,133 @@
+// Package cond provides synchronisation primitives for coordinating goroutines.
+package cond
+
+import (
+	"context"
+
+	"darvaza.org/x/sync/errors"
+)
+
+// CountZero is a specialised variant of Count that specifically broadcasts
+// when the counter reaches zero. This simplifies coordination in cases
+// where completion is signified by a zero value.
+type CountZero Count
+
+// isZero returns true when the provided value equals zero.
+// Used as the broadcast condition for the CountZero type.
+func isZero(n int32) bool { return n == 0 }
+
+// NewCountZero creates a new Count that automatically wakes
+// waiters when the count reaches zero.
+func NewCountZero(initialValue int) *CountZero {
+	c := NewCount(
+		initialValue,
+		isZero,
+	)
+	return (*CountZero)(c)
+}
+
+// sys returns the underlying Count instance.
+// Returns nil if the receiver is nil.
+func (c0 *CountZero) sys() *Count {
+	if c0 == nil {
+		return nil
+	}
+	return (*Count)(c0)
+}
+
+// check validates the CountZero instance and returns the underlying Count.
+// Returns an error if the receiver is nil or not properly initialised.
+func (c0 *CountZero) check() (*Count, error) {
+	c := c0.sys()
+	switch {
+	case c == nil:
+		return nil, errors.ErrNilReceiver
+	case c.b.IsNil():
+		return nil, errors.ErrNotInitialised
+	default:
+		return c, nil
+	}
+}
+
+// Init initialises the CountZero with a given initial value.
+// Returns an error if the receiver is nil or already initialised.
+func (c0 *CountZero) Init(initialValue int) error {
+	if c := c0.sys(); c != nil {
+		return c.doInit(
+			initialValue,
+			[]func(int32) bool{isZero},
+		)
+	}
+	return errors.ErrNilReceiver
+}
+
+// Reset sets the CountZero to a new value.
+// Returns an error if the instance is not properly initialised or is nil.
+func (c0 *CountZero) Reset(value int) error {
+	c, err := c0.check()
+	if err != nil {
+		return err
+	}
+	return c.doReset(value)
+}
+
+// Close releases the resources associated with the CountZero.
+// Returns an error if the receiver is nil or not properly initialised.
+func (c0 *CountZero) Close() error {
+	c, err := c0.check()
+	if err != nil {
+		return err
+	}
+	return c.b.Close()
+}
+
+// IsNil reports whether the CountZero is nil or uninitialised.
+// Provides a safe way to check the initialisation status.
+func (c0 *CountZero) IsNil() bool {
+	if c := c0.sys(); c != nil {
+		return c.b.IsNil()
+	}
+	return true
+}
+
+// IsClosed reports whether the CountZero is closed and no longer usable.
+// Returns true if nil or if the underlying barrier is closed.
+func (c0 *CountZero) IsClosed() bool {
+	if c := c0.sys(); c != nil {
+		return c.b.IsClosed()
+	}
+	return true
+}
+
+// Add atomically adds the given value and returns the new value.
+// Broadcasts to waiters if the result is zero.
+func (c0 *CountZero) Add(n int) int { return c0.sys().Add(n) }
+
+// Inc atomically increments the counter by 1 and returns the new value.
+// Broadcasts to waiters if the result is zero.
+func (c0 *CountZero) Inc() int { return c0.sys().Inc() }
+
+// Dec atomically decrements the counter by 1 and returns the new value.
+// Broadcasts to waiters if the result is zero.
+func (c0 *CountZero) Dec() int { return c0.sys().Dec() }
+
+// Value atomically returns the current value without affecting waiters.
+func (c0 *CountZero) Value() int { return c0.sys().Value() }
+
+// Wait blocks the calling goroutine until the counter reaches zero.
+// Returns an error if the CountZero is nil or not properly initialised.
+func (c0 *CountZero) Wait() error {
+	return c0.sys().WaitFnAbort(nil, nil)
+}
+
+// WaitAbort blocks until the counter reaches zero or the abort channel closes.
+// Returns context.Canceled if aborted, or nil if the counter reaches zero.
+func (c0 *CountZero) WaitAbort(abort <-chan struct{}) error {
+	return c0.sys().WaitFnAbort(abort, nil)
+}
+
+// WaitContext blocks until the counter reaches zero or the context is cancelled.
+// Returns the context's error if cancelled, or nil if the counter reaches zero.
+func (c0 *CountZero) WaitContext(ctx context.Context) error {
+	return c0.sys().WaitFnContext(ctx, nil)
+}

--- a/sync/cond/utils.go
+++ b/sync/cond/utils.go
@@ -1,0 +1,46 @@
+package cond
+
+import "darvaza.org/core"
+
+// makeAnyMatch creates a function that returns true if any of the provided
+// functions return true when applied to a value.
+// The returned function evaluates each predicate in sequence and returns early
+// on the first match.
+//
+//revive:disable-next-line:cognitive-complexity
+func makeAnyMatch[T any](funcs []func(T) bool) func(T) bool {
+	// remove nil entries
+	funcs = core.SliceCopyFn(funcs, func(_ []func(T) bool, fn func(T) bool) (func(T) bool, bool) {
+		return fn, fn != nil
+	})
+
+	switch len(funcs) {
+	case 0:
+		// unconstrained
+		return func(_ T) bool { return true }
+	case 1:
+		// single case
+		return funcs[0]
+	default:
+		// any of the given conditions
+		return func(v T) bool {
+			for _, fn := range funcs {
+				if fn(v) {
+					return true
+				}
+			}
+			return false
+		}
+	}
+}
+
+// isCancelled checks if the abort channel has been closed, indicating
+// cancellation. Returns true if the channel is closed, false otherwise.
+func isCancelled(abort <-chan struct{}) bool {
+	select {
+	case <-abort:
+		return true
+	default:
+		return false
+	}
+}

--- a/sync/cond/utils_test.go
+++ b/sync/cond/utils_test.go
@@ -1,0 +1,156 @@
+package cond
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestMakeAnyMatch verifies that makeAnyMatch correctly combines predicates
+// according to the specification.
+func TestMakeAnyMatch(t *testing.T) {
+	t.Parallel()
+
+	// Define test cases with expected behaviour
+	testCases := []struct {
+		name     string
+		funcs    []func(int) bool
+		inputs   []int
+		expected []bool
+	}{
+		{
+			name:     "empty funcs slice returns always true",
+			funcs:    []func(int) bool{},
+			inputs:   []int{0, 1, -1, 42},
+			expected: []bool{true, true, true, true},
+		},
+		{
+			name:     "nil functions are the same as no functions",
+			funcs:    []func(int) bool{nil, nil},
+			inputs:   []int{0, 1, -1},
+			expected: []bool{true, true, true},
+		},
+		{
+			name: "single function is returned as is",
+			funcs: []func(int) bool{
+				func(n int) bool { return n > 0 },
+			},
+			inputs:   []int{-1, 0, 1},
+			expected: []bool{false, false, true},
+		},
+		{
+			name: "combined functions return true if any match",
+			funcs: []func(int) bool{
+				func(n int) bool { return n < 0 },
+				func(n int) bool { return n > 10 },
+			},
+			inputs:   []int{-5, 0, 5, 15},
+			expected: []bool{true, false, false, true},
+		},
+		{
+			name: "short-circuit evaluation",
+			funcs: []func(int) bool{
+				func(n int) bool { return n < 0 },
+				func(_ int) bool {
+					t.Error("This should not be called when first func returns true")
+					return true
+				},
+			},
+			inputs:   []int{-1},
+			expected: []bool{true},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			runMakeAnyMatchTest(t, tc.funcs, tc.inputs, tc.expected)
+		})
+	}
+}
+
+// TestMakeAnyMatchWithStrings verifies that makeAnyMatch works with
+// different types like strings.
+func TestMakeAnyMatchWithStrings(t *testing.T) {
+	t.Parallel()
+
+	// Define predicates for strings
+	funcs := []func(string) bool{
+		func(s string) bool { return len(s) > 5 },
+		func(s string) bool { return s == "match" },
+	}
+
+	testCases := []struct {
+		input    string
+		expected bool
+	}{
+		{"short", false},
+		{"veryLongString", true},
+		{"match", true},
+	}
+
+	// Create the combined function
+	resultFunc := makeAnyMatch(funcs)
+
+	for _, tc := range testCases {
+		t.Run(tc.input, func(t *testing.T) {
+			t.Parallel()
+			actual := resultFunc(tc.input)
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+}
+
+// runMakeAnyMatchTest executes a single test case for the makeAnyMatch function.
+func runMakeAnyMatchTest(
+	t *testing.T,
+	funcs []func(int) bool,
+	inputs []int,
+	expected []bool,
+) {
+	t.Helper()
+
+	// Create the combined function
+	resultFunc := makeAnyMatch(funcs)
+	assert.NotNil(t, resultFunc, "makeAnyMatch should never return nil")
+
+	// Test each input
+	for i, input := range inputs {
+		actual := resultFunc(input)
+		assert.Equal(t, expected[i], actual, "Failed for input %v", input)
+	}
+}
+
+// BenchmarkMakeAnyMatch measures the performance of makeAnyMatch with
+// varying numbers of predicates.
+func BenchmarkMakeAnyMatch(b *testing.B) {
+	// Prepare a set of predicates
+	predicates := []func(int) bool{
+		func(n int) bool { return n < 0 },
+		func(n int) bool { return n > 100 },
+		func(n int) bool { return n%2 == 0 },
+		func(n int) bool { return n%3 == 0 },
+		func(n int) bool { return n%5 == 0 },
+	}
+
+	benchCases := []struct {
+		name string
+		n    int // Number of predicates to use
+	}{
+		{"Single", 1},
+		{"Two", 2},
+		{"Five", 5},
+	}
+
+	for _, bc := range benchCases {
+		funcs := predicates[:bc.n]
+		resultFunc := makeAnyMatch(funcs)
+
+		b.Run(bc.name, func(b *testing.B) {
+			for i := range b.N {
+				// Use i as the input to get varying results
+				_ = resultFunc(i)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new `cond` sub-package offering advanced synchronization primitives for goroutine coordination, including `Barrier`, `Count`, and `CountZero`.
  - `Barrier` enables reusable signaling for goroutine coordination.
  - `Count` provides an atomic counter with condition-based waiting and signaling.
  - `CountZero` simplifies waiting for a counter to reach zero, ideal for tracking completion of concurrent operations.

- **Documentation**
  - Expanded README with detailed explanations and usage examples for the new synchronization primitives.

- **Tests**
  - Added comprehensive unit and benchmark tests to ensure correctness and performance of the new primitives and utility functions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->