### PR TITLE
feat(net/reconnect): enhance address validation with abstract UNIX socket support

### DIFF
--- a/net/reconnect/config_test.go
+++ b/net/reconnect/config_test.go
@@ -2,6 +2,7 @@ package reconnect
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"darvaza.org/core"
@@ -54,6 +55,7 @@ func makeValidateRemoteTestCases() []core.TestCase {
 		newValidateRemoteTestCase("valid unix absolute path", "/var/run/app.sock", false),
 		newValidateRemoteTestCase("valid unix with .sock", "app.sock", false),
 		newValidateRemoteTestCase("valid unix relative", "./run/app.sock", false),
+		newValidateRemoteTestCase("valid abstract socket", "@abstract-name", false),
 
 		// Valid TCP addresses (edge cases)
 		newValidateRemoteTestCase("valid tcp hostname ending with .sock", "foo.sock:443", false),
@@ -62,7 +64,13 @@ func makeValidateRemoteTestCases() []core.TestCase {
 		newValidateRemoteTestCase("empty string", "", true),
 		newValidateRemoteTestCase("tcp missing port", "example.com", true),
 		newValidateRemoteTestCase("tcp colon no port", "example.com:", true),
+		newValidateRemoteTestCase("tcp port zero", "localhost:0", true),
+		newValidateRemoteTestCase("tcp port zero ipv6", "[::1]:0", true),
+		newValidateRemoteTestCase("tcp empty host", ":8080", true),
 		newValidateRemoteTestCase("unix empty after prefix", "unix:", true),
+		newValidateRemoteTestCase("abstract socket empty name", "@", true),
+		newValidateRemoteTestCase("unix path too long", "/"+strings.Repeat("a", 107), true),
+		newValidateRemoteTestCase("unix path with null byte", "/tmp/sock\x00et", true),
 	}
 }
 

--- a/net/reconnect/errors.go
+++ b/net/reconnect/errors.go
@@ -24,6 +24,12 @@ var (
 
 	// ErrRunning indicates the [Client] has already being started.
 	ErrRunning = core.QuietWrap(syscall.EBUSY, "client already running")
+
+	// ErrNameEmpty indicates a name is empty
+	ErrNameEmpty = errors.New("name missing")
+
+	// ErrNameTooLong indicates a name exceeds maximum length
+	ErrNameTooLong = errors.New("name too long")
 )
 
 // IsFatal tells if the error means the connection

--- a/net/reconnect/utils.go
+++ b/net/reconnect/utils.go
@@ -4,9 +4,12 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net"
+	stdnet "net"
 	"strings"
 	"time"
+
+	"darvaza.org/core"
+	"darvaza.org/x/net"
 )
 
 const (
@@ -14,10 +17,13 @@ const (
 	NetworkTCP = "tcp"
 	// NetworkUnix represents Unix domain socket network type
 	NetworkUnix = "unix"
+	// MaxUNIXSocketPathLength is the maximum length for UNIX domain socket paths
+	// Limited by sockaddr_un.sun_path (108 bytes including null terminator on Linux)
+	MaxUNIXSocketPathLength = 107
 )
 
-func newDialer(keepalive, timeout time.Duration) *net.Dialer {
-	return &net.Dialer{
+func newDialer(keepalive, timeout time.Duration) *stdnet.Dialer {
+	return &stdnet.Dialer{
 		KeepAlive: keepalive,
 		Timeout:   timeout,
 	}
@@ -48,6 +54,7 @@ func TimeoutToAbsoluteTime(base time.Time, d time.Duration) time.Time {
 // It supports:
 // - "unix:/path/to/socket" - explicit Unix socket.
 // - "/path/to/socket" - Unix socket (absolute path).
+// - "@abstract-name" - abstract Unix socket.
 // - "path/to/file.sock" - Unix socket (ends with .sock).
 // - "host:port" - TCP socket.
 func ParseRemote(remote string) (network, address string, err error) {
@@ -55,41 +62,92 @@ func ParseRemote(remote string) (network, address string, err error) {
 		return "", "", errors.New("remote address missing")
 	}
 
-	// Check for explicit unix: prefix
-	if addr, ok := strings.CutPrefix(remote, NetworkUnix+":"); ok {
-		return parseRemoteUNIX(addr)
-	}
-
-	// Check if it's an absolute path (Unix socket)
-	if strings.HasPrefix(remote, "/") {
-		return parseRemoteUNIX(remote)
-	}
-
-	// Check if it ends with .sock (Unix socket)
-	if strings.HasSuffix(remote, ".sock") {
-		return parseRemoteUNIX(remote)
+	if addr, skip, err := parseRemoteUNIX(remote); !skip || err != nil {
+		return NetworkUnix, addr, err
 	}
 
 	// Fallback to TCP
 	return parseRemoteTCP(remote)
 }
 
-func parseRemoteUNIX(remote string) (network, address string, err error) {
-	// not-empty
-	if remote == "" {
-		return "", "", errors.New("unix socket path missing")
+func parseRemoteUNIX(remote string) (address string, skip bool, err error) {
+	// Check for explicit unix: prefix
+	if addr, ok := strings.CutPrefix(remote, NetworkUnix+":"); ok {
+		err = validateMustRemoteUNIX(addr)
+		if err != nil {
+			// invalid prefixed unix socket
+			err = core.Wrapf(err, "%q: invalid prefixed UNIX socket", remote)
+		}
+		return addr, false, err
 	}
-	// TODO: validate path when it might be valid but not exist?
-	return NetworkUnix, remote, nil
+
+	skip, err = validateRemoteUNIX(remote)
+	switch {
+	case skip:
+		// try TCP instead
+		return "", true, nil
+	case err != nil:
+		// invalid unix socket
+		return "", false, core.Wrapf(err, "%q: invalid UNIX socket", remote)
+	default:
+		// good-enough unix socket
+		return remote, false, nil
+	}
+}
+
+func validateMustRemoteUNIX(remote string) error {
+	skip, err := validateRemoteUNIX(remote)
+	if skip {
+		err = validateUNIXName(remote)
+	}
+	return err
+}
+
+func validateRemoteUNIX(remote string) (skip bool, err error) {
+	var validatePath bool
+
+	switch {
+	case strings.HasPrefix(remote, "@"):
+		// abstract socket, must validate
+		return false, validateUNIXName(remote[1:])
+	case strings.HasPrefix(remote, "/"):
+		// absolute path
+		validatePath = true
+	case strings.HasSuffix(remote, ".sock"):
+		// path ends with .sock
+		validatePath = true
+	}
+
+	if validatePath {
+		return false, validateUNIXName(remote)
+	}
+
+	// skip others
+	return true, nil
+}
+
+func validateUNIXName(name string) error {
+	switch {
+	case name == "":
+		return ErrNameEmpty
+	case len(name) > MaxUNIXSocketPathLength:
+		return ErrNameTooLong
+	case strings.ContainsRune(name, 0):
+		return core.ErrInvalid
+	default:
+		return nil
+	}
 }
 
 func parseRemoteTCP(remote string) (network, address string, err error) {
-	// TCP - validate host:port
-	_, port, err := net.SplitHostPort(remote)
+	// TCP - validate host:port using darvaza.org/x/net
+	host, port, err := net.SplitHostPort(remote)
 	switch {
 	case err != nil:
 		return "", "", err
-	case port == "":
+	case host == "", host == "::", host == "0.0.0.0", host == "0":
+		return "", "", fmt.Errorf("%q: host missing", remote)
+	case port == 0:
 		return "", "", fmt.Errorf("%q: port missing", remote)
 	default:
 		return NetworkTCP, remote, nil

--- a/net/reconnect/utils_test.go
+++ b/net/reconnect/utils_test.go
@@ -74,11 +74,19 @@ func makeParseRemoteTestCases() []core.TestCase {
 		newParseRemoteTestCase("unix relative nested with .sock", "var/run/app.sock", "unix",
 			"var/run/app.sock", false),
 
+		// Unix socket cases with abstract sockets
+		newParseRemoteTestCase("abstract socket", "@abstract-name", "unix", "@abstract-name", false),
+		newParseRemoteTestCase("abstract socket with dash", "@my-service", "unix", "@my-service", false),
+
 		// Error cases
 		newParseRemoteTestCase("empty string", "", "", "", true),
 		newParseRemoteTestCase("tcp missing port", "example.com", "", "", true),
 		newParseRemoteTestCase("tcp colon no port", "example.com:", "", "", true),
+		newParseRemoteTestCase("tcp port zero", "localhost:0", "", "", true),
+		newParseRemoteTestCase("tcp empty host", ":8080", "", "", true),
 		newParseRemoteTestCase("unix empty after prefix", "unix:", "", "", true),
+		newParseRemoteTestCase("abstract socket empty name", "@", "", "", true),
+		newParseRemoteTestCase("unix path with null byte", "/tmp/sock\x00et", "", "", true),
 	}
 }
 


### PR DESCRIPTION
# Enhanced Address Validation with Abstract UNIX Socket Support

## Summary

This PR significantly enhances the `net/reconnect` package's address validation capabilities by adding comprehensive UNIX domain socket support, including abstract sockets, whilst improving TCP validation robustness.

## Key Changes

### UNIX Domain Socket Enhancements

- **Abstract socket support**: New `@name` syntax recognition and validation for Linux abstract UNIX sockets.
- **Proper path length validation**: Enforce 107-byte maximum per Linux `sockaddr_un.sun_path` specification.
- **Security improvements**: Add null byte detection to prevent potential security issues in socket names.
- **Architectural refactoring**: Split validation logic into dedicated functions (`validateRemoteUNIX`, `validateMustRemoteUNIX`, `validateUNIXName`) for better separation of concerns.

### TCP Validation Improvements

- **Enhanced host validation**: Detect empty hosts including edge cases (`""`, `"::"`, `"0.0.0.0"`, `"0"`).
- **Consistent parsing**: Replace `net.SplitHostPort` with `darvaza.org/x/net.SplitHostPort` for uniform behaviour across the codebase.
- **Port zero detection**: Handle both missing ports and explicit `:0` scenarios properly.

### Error Handling

- **Dedicated error types**: Add `ErrNameEmpty` and `ErrNameTooLong` for cleaner error reporting.
- **Contextual error wrapping**: Proper error context in `parseRemoteUNIX` with meaningful messages.
- **Comprehensive validation**: All validation paths now provide consistent error behaviour.

## Test Coverage

Added comprehensive test cases covering:

- Abstract UNIX socket validation (`@abstract-name`, `@my-service`)
- Empty abstract socket names (`@`)
- Path length limits (107+ character paths)
- TCP edge cases (port zero, empty hosts, IPv6 scenarios)
- All existing functionality remains fully tested

## Breaking Changes

None. All existing functionality is preserved whilst adding new capabilities.

## Dependencies

- Utilises `darvaza.org/core` for error wrapping
- Imports `darvaza.org/x/net` for consistent address parsing
- Standard library `net` aliased as `stdnet` to avoid conflicts


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Stricter remote address validation with clearer errors for malformed TCP/Unix addresses (e.g., empty host/port and invalid zero ports are now rejected).

* **New Features**
  * Added support and validation for Unix-style addresses, including abstract socket names and a documented socket path length limit.

* **Tests**
  * Expanded test coverage for Unix abstract sockets and additional TCP/Unix edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->