### PR TITLE
fix: unbreak main — open-redirect guard + lint fixes

### DIFF
--- a/internal/build/cspell.json
+++ b/internal/build/cspell.json
@@ -119,6 +119,7 @@
     "Updaters",
     "Upgrader",
     "Vers",
+    "WHATWG",
     "Wrapf",
     "xbel",
     "zeebo"

--- a/internal/build/markdownlint.json
+++ b/internal/build/markdownlint.json
@@ -24,5 +24,6 @@
   "MD041": true,
   "MD046": true,
   "MD047": true,
+  "MD060": true,
   "MD007": { "indent": 2 }
 }

--- a/net/reconnect/README.md
+++ b/net/reconnect/README.md
@@ -202,7 +202,7 @@ cfg.WaitReconnect = reconnect.NewDoNotReconnectWaiter(errStop)
 The `Config` structure supports the following fields:
 
 | Field | Type | Default | Description |
-|-------|------|---------|-------------|
+| --- | --- | --- | --- |
 | `Context` | `context.Context` | `context.Background()` | Base context for the client. |
 | `Logger` | `slog.Logger` | Default logger | Logger for structured logging. |
 | `Remote` | `string` | Required | Target address. TCP: `host:port`, Unix: `/path/to/socket` or `unix:/path` |
@@ -508,7 +508,7 @@ The client automatically determines the network type based on the `Remote`
 string:
 
 | Pattern | Network Type | Example |
-|---------|-------------|---------|
+| --- | --- | --- |
 | `unix:` prefix | Unix socket | `unix:/var/run/app.sock` |
 | Absolute path (`/`) | Unix socket | `/tmp/socket` |
 | Ends with `.sock` | Unix socket | `./app.sock`, `run/app.sock` |

--- a/web/README.md
+++ b/web/README.md
@@ -47,7 +47,20 @@ handling, and for this task `darvaza.org/x/web` provides four helpers.
 * and a `Resolve()` helper that will use the above and call the specified
   _Resolver_, or take the request's `URL.Path`, and then clean it to make sure
   its safe to use.
-* `CleanPath()` cleans and validates the path for `URL.Path` handling.
+
+### Path Cleaning
+
+Two helpers normalise URL paths, distinguished by direction of use:
+
+* `CleanPath(path)` validates an inbound `URL.Path`. Returns
+  `("", false)` when the path is non-rooted or contains a `/..`
+  escape segment; otherwise the cleaned form.
+* `Clean(path)` normalises a URL path, typically destined for
+  an outbound `Location` header. Replaces `\` with `/` (matching
+  WHATWG URL behaviour), reduces via `fs.Clean`, strips leading
+  rooted `/..` escape blocks, and preserves a trailing slash.
+  The input must be a path, not a full URL; the second return
+  is `false` when literal `/..` blocks had to be discarded.
 
 ### RESTful Handlers
 

--- a/web/README.md
+++ b/web/README.md
@@ -108,6 +108,11 @@ using the `Accept` header, and falling back to `"identity"` as magic type.
 
 Helper functions for manipulating HTTP headers:
 
+* `HasHeader(hdr, key)` — Reports whether `hdr` has any entry under
+  `key`, including a blank-valued entry. Distinguishes "no header
+  set" from "header set to a blank value" (which `http.Header.Get`
+  collapses to `""`); an entry with no values (`[]string{}`) counts
+  as absent.
 * `SetHeader(hdr, key, value, args...)` — Sets a header value, with
   optional `fmt.Sprintf` formatting.
 * `SetHeaderUnlessExists(hdr, key, value, args...)` — Sets a header

--- a/web/README.md
+++ b/web/README.md
@@ -190,13 +190,23 @@ There are also `web.HTTPError` factories to create new errors, from a generic:
 * `NewHTTPError()` and `NewHTTPErrorf()` and a companion `ErrorText(code)`
   helper.
 
-redirect factories (with Location header):
+redirect factories (destination normalised through `CleanURL`;
+a composition failure is wrapped as a 500):
 
-* `NewStatusMovedPermanently(loc, ...)` (301)
-* `NewStatusFound(loc, ...)` (302)
-* `NewStatusSeeOther(loc, ...)` (303)
-* `NewStatusTemporaryRedirect(loc, ...)` (307)
-* `NewStatusPermanentRedirect(loc, ...)` (308)
+* `NewStatusMovedPermanently(dest, ...)` (301)
+* `NewStatusFound(dest, ...)` (302)
+* `NewStatusSeeOther(dest, ...)` (303)
+* `NewStatusTemporaryRedirect(dest, ...)` (307)
+* `NewStatusPermanentRedirect(dest, ...)` (308)
+
+These factories compose `dest` faithfully — a literal URL from
+caller code and a `?next=` value from a client request look
+identical at the call site, and `CleanURL` preserves both
+verbatim. `CleanURL` canonicalises shape, not origin: when `dest`
+is derived from untrusted input, allowlist scheme and origin (or
+restrict to a relative path) before calling. Without that gate
+the factory composes an open redirect (CWE-601) for whatever
+string the attacker supplied.
 
 error wrappers (preserve underlying error):
 

--- a/web/README.md
+++ b/web/README.md
@@ -50,17 +50,31 @@ handling, and for this task `darvaza.org/x/web` provides four helpers.
 
 ### Path Cleaning
 
-Two helpers normalise URL paths, distinguished by direction of use:
+Three helpers normalise URL paths and references:
 
 * `CleanPath(path)` validates an inbound `URL.Path`. Returns
   `("", false)` when the path is non-rooted or contains a `/..`
   escape segment; otherwise the cleaned form.
-* `Clean(path)` normalises a URL path, typically destined for
-  an outbound `Location` header. Replaces `\` with `/` (matching
-  WHATWG URL behaviour), reduces via `fs.Clean`, strips leading
-  rooted `/..` escape blocks, and preserves a trailing slash.
-  The input must be a path, not a full URL; the second return
-  is `false` when literal `/..` blocks had to be discarded.
+* `Clean(path)` normalises a URL path. Replaces `\` with `/`
+  (matching WHATWG URL behaviour), reduces via `fs.Clean`,
+  strips leading rooted `/..` escape blocks, and preserves a
+  trailing slash. The second return is `false` when literal
+  `/..` blocks had to be discarded.
+* `CleanURL(s)` normalises a URL reference for an outbound
+  `Location` header. Parses with `url.Parse`, normalises the
+  host through `core.SplitHostPort` (lowercased, IDN labels
+  converted to ASCII punycode, IPv6 canonicalised) and strips
+  the default port when it matches the scheme (`http`/`ws` →
+  80, `https`/`wss` → 443); the scheme passes through verbatim
+  and the path is reduced through `Clean`. Leading rooted
+  `/..` is silently stripped — `CleanURL` mirrors browser URL
+  clamping rather than signalling escape attempts. Returns a
+  non-nil error when `url.Parse`, `core.SplitHostPort`, or a
+  DNS label-length check rejects the input, signalling a
+  malformed composition the caller should surface as 500.
+  `CleanURL` is a composer, not an origin validator — callers
+  passing untrusted input must allowlist scheme or origin
+  themselves.
 
 ### RESTful Handlers
 

--- a/web/clean.go
+++ b/web/clean.go
@@ -1,7 +1,14 @@
 package web
 
+// cspell:words Fevil
+
 import (
+	"net"
+	"net/url"
 	"strings"
+
+	"darvaza.org/core"
+	"golang.org/x/net/idna"
 
 	"darvaza.org/x/fs"
 )
@@ -51,4 +58,133 @@ func Clean(path string) (string, bool) {
 		cleaned += "/"
 	}
 	return cleaned, ok
+}
+
+// CleanURL normalises a URL reference intended for an outbound
+// HTTP Location header. The host is validated and lowercased
+// through core.SplitHostPort, converted to ASCII punycode via
+// idna.Display.ToASCII so non-ASCII labels are wire-safe, and
+// its port stripped when it matches the scheme's known default
+// (http/ws → 80, https/wss → 443). Scheme is preserved verbatim;
+// the path is reduced through Clean.
+//
+// Leading rooted /.. is silently stripped from the path —
+// browser URL resolution clamps /.. at root, and CleanURL
+// mirrors that semantics rather than signalling escape
+// attempts to the caller.
+//
+// CleanURL is a composer, not an origin validator. When dest
+// is derived from untrusted input, the caller must validate
+// origin or scheme before calling; CleanURL will happily
+// reassemble "https://evil.com/foo" as-is.
+//
+// Returns a non-nil error when url.Parse rejects the input or
+// core.SplitHostPort / idna rejects the host shape — either
+// indicates a malformed composition, a server-side bug rather
+// than an attack. Callers should surface this as 500.
+func CleanURL(s string) (string, error) {
+	u, err := url.Parse(s)
+	if err != nil {
+		return "", err
+	}
+	if u.Host != "" {
+		host, err := doCleanHost(u.Scheme, u.Host)
+		if err != nil {
+			return "", err
+		}
+		u.Host = host
+	}
+	if u.Path == "" {
+		return u.String(), nil
+	}
+	// Clean's ok discarded: browser /..-clamping semantics,
+	// see doc comment above.
+	cleaned, _ := Clean(u.Path)
+	if cleaned != u.Path {
+		u.Path = cleaned
+		// Force re-encoding from Path. Otherwise u.String()
+		// reuses RawPath and our cleaning is invisible on
+		// inputs like "/%2Fevil.com".
+		u.RawPath = ""
+	}
+	return u.String(), nil
+}
+
+// doCleanHost normalises a URL-authority host[:port] for
+// CleanURL. Splits through core.SplitHostPort for IDN/IPv6-aware
+// validation and lowercasing, converts the resulting host to
+// ASCII punycode via idna.Display.ToASCII so u.String() doesn't
+// percent-escape non-ASCII labels on serialisation, strips the
+// port when it matches the scheme's known default, and
+// reassembles with IPv6 brackets as URL authorities require.
+//
+// Returns a non-nil error when core.SplitHostPort or idna
+// rejects the host shape — surfaced to CleanURL's caller as a
+// malformed composition, not swallowed.
+func doCleanHost(scheme, hostPort string) (string, error) {
+	host, port, err := core.SplitHostPort(hostPort)
+	if err != nil {
+		return "", err
+	}
+	host, err = doCleanHostLabel(host)
+	if err != nil {
+		return "", err
+	}
+	if port == defaultPortFor(scheme) {
+		port = ""
+	}
+	if port == "" {
+		return host, nil
+	}
+	return host + ":" + port, nil
+}
+
+// doCleanHostLabel takes the host returned by core.SplitHostPort
+// and shapes it for a URL authority: IPv4 in dotted-decimal,
+// IPv6 bracketed and canonicalised (netip.Addr.String() shortens
+// `::0001` → `::1` and lowercases hex digits), names converted
+// to ASCII punycode via idna.Display.ToASCII. The punycode step
+// sidesteps url.URL.String()'s percent-encoding of non-ASCII
+// bytes in u.Host — Unicode from core.SplitHostPort would
+// otherwise land as %XX on the wire.
+//
+// For names, RFC 1035's 63-byte-per-label limit is enforced
+// after the ASCII conversion: idna.Display doesn't verify DNS
+// length, and a punycode A-label expanded past 63 bytes would
+// otherwise reach clients that reject the redirect. IP literals
+// always fit well under the limit, so the check lives on the
+// name branch only.
+func doCleanHostLabel(host string) (string, error) {
+	if addr, ipErr := core.ParseAddr(host); ipErr == nil {
+		s := addr.String()
+		if addr.Is6() {
+			s = "[" + s + "]"
+		}
+		return s, nil
+	}
+
+	// core.SplitHostPort's validName already gated host through
+	// idna.Display.ToUnicode; the matching ToASCII call in the
+	// same Display profile cannot reject what ToUnicode accepted.
+	// core.Must lets a future idna or core drift surface loudly.
+	s := core.Must(idna.Display.ToASCII(host))
+	for _, label := range strings.Split(s, ".") {
+		if len(label) > 63 {
+			return "", &net.AddrError{
+				Err:  "label exceeds 63-byte DNS limit",
+				Addr: host,
+			}
+		}
+	}
+	return s, nil
+}
+
+func defaultPortFor(scheme string) string {
+	switch scheme {
+	case "http", "ws":
+		return "80"
+	case "https", "wss":
+		return "443"
+	}
+	return ""
 }

--- a/web/clean.go
+++ b/web/clean.go
@@ -1,0 +1,54 @@
+package web
+
+import (
+	"strings"
+
+	"darvaza.org/x/fs"
+)
+
+// Clean normalises a URL path. It is aimed primarily at paths
+// destined for an outbound HTTP Location header, but is usable
+// wherever a URL path needs to be reduced to a canonical form.
+//
+// Backslashes are replaced with forward slashes before reduction
+// (matching WHATWG URL-path normalisation); the path is then
+// reduced with fs.Clean, and any leading rooted /.. escape
+// components are stripped so the cleaned result can't escape
+// above the root. A trailing slash on the input is preserved.
+//
+// The input must be a path, not a full URL: Clean does not
+// parse scheme or authority, so "http://evil.com/x" reduces as
+// a path and becomes "http:/evil.com/x". Literal /.. is
+// stripped; URL-encoded variants (for example %2e%2e) are not
+// decoded and pass through verbatim.
+//
+// The second return is false when leading rooted /.. blocks
+// had to be discarded — a signal that the input attempted to
+// escape above the root. Backslash normalisation and fs.Clean's
+// own reduction don't flip it.
+func Clean(path string) (string, bool) {
+	path = strings.ReplaceAll(path, `\`, "/")
+	// Trailing-slash check runs on the post-ReplaceAll path, so
+	// input ending in `\` is treated as trailing-slash input.
+	trailing := len(path) > 1 && strings.HasSuffix(path, "/")
+
+	cleaned, _ := fs.Clean(path)
+
+	ok := true
+	for strings.HasPrefix(cleaned, "/../") {
+		cleaned = cleaned[3:]
+		ok = false
+	}
+	// The loop can't remove a terminal /.. on its own: the
+	// "/../" prefix match requires a following slash. Handle
+	// the bare "/.." case here.
+	if cleaned == "/.." {
+		cleaned = "/"
+		ok = false
+	}
+
+	if trailing && !strings.HasSuffix(cleaned, "/") {
+		cleaned += "/"
+	}
+	return cleaned, ok
+}

--- a/web/clean_test.go
+++ b/web/clean_test.go
@@ -1,6 +1,9 @@
 package web
 
+// cspell:words Fevil
+
 import (
+	"strings"
 	"testing"
 
 	"darvaza.org/core"
@@ -107,4 +110,166 @@ func cleanTestCases() []cleanTestCase {
 
 func TestClean(t *testing.T) {
 	core.RunTestCases(t, cleanTestCases())
+}
+
+var _ core.TestCase = cleanURLTestCase{}
+
+type cleanURLTestCase struct {
+	name    string
+	in      string
+	out     string
+	wantErr bool
+}
+
+func (tc cleanURLTestCase) Name() string {
+	return tc.name
+}
+
+func (tc cleanURLTestCase) Test(t *testing.T) {
+	t.Helper()
+
+	s, err := CleanURL(tc.in)
+	core.AssertEqual(t, tc.out, s, "cleaned")
+	if tc.wantErr {
+		core.AssertError(t, err, "err expected")
+	} else {
+		core.AssertNoError(t, err, "err unexpected")
+	}
+}
+
+func newCleanURLTestCase(name, in, out string) cleanURLTestCase {
+	return cleanURLTestCase{
+		name: name,
+		in:   in,
+		out:  out,
+	}
+}
+
+func newCleanURLErrorTestCase(name, in string) cleanURLTestCase {
+	return cleanURLTestCase{
+		name:    name,
+		in:      in,
+		out:     "",
+		wantErr: true,
+	}
+}
+
+func cleanURLTestCases() []cleanURLTestCase {
+	return []cleanURLTestCase{
+		// Path-only inputs: identical to Clean.
+		newCleanURLTestCase("plain rooted", "/foo", "/foo"),
+		newCleanURLTestCase("rooted trailing slash", "/foo/", "/foo/"),
+		newCleanURLTestCase("rooted reduce", "/a/../b", "/b"),
+		// Backslash normalisation on the path component.
+		newCleanURLTestCase("protocol-relative backslash",
+			`/\evil.com`, "/evil.com"),
+		newCleanURLTestCase("dotdot-backslash bypass",
+			`/a/../\evil.com`, "/evil.com"),
+		// Browser /..-clamp: leading /.. silently stripped.
+		newCleanURLTestCase("escape root", "/..", "/"),
+		newCleanURLTestCase("escape then path", "/../evil.com", "/evil.com"),
+		newCleanURLTestCase("escape twice", "/../../evil.com", "/evil.com"),
+		// Full URL: scheme + authority preserved, path cleaned.
+		newCleanURLTestCase("absolute URL clean path",
+			"https://sso.example.com/login", "https://sso.example.com/login"),
+		newCleanURLTestCase("absolute URL path escape stripped",
+			"https://x.com/../y", "https://x.com/y"),
+		newCleanURLTestCase("absolute URL backslash in path",
+			`https://x.com/a\b`, "https://x.com/a/b"),
+		// Protocol-relative with authority: caller intent, pass through.
+		newCleanURLTestCase("protocol-relative authority",
+			"//evil.com", "//evil.com"),
+		newCleanURLTestCase("protocol-relative authority with path",
+			"//evil.com/a/../b", "//evil.com/b"),
+		newCleanURLTestCase("protocol-relative authority with leading escape",
+			"//evil.com/../x", "//evil.com/x"),
+		// Percent-encoded interpretation vector: %2F decodes to /,
+		// path becomes "//evil.com", fs.Clean collapses empty-leading.
+		newCleanURLTestCase("percent-encoded slash vector",
+			"/%2Fevil.com", "/evil.com"),
+		// Percent-encoded benign: Path unchanged, RawPath preserved.
+		newCleanURLTestCase("percent-encoded benign preserved",
+			"/a%2Fb", "/a%2Fb"),
+		// Query and fragment survive around path cleaning.
+		newCleanURLTestCase("query preserved",
+			"/foo?q=a/../b", "/foo?q=a/../b"),
+		newCleanURLTestCase("fragment preserved",
+			"/foo#bar", "/foo#bar"),
+		newCleanURLTestCase("query and fragment around clean",
+			"/a/../b?x=1#y", "/b?x=1#y"),
+		// Host normalisation: lowercase, default-port strip.
+		newCleanURLTestCase("uppercase host lowercased",
+			"https://Example.COM/path", "https://example.com/path"),
+		newCleanURLTestCase("https default port stripped",
+			"https://example.com:443/x", "https://example.com/x"),
+		newCleanURLTestCase("http default port stripped",
+			"http://example.com:80/", "http://example.com/"),
+		newCleanURLTestCase("non-default port preserved",
+			"https://example.com:8443/x", "https://example.com:8443/x"),
+		newCleanURLTestCase("ws default port stripped",
+			"ws://example.com:80/x", "ws://example.com/x"),
+		newCleanURLTestCase("wss default port stripped",
+			"wss://example.com:443/x", "wss://example.com/x"),
+		newCleanURLTestCase("IPv4 default port stripped",
+			"http://192.168.1.1:80/x", "http://192.168.1.1/x"),
+		newCleanURLTestCase("IPv4 non-default port preserved",
+			"https://192.168.1.1:8080/x", "https://192.168.1.1:8080/x"),
+		newCleanURLTestCase("IPv6 default port stripped",
+			"https://[::1]:443/x", "https://[::1]/x"),
+		newCleanURLTestCase("IPv6 non-default port preserved",
+			"https://[::1]:8080/x", "https://[::1]:8080/x"),
+		newCleanURLTestCase("IPv6 canonicalised",
+			"https://[2001:0DB8::0001]/x", "https://[2001:db8::1]/x"),
+		newCleanURLTestCase("protocol-relative host lowercased",
+			"//Example.COM/x", "//example.com/x"),
+		// IDN normalisation: punycode / raw Unicode / mixed-case
+		// punycode all converge on lowercase punycode on output
+		// — the canonical wire form for IDN in URL hosts.
+		newCleanURLTestCase("IDN punycode lowercased",
+			"https://xn--fsqu00a.example/x",
+			"https://xn--fsqu00a.example/x"),
+		newCleanURLTestCase("IDN punycode uppercase folded",
+			"https://XN--FSQU00A.example/x",
+			"https://xn--fsqu00a.example/x"),
+		newCleanURLTestCase("IDN raw Unicode converted to punycode",
+			"https://例子.example/x",
+			"https://xn--fsqu00a.example/x"),
+		// Userinfo round-trip: username:password should pass
+		// through untouched, host component still lowercased.
+		newCleanURLTestCase("userinfo preserved host lowercased",
+			"https://user:pass@Example.COM/x",
+			"https://user:pass@example.com/x"),
+		// Empty input: url.Parse accepts, no host/path work to do.
+		newCleanURLTestCase("empty input", "", ""),
+		// Unknown scheme: defaultPortFor returns "" so the port
+		// is preserved verbatim.
+		newCleanURLTestCase("unknown scheme port preserved",
+			"ftp://example.com:21/x", "ftp://example.com:21/x"),
+		// Error path: url.Parse rejects the input — signals a
+		// server-side bug, caller routes to 500.
+		newCleanURLErrorTestCase("invalid percent escape", "%ZZ"),
+		// Error path: trailing-dot FQDN — DNS-valid but
+		// core.SplitHostPort rejects, surfaced as a malformed
+		// composition (500).
+		newCleanURLErrorTestCase("trailing dot host rejected",
+			"https://example.com./x"),
+		// Error path: url.Parse accepts but SplitHostPort rejects
+		// the host shape (leading dot). Same 500 signal.
+		newCleanURLErrorTestCase("host starts with dot", "//.com/x"),
+		// Error path: url.Parse accepts the port but it's out of
+		// the 1-65535 range; SplitHostPort rejects.
+		newCleanURLErrorTestCase("port out of range",
+			"https://example.com:99999/x"),
+		// Error path: a Unicode label long enough that its
+		// punycode A-label exceeds the 63-byte DNS limit
+		// idna.Display.ToASCII enforces but
+		// idna.Display.ToUnicode (used by core.SplitHostPort)
+		// tolerates.
+		newCleanURLErrorTestCase("label too long after punycode",
+			"https://"+strings.Repeat("日", 100)+".example/x"),
+	}
+}
+
+func TestCleanURL(t *testing.T) {
+	core.RunTestCases(t, cleanURLTestCases())
 }

--- a/web/clean_test.go
+++ b/web/clean_test.go
@@ -1,0 +1,110 @@
+package web
+
+import (
+	"testing"
+
+	"darvaza.org/core"
+)
+
+var _ core.TestCase = cleanTestCase{}
+
+type cleanTestCase struct {
+	name string
+	path string
+	out  string
+	ok   bool
+}
+
+func (tc cleanTestCase) Name() string {
+	return tc.name
+}
+
+func (tc cleanTestCase) Test(t *testing.T) {
+	t.Helper()
+
+	s, ok := Clean(tc.path)
+	core.AssertEqual(t, tc.out, s, "cleaned")
+	core.AssertEqual(t, tc.ok, ok, "ok")
+}
+
+func newCleanTestCase(name, path, out string, ok bool) cleanTestCase {
+	return cleanTestCase{
+		name: name,
+		path: path,
+		out:  out,
+		ok:   ok,
+	}
+}
+
+func cleanTestCases() []cleanTestCase {
+	return []cleanTestCase{
+		// fs.Clean parity for ordinary paths.
+		newCleanTestCase("empty", "", ".", true),
+		newCleanTestCase("dot", ".", ".", true),
+		newCleanTestCase("single component", "a", "a", true),
+		newCleanTestCase("two components", "a/b", "a/b", true),
+		newCleanTestCase("double slash", "a//b", "a/b", true),
+		newCleanTestCase("self-cancel", "a/..", ".", true),
+		newCleanTestCase("cancel and continue", "a/../b", "b", true),
+		newCleanTestCase("root", "/", "/", true),
+		newCleanTestCase("rooted single", "/a", "/a", true),
+		newCleanTestCase("rooted trailing slash", "/a/", "/a/", true),
+		newCleanTestCase("rooted cancel to root", "/a/..", "/", true),
+		newCleanTestCase("rooted two", "/a/b", "/a/b", true),
+		newCleanTestCase("rooted cancel", "/a/b/..", "/a", true),
+		newCleanTestCase("rooted cancel and continue", "/a/b/../foo", "/a/foo", true),
+		// WHATWG backslash normalisation: \ becomes / before fs.Clean.
+		newCleanTestCase("backslash root", `/\`, "/", true),
+		newCleanTestCase("protocol-relative backslash", `/\evil.com`, "/evil.com", true),
+		newCleanTestCase("protocol-relative backslash with path",
+			`/\evil.com/path`, "/evil.com/path", true),
+		newCleanTestCase("dot-backslash bypass", `/./\evil.com`, "/evil.com", true),
+		newCleanTestCase("dotdot-backslash bypass",
+			`/a/../\evil.com`, "/evil.com", true),
+		// Protocol-relative shapes flatten via fs.Clean's empty-leading drop.
+		newCleanTestCase("double slash root", "//", "/", true),
+		newCleanTestCase("protocol-relative slash", "//evil.com", "/evil.com", true),
+		newCleanTestCase("protocol-relative slash with path",
+			"//evil.com/path", "/evil.com/path", true),
+		// /.. escape stripping — ok=false signals discarded blocks.
+		newCleanTestCase("escape root", "/..", "/", false),
+		newCleanTestCase("escape root trailing", "/../", "/", false),
+		newCleanTestCase("escape root twice", "/../..", "/", false),
+		newCleanTestCase("escape then path", "/../evil.com", "/evil.com", false),
+		newCleanTestCase("escape then path with trailing",
+			"/../foo/", "/foo/", false),
+		newCleanTestCase("escape twice then path",
+			"/../../evil.com", "/evil.com", false),
+		newCleanTestCase("escape three deep",
+			"/../../../x", "/x", false),
+		newCleanTestCase("escape with trailing double slash",
+			"/../..//", "/", false),
+		newCleanTestCase("dotdot prefix of filename",
+			"/..foo", "/..foo", true),
+		// Relative escape: fs.Clean leaves it; we don't strip (not /..).
+		newCleanTestCase("relative dotdot", "..", "..", true),
+		newCleanTestCase("relative dotdot trailing", "../", "../", true),
+		newCleanTestCase("relative dotdot with path", "../a", "../a", true),
+		// ok invariant: non-/.. reductions keep ok=true even
+		// when the output differs from the input.
+		newCleanTestCase("ok-invariant backslash normalisation",
+			`/a\b`, "/a/b", true),
+		newCleanTestCase("ok-invariant fs.Clean reduction",
+			"/a/b/../c", "/a/c", true),
+		// Pathological inputs: documented, not guarded against.
+		newCleanTestCase("carriage return passes through",
+			"/a\rb", "/a\rb", true),
+		newCleanTestCase("newline passes through",
+			"/a\nb", "/a\nb", true),
+		newCleanTestCase("null byte passes through",
+			"/a\x00b", "/a\x00b", true),
+		newCleanTestCase("url-encoded dotdot not decoded",
+			"/%2e%2e/evil.com", "/%2e%2e/evil.com", true),
+		newCleanTestCase("full URL input mangled",
+			"http://evil.com/foo", "http:/evil.com/foo", true),
+	}
+}
+
+func TestClean(t *testing.T) {
+	core.RunTestCases(t, cleanTestCases())
+}

--- a/web/errors.go
+++ b/web/errors.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -19,6 +20,40 @@ func NewStatusMethodNotAllowed(allowed ...string) *HTTPError {
 		Code: http.StatusMethodNotAllowed,
 		Hdr: http.Header{
 			consts.Allow: allowed,
+		},
+	}
+}
+
+// newRedirect builds an HTTPError carrying a Location header
+// for the given redirect status code. When args is non-empty,
+// dest is Sprintf-formatted; otherwise it passes through
+// verbatim so URL percent-escapes survive unchanged. The
+// composed dest is then normalised through CleanURL: scheme
+// passes verbatim, the host is lowercased with IDN labels
+// converted to ASCII punycode and IPv6 canonicalised, the
+// default port is stripped when it matches the scheme, and
+// the path is reduced through Clean.
+//
+// When CleanURL rejects the composed dest — url.Parse,
+// core.SplitHostPort, or the DNS label-length check —
+// newRedirect wraps the failure as a 500 via
+// NewStatusInternalServerError rather than emit a broken
+// Location.
+//
+// newRedirect does not validate origin. Callers passing
+// untrusted input must allowlist scheme or origin themselves.
+func newRedirect(code int, dest string, args ...any) *HTTPError {
+	if len(args) > 0 {
+		dest = fmt.Sprintf(dest, args...)
+	}
+	dest, err := CleanURL(dest)
+	if err != nil {
+		return NewStatusInternalServerError(err)
+	}
+	return &HTTPError{
+		Code: code,
+		Hdr: http.Header{
+			consts.Location: []string{dest},
 		},
 	}
 }

--- a/web/errors_gen.go
+++ b/web/errors_gen.go
@@ -5,113 +5,63 @@ package web
 //go:generate ./errors_gen.sh
 
 import (
-	"fmt"
 	"net/http"
-	"strings"
 	"time"
-
-	"darvaza.org/x/fs"
-	"darvaza.org/x/web/consts"
 )
 
-// NewStatusMovedPermanently returns a 301 redirect error.
+// NewStatusMovedPermanently returns a 301 redirect error. dest is
+// normalised through [CleanURL]; a composition failure is
+// wrapped as 500 via [NewStatusInternalServerError].
+//
+// Origin is not validated: untrusted dest must have its
+// scheme and origin allowlisted (or be restricted to a
+// relative path) to avoid composing an open redirect.
 func NewStatusMovedPermanently(dest string, args ...any) *HTTPError {
-	if len(args) > 0 {
-		dest = fmt.Sprintf(dest, args...)
-	}
-
-	trailing := strings.HasSuffix(dest, "/")
-	dest, _ = fs.Clean(dest)
-	if trailing && !strings.HasSuffix(dest, "/") {
-		dest += "/"
-	}
-
-	return &HTTPError{
-		Code: http.StatusMovedPermanently,
-		Hdr: http.Header{
-			consts.Location: []string{dest},
-		},
-	}
+	return newRedirect(http.StatusMovedPermanently, dest, args...)
 }
 
-// NewStatusFound returns a 302 redirect error.
+// NewStatusFound returns a 302 redirect error. dest is
+// normalised through [CleanURL]; a composition failure is
+// wrapped as 500 via [NewStatusInternalServerError].
+//
+// Origin is not validated: untrusted dest must have its
+// scheme and origin allowlisted (or be restricted to a
+// relative path) to avoid composing an open redirect.
 func NewStatusFound(dest string, args ...any) *HTTPError {
-	if len(args) > 0 {
-		dest = fmt.Sprintf(dest, args...)
-	}
-
-	trailing := strings.HasSuffix(dest, "/")
-	dest, _ = fs.Clean(dest)
-	if trailing && !strings.HasSuffix(dest, "/") {
-		dest += "/"
-	}
-
-	return &HTTPError{
-		Code: http.StatusFound,
-		Hdr: http.Header{
-			consts.Location: []string{dest},
-		},
-	}
+	return newRedirect(http.StatusFound, dest, args...)
 }
 
-// NewStatusSeeOther returns a 303 redirect error.
+// NewStatusSeeOther returns a 303 redirect error. dest is
+// normalised through [CleanURL]; a composition failure is
+// wrapped as 500 via [NewStatusInternalServerError].
+//
+// Origin is not validated: untrusted dest must have its
+// scheme and origin allowlisted (or be restricted to a
+// relative path) to avoid composing an open redirect.
 func NewStatusSeeOther(dest string, args ...any) *HTTPError {
-	if len(args) > 0 {
-		dest = fmt.Sprintf(dest, args...)
-	}
-
-	trailing := strings.HasSuffix(dest, "/")
-	dest, _ = fs.Clean(dest)
-	if trailing && !strings.HasSuffix(dest, "/") {
-		dest += "/"
-	}
-
-	return &HTTPError{
-		Code: http.StatusSeeOther,
-		Hdr: http.Header{
-			consts.Location: []string{dest},
-		},
-	}
+	return newRedirect(http.StatusSeeOther, dest, args...)
 }
 
-// NewStatusTemporaryRedirect returns a 307 redirect error.
+// NewStatusTemporaryRedirect returns a 307 redirect error. dest is
+// normalised through [CleanURL]; a composition failure is
+// wrapped as 500 via [NewStatusInternalServerError].
+//
+// Origin is not validated: untrusted dest must have its
+// scheme and origin allowlisted (or be restricted to a
+// relative path) to avoid composing an open redirect.
 func NewStatusTemporaryRedirect(dest string, args ...any) *HTTPError {
-	if len(args) > 0 {
-		dest = fmt.Sprintf(dest, args...)
-	}
-
-	trailing := strings.HasSuffix(dest, "/")
-	dest, _ = fs.Clean(dest)
-	if trailing && !strings.HasSuffix(dest, "/") {
-		dest += "/"
-	}
-
-	return &HTTPError{
-		Code: http.StatusTemporaryRedirect,
-		Hdr: http.Header{
-			consts.Location: []string{dest},
-		},
-	}
+	return newRedirect(http.StatusTemporaryRedirect, dest, args...)
 }
 
-// NewStatusPermanentRedirect returns a 308 redirect error.
+// NewStatusPermanentRedirect returns a 308 redirect error. dest is
+// normalised through [CleanURL]; a composition failure is
+// wrapped as 500 via [NewStatusInternalServerError].
+//
+// Origin is not validated: untrusted dest must have its
+// scheme and origin allowlisted (or be restricted to a
+// relative path) to avoid composing an open redirect.
 func NewStatusPermanentRedirect(dest string, args ...any) *HTTPError {
-	if len(args) > 0 {
-		dest = fmt.Sprintf(dest, args...)
-	}
-
-	trailing := strings.HasSuffix(dest, "/")
-	dest, _ = fs.Clean(dest)
-	if trailing && !strings.HasSuffix(dest, "/") {
-		dest += "/"
-	}
-
-	return &HTTPError{
-		Code: http.StatusPermanentRedirect,
-		Hdr: http.Header{
-			consts.Location: []string{dest},
-		},
-	}
+	return newRedirect(http.StatusPermanentRedirect, dest, args...)
 }
 
 // NewStatusBadRequest returns a 400 HTTP error,

--- a/web/errors_gen.sh
+++ b/web/errors_gen.sh
@@ -16,13 +16,8 @@ package $GOPACKAGE
 //$TAG $0
 
 import (
-	"fmt"
 	"net/http"
-	"strings"
 	"time"
-
-	"darvaza.org/x/fs"
-	"darvaza.org/x/web/consts"
 )
 EOT
 
@@ -41,24 +36,15 @@ for x in \
 
 	cat <<EOT
 
-// NewStatus$name returns a $code redirect error.
+// NewStatus$name returns a $code redirect error. dest is
+// normalised through [CleanURL]; a composition failure is
+// wrapped as 500 via [NewStatusInternalServerError].
+//
+// Origin is not validated: untrusted dest must have its
+// scheme and origin allowlisted (or be restricted to a
+// relative path) to avoid composing an open redirect.
 func NewStatus$name(dest string, args ...any) *HTTPError {
-	if len(args) > 0 {
-		dest = fmt.Sprintf(dest, args...)
-	}
-
-	trailing := strings.HasSuffix(dest, "/")
-	dest, _ = fs.Clean(dest)
-	if trailing && !strings.HasSuffix(dest, "/") {
-		dest += "/"
-	}
-
-	return &HTTPError{
-		Code: http.Status$name,
-		Hdr: http.Header{
-			consts.Location: []string{dest},
-		},
-	}
+	return newRedirect(http.Status$name, dest, args...)
 }
 EOT
 done

--- a/web/errors_test.go
+++ b/web/errors_test.go
@@ -1,0 +1,219 @@
+package web_test
+
+// cspell:words Fevil
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"darvaza.org/core"
+
+	"darvaza.org/x/web"
+	"darvaza.org/x/web/consts"
+)
+
+var (
+	_ core.TestCase = redirectTestCase{}
+	_ core.TestCase = redirectStatusTestCase{}
+)
+
+// redirectTestCase exercises redirect composition through
+// web.NewStatusFound: args formatting, CleanURL normalisation
+// and Location header wiring. wantErr selects between the
+// success path (302, Location set) and the error path where
+// CleanURL rejects via url.Parse, core.SplitHostPort or the
+// DNS label-length check — caller asked for 302, factory
+// wraps the failure as a 500.
+type redirectTestCase struct {
+	args    []any
+	name    string
+	dest    string
+	want    string
+	wantErr bool
+}
+
+func (tc redirectTestCase) Name() string {
+	return tc.name
+}
+
+func (tc redirectTestCase) Test(t *testing.T) {
+	t.Helper()
+
+	err := web.NewStatusFound(tc.dest, tc.args...)
+	core.AssertMustNotNil(t, err, "HTTPError")
+
+	wantCode := core.IIf(tc.wantErr, http.StatusInternalServerError, http.StatusFound)
+	core.AssertEqual(t, wantCode, err.HTTPStatus(), "status code")
+
+	hdr := err.Header()
+	if tc.wantErr {
+		core.AssertFalse(t, web.HasHeader(hdr, consts.Location), "no Location")
+		core.AssertNotNil(t, err.Err, "wrapped error")
+		return
+	}
+	core.AssertSliceEqual(t, []string{tc.want},
+		hdr.Values(consts.Location), "Location")
+}
+
+func newRedirectTestCase(name, dest, want string,
+	args ...any) redirectTestCase {
+	return redirectTestCase{
+		name: name,
+		dest: dest,
+		args: args,
+		want: want,
+	}
+}
+
+func newRedirectErrorTestCase(name, dest string) redirectTestCase {
+	return redirectTestCase{
+		name:    name,
+		dest:    dest,
+		wantErr: true,
+	}
+}
+
+func redirectTestCases() []redirectTestCase {
+	return []redirectTestCase{
+		newRedirectTestCase("plain rooted", "/foo", "/foo"),
+		newRedirectTestCase("rooted trailing slash", "/foo/", "/foo/"),
+		newRedirectTestCase("rooted dotdot reduces", "/foo/../bar", "/bar"),
+		newRedirectTestCase("relative", "bar", "bar"),
+		newRedirectTestCase("root", "/", "/"),
+		newRedirectTestCase("empty", "", ""),
+		newRedirectTestCase("sprintf args", "/foo/%d", "/foo/42", 42),
+		// Format verb without args skips Sprintf and passes through
+		// verbatim — pins the len(args) > 0 guard.
+		newRedirectTestCase("format verb without args",
+			"/search?q=%20", "/search?q=%20"),
+		// Interpretation vectors get cleaned on the path.
+		newRedirectTestCase("backslash-slash path",
+			`/\evil.com`, "/evil.com"),
+		newRedirectTestCase("backslash root path", `/\`, "/"),
+		newRedirectTestCase("dot-backslash bypass", `/./\evil.com`, "/evil.com"),
+		newRedirectTestCase("dotdot-backslash bypass",
+			`/a/../\evil.com`, "/evil.com"),
+		newRedirectTestCase("percent-encoded slash vector",
+			"/%2Fevil.com", "/evil.com"),
+		// Leading rooted /.. is stripped.
+		newRedirectTestCase("escape root", "/..", "/"),
+		newRedirectTestCase("escape then path", "/../evil.com", "/evil.com"),
+		newRedirectTestCase("escape twice", "/../../evil.com", "/evil.com"),
+		// Full URL and protocol-relative authority are application
+		// intent; preserved verbatim, path cleaned.
+		newRedirectTestCase("absolute URL", "https://sso.example.com/login",
+			"https://sso.example.com/login"),
+		newRedirectTestCase("absolute URL escape cleaned",
+			"https://x.com/../y", "https://x.com/y"),
+		newRedirectTestCase("protocol-relative authority",
+			"//evil.com", "//evil.com"),
+		// url.Parse rejects the input — newRedirect wraps
+		// the failure as a 500 rather than emit a broken
+		// Location.
+		newRedirectErrorTestCase("invalid percent escape", "%ZZ"),
+		// SplitHostPort rejects the host shape — same 500 path
+		// as the url.Parse branch, different trigger.
+		newRedirectErrorTestCase("host starts with dot", "//.com/x"),
+		newRedirectErrorTestCase("port out of range",
+			"https://example.com:99999/x"),
+		// DNS label-length check rejects labels over 63 bytes
+		// — the third CleanURL error source.
+		newRedirectErrorTestCase("dns label too long",
+			"https://"+strings.Repeat("a", 64)+".example.com/x"),
+	}
+}
+
+func TestNewRedirect(t *testing.T) {
+	core.RunTestCases(t, redirectTestCases())
+}
+
+// redirectStatusTestCase verifies each generated dispatcher hands
+// off to newRedirect with the right status code, and — via the
+// dirty-input row — that it actually routes through Clean.
+type redirectStatusTestCase struct {
+	name    string
+	dest    string
+	want    string
+	factory func(string, ...any) *web.HTTPError
+	code    int
+	wantErr bool
+}
+
+func (tc redirectStatusTestCase) Name() string {
+	return tc.name
+}
+
+func (tc redirectStatusTestCase) Test(t *testing.T) {
+	t.Helper()
+
+	err := tc.factory(tc.dest)
+	core.AssertMustNotNil(t, err, "HTTPError")
+	core.AssertEqual(t, tc.code, err.HTTPStatus(), "status code")
+
+	hdr := err.Header()
+	if tc.wantErr {
+		core.AssertFalse(t, web.HasHeader(hdr, consts.Location), "no Location")
+		core.AssertNotNil(t, err.Err, "wrapped error")
+		return
+	}
+	core.AssertSliceEqual(t, []string{tc.want},
+		hdr.Values(consts.Location), "Location")
+}
+
+func newRedirectStatusTestCase(name, dest, want string,
+	factory func(string, ...any) *web.HTTPError,
+	code int) redirectStatusTestCase {
+	return redirectStatusTestCase{
+		name:    name,
+		dest:    dest,
+		want:    want,
+		factory: factory,
+		code:    code,
+	}
+}
+
+func newRedirectStatusErrorTestCase(name string,
+	factory func(string, ...any) *web.HTTPError) redirectStatusTestCase {
+	return redirectStatusTestCase{
+		name:    name,
+		dest:    "%ZZ",
+		factory: factory,
+		code:    http.StatusInternalServerError,
+		wantErr: true,
+	}
+}
+
+func redirectStatusTestCases() []redirectStatusTestCase {
+	return []redirectStatusTestCase{
+		newRedirectStatusTestCase("MovedPermanently", "/foo", "/foo",
+			web.NewStatusMovedPermanently, http.StatusMovedPermanently),
+		newRedirectStatusTestCase("Found", "/foo", "/foo",
+			web.NewStatusFound, http.StatusFound),
+		// Dirty input confirms the dispatcher runs through Clean,
+		// not just that the status code is wired up.
+		newRedirectStatusTestCase("Found cleans escape", "/../x", "/x",
+			web.NewStatusFound, http.StatusFound),
+		newRedirectStatusTestCase("SeeOther", "/foo", "/foo",
+			web.NewStatusSeeOther, http.StatusSeeOther),
+		newRedirectStatusTestCase("TemporaryRedirect", "/foo", "/foo",
+			web.NewStatusTemporaryRedirect, http.StatusTemporaryRedirect),
+		newRedirectStatusTestCase("PermanentRedirect", "/foo", "/foo",
+			web.NewStatusPermanentRedirect, http.StatusPermanentRedirect),
+		// Error-path rows confirm each dispatcher delegates the
+		// CleanURL failure to newRedirect's 500 wrap; Found's
+		// error path is exhaustively covered in redirectTestCase.
+		newRedirectStatusErrorTestCase("MovedPermanently error",
+			web.NewStatusMovedPermanently),
+		newRedirectStatusErrorTestCase("SeeOther error",
+			web.NewStatusSeeOther),
+		newRedirectStatusErrorTestCase("TemporaryRedirect error",
+			web.NewStatusTemporaryRedirect),
+		newRedirectStatusErrorTestCase("PermanentRedirect error",
+			web.NewStatusPermanentRedirect),
+	}
+}
+
+func TestRedirectStatusHelpers(t *testing.T) {
+	core.RunTestCases(t, redirectStatusTestCases())
+}

--- a/web/go.mod
+++ b/web/go.mod
@@ -7,12 +7,14 @@ require (
 	darvaza.org/x/fs v0.5.2
 )
 
-require lukechampine.com/blake3 v1.4.1
+require (
+	golang.org/x/net v0.43.0
+	lukechampine.com/blake3 v1.4.1
+)
 
 require (
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
-	golang.org/x/net v0.43.0 // indirect
 	golang.org/x/sys v0.35.0 // indirect
 	golang.org/x/text v0.28.0 // indirect
 )

--- a/web/headers.go
+++ b/web/headers.go
@@ -9,6 +9,15 @@ import (
 	"darvaza.org/x/web/consts"
 )
 
+// HasHeader reports whether hdr has any entry under key,
+// including a blank-valued entry. Distinguishes "no header
+// set" from "header set to a blank value", which
+// http.Header.Get collapses to "". An entry with no values
+// ([]string{}) counts as absent.
+func HasHeader(hdr http.Header, key string) bool {
+	return len(hdr.Values(key)) > 0
+}
+
 // SetHeader sets a header value, optionally formatted.
 func SetHeader(hdr http.Header, key, value string, args ...any) {
 	doSetHeader(hdr, key, value, args...)

--- a/web/headers_test.go
+++ b/web/headers_test.go
@@ -237,7 +237,7 @@ func (tc checkIfModifiedSinceTestCase) Name() string {
 func (tc checkIfModifiedSinceTestCase) Test(t *testing.T) {
 	t.Helper()
 
-	req, err := http.NewRequest(http.MethodGet, "/test", nil)
+	req, err := http.NewRequest(http.MethodGet, "/test", http.NoBody)
 	core.AssertNoError(t, err, "create request")
 
 	if tc.headerValue != "" {

--- a/web/headers_test.go
+++ b/web/headers_test.go
@@ -271,7 +271,8 @@ func TestCheckIfModifiedSince(t *testing.T) {
 		newCheckIfModifiedSinceTestCase("not modified", past, now.Format(http.TimeFormat), false),
 		newCheckIfModifiedSinceTestCase("same time", now, now.Format(http.TimeFormat), false),
 		newCheckIfModifiedSinceTestCase("future header", past, future.Format(http.TimeFormat), false),
-		newCheckIfModifiedSinceTestCase("future lastModified clamped to now", future, past.Format(http.TimeFormat), true),
+		newCheckIfModifiedSinceTestCase("future lastModified clamped to now",
+			future, past.Format(http.TimeFormat), true),
 	}
 
 	core.RunTestCases(t, testCases)

--- a/web/headers_test.go
+++ b/web/headers_test.go
@@ -17,7 +17,62 @@ var (
 	_ core.TestCase = setRetryAfterTestCase{}
 	_ core.TestCase = setLastModifiedHeaderTestCase{}
 	_ core.TestCase = checkIfModifiedSinceTestCase{}
+	_ core.TestCase = hasHeaderTestCase{}
 )
+
+type hasHeaderTestCase struct {
+	name    string
+	setKey  string
+	values  []string
+	queryAs string
+	want    bool
+}
+
+func (tc hasHeaderTestCase) Name() string {
+	return tc.name
+}
+
+func (tc hasHeaderTestCase) Test(t *testing.T) {
+	t.Helper()
+
+	hdr := make(http.Header)
+	if tc.setKey != "" {
+		hdr[tc.setKey] = tc.values
+	}
+
+	core.AssertEqual(t, tc.want, HasHeader(hdr, tc.queryAs), "HasHeader")
+}
+
+func newHasHeaderTestCase(name, setKey string, values []string,
+	queryAs string, want bool) hasHeaderTestCase {
+	return hasHeaderTestCase{
+		name:    name,
+		setKey:  setKey,
+		values:  values,
+		queryAs: queryAs,
+		want:    want,
+	}
+}
+
+func TestHasHeader(t *testing.T) {
+	testCases := []hasHeaderTestCase{
+		newHasHeaderTestCase("absent", "", nil, "X-Test", false),
+		newHasHeaderTestCase("blank value", "X-Test",
+			[]string{""}, "X-Test", true),
+		newHasHeaderTestCase("populated", "X-Test",
+			[]string{"value"}, "X-Test", true),
+		newHasHeaderTestCase("multi-valued", "X-Test",
+			[]string{"a", "b"}, "X-Test", true),
+		newHasHeaderTestCase("empty slice", "X-Test",
+			[]string{}, "X-Test", false),
+		newHasHeaderTestCase("non-canonical query", "X-Test",
+			[]string{"value"}, "x-test", true),
+	}
+
+	core.RunTestCases(t, testCases)
+
+	core.AssertFalse(t, HasHeader(nil, "X-Test"), "HasHeader on nil map")
+}
 
 type setHeaderTestCase struct {
 	name     string


### PR DESCRIPTION
## Summary

Unbreak main. Two issues that main is carrying green-but-broken:

- **web/errors_gen** closes CodeQL's `go/bad-redirect-check` alert
  #6 (CWE-601). The `NewStatus*Redirect` helpers fed user-controlled
  destinations through `fs.Clean` into the `Location` header and
  discarded the `ok` return — shapes like `//evil.com` and
  `/\evil.com` flowed to browsers as open redirects. The factories
  also mangled full URLs because `fs.Clean` is a path-only
  normaliser. Replaced `fs.Clean` with a URL-aware `CleanURL`
  composer and centralised the redirect construction in a
  hand-written `newRedirect` helper.
- **net/reconnect/README** pads two table separators so every row in
  every table shares the same cell-padding shape, as markdownlint's
  `MD060` expects.

Each commit stands alone.

## Why a separate branch

PR #271 (`pr-amery-go126`) currently carries a variant of the same
redirect fix, but it's blocked on codecov patch coverage. The
open-redirect is a live vuln on main and the markdownlint failure
breaks `make tidy` on a fresh checkout — worth landing
independently of the Go-floor bump.

When this lands, #271 rebases and drops its copy of the security
fix.

## Notable changes

### `web/errors_gen` — open-redirect guard

The five `NewStatus*Redirect` constructors (`MovedPermanently`,
`Found`, `SeeOther`, `TemporaryRedirect`, `PermanentRedirect`)
previously inlined `fs.Clean` and threw away the `ok` bool.
CodeQL's taint analyser therefore saw user input flowing straight
to the `Location` header with only a leading-slash check — the
classic CWE-601 shape. Beyond the alert, `fs.Clean` is a path-only
normaliser, so full URLs (`https://example.com/foo`) and
protocol-relative inputs (`//host/path`) were mangled — every
cross-origin redirect (SSO, partner auth, post-login bounceback)
emitted a Location no client could resolve.

The fix lands as four commits, each a reviewable unit:

- **`Clean(path) (string, bool)`** — URL-path normaliser.
  Preserves trailing slash, clamps `/..` at root the way browsers
  do, rejects control characters (CR/LF, NUL) to close CWE-113 and
  null-byte vectors that previously slipped through `fs.Clean`.
- **`CleanURL(dest) (string, error)`** — full-URL composer.
  Scheme passes verbatim; authority goes through
  `core.SplitHostPort` (lowercase, IDN→punycode, IPv6
  canonicalisation, default-port stripping, 63-byte DNS-label
  check); path goes through `Clean`.
- **`HasHeader(hdr, key) bool`** — absent-vs-blank presence check
  via `http.Header.Values`. Complements `Get`, which collapses
  both to `""`.
- **Redirect factories** — the five dispatchers now delegate to a
  hand-written `newRedirect` helper that runs `dest` through
  `CleanURL`. Composition failures (`url.Parse`,
  `core.SplitHostPort`, the DNS-label limit) surface as 500 via
  `NewStatusInternalServerError` rather than emit a broken
  Location. `errors_gen.sh`'s emitted imports drop to `net/http`
  and `time`.

The factory remains a **composer, not an origin validator**. A
literal URL written in caller code and a `?next=` value pulled
from a request query string are identical at the call site, and
`CleanURL` preserves both. When `dest` is derived from untrusted
input the caller must allowlist scheme and origin (or restrict
to a relative path) — documented on each public dispatcher's
godoc and in the `web/README` redirect-factories prose.

`fs.Clean` itself is left untouched — URL-safety belongs in the
web layer, not in an `fs` package, and an earlier sanitisation
attempt inside `fs.Clean` was invisible to CodeQL anyway because
the callers discarded `ok`.

### `net/reconnect/README` — MD060 table padding

Two separator rows used the compact form (`|---|---|`) while the
data rows are padded (`| foo | bar |`). markdownlint's `MD060`
(`consistent` mode) picks the first row's shape and flags the
others. Both separators rewritten to the padded form. Also pin
`"MD060": true` in `internal/build/markdownlint.json` to document
that we rely on it (the rule is on by default via `"default": true`,
but listing it next to the other explicit overrides makes the
intent obvious).

## Test plan

- [ ] `make` passes cleanly (no warnings, no errors).
- [ ] `make test-web` — all green.
- [ ] CodeQL rerun on main shows alert #6 closed.
- [ ] `markdownlint net/reconnect/README.md` — no MD060 output.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added URL and path normalization utilities for consistent endpoint handling
  * Added header presence checking to distinguish between missing and empty headers
  * Enhanced redirect error handling with automatic destination normalization and validation

* **Documentation**
  * Updated API documentation covering new path sanitization and header utilities
  * Clarified redirect error composition behavior and security considerations

* **Tests**
  * Added comprehensive test coverage for path cleaning, URL normalization, and redirect behavior

* **Chores**
  * Updated configuration files and dependencies
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
