### PR TITLE
feat(sync/errors): introduce ErrClosed, ErrAlreadyInitialised and ErrNotInitialised errors

### DIFF
--- a/sync/README.md
+++ b/sync/README.md
@@ -291,10 +291,14 @@ These utility functions provide:
 The [`errors`][sync-errors-link] sub-package defines error types for common
 synchronisation issues:
 
+* `ErrAlreadyInitialised`: Returned when a primitive that was already
+  initialised is being initialised again.
+* `ErrNotInitialised`: Returned when a primitive was expected to be
+  initialised but was not.
 * `ErrNilContext`: Returned when a nil context is encountered in
-  context-aware operations
-* `ErrNilMutex`: Returned when a Mutex was expected but none provided
-* `ErrNilReceiver`: Returned when methods are called on a nil receiver
+  context-aware operations.
+* `ErrNilMutex`: Returned when a Mutex was expected but none was provided.
+* `ErrNilReceiver`: Returned when methods are called on a nil receiver.
 
 The package uses `core.CompoundError` to collect and combine multiple errors
 that may occur during operations on multiple mutexes. This allows for

--- a/sync/README.md
+++ b/sync/README.md
@@ -295,6 +295,8 @@ synchronisation issues:
   initialised is being initialised again.
 * `ErrNotInitialised`: Returned when a primitive was expected to be
   initialised but was not.
+* `ErrClosed`: Returned when operations cannot proceed because the target is
+  closed.
 * `ErrNilContext`: Returned when a nil context is encountered in
   context-aware operations.
 * `ErrNilMutex`: Returned when a Mutex was expected but none was provided.

--- a/sync/errors/errors.go
+++ b/sync/errors/errors.go
@@ -7,6 +7,14 @@ import (
 	"darvaza.org/core"
 )
 
+// ErrAlreadyInitialised indicates initialisation cannot proceed because the
+// target is already initialised.
+var ErrAlreadyInitialised = errors.New("already initialised")
+
+// ErrNotInitialised indicates operations cannot proceed because the target
+// has not been initialised.
+var ErrNotInitialised = errors.New("not initialised")
+
 // ErrNilContext indicates operations cannot proceed with a nil context.
 var ErrNilContext = errors.New("nil context not allowed")
 

--- a/sync/errors/errors.go
+++ b/sync/errors/errors.go
@@ -15,6 +15,9 @@ var ErrAlreadyInitialised = errors.New("already initialised")
 // has not been initialised.
 var ErrNotInitialised = errors.New("not initialised")
 
+// ErrClosed indicates operations cannot proceed because the target is closed.
+var ErrClosed = errors.New("closed")
+
 // ErrNilContext indicates operations cannot proceed with a nil context.
 var ErrNilContext = errors.New("nil context not allowed")
 

--- a/sync/errors/std.go
+++ b/sync/errors/std.go
@@ -2,8 +2,16 @@ package errors
 
 import "errors"
 
-// New creates a new error with the given text using the standard library errors package.
-// It exists because we are shadowing the errors package.
+// New creates a new error with the given text using the standard library
+// errors package.
+// This function exists because we shadow the errors package.
 func New(text string) error {
 	return errors.New(text)
+}
+
+// Is reports whether err is or wraps target, using the standard library
+// errors package.
+// This function exists because we shadow the errors package.
+func Is(err, target error) bool {
+	return errors.Is(err, target)
 }


### PR DESCRIPTION
and an `errors.Is` proxy to use when shadowing the standard errors package

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new error types for synchronization: errors for already initialized, not initialized, and closed targets.
	- Added a function to check if an error matches a specific error type.
- **Documentation**
	- Expanded and clarified documentation on available error types, including descriptions for new errors and improved wording for existing ones.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->