### PR TITLE
build: bump darvaza.org/slog to v0.9.0

### DIFF
--- a/net/go.mod
+++ b/net/go.mod
@@ -4,8 +4,8 @@ go 1.24.0
 
 require (
 	darvaza.org/core v0.19.0
-	darvaza.org/slog v0.8.1
-	darvaza.org/slog/handlers/discard v0.6.2
+	darvaza.org/slog v0.9.0
+	darvaza.org/slog/handlers/discard v0.7.0
 	darvaza.org/x/fs v0.5.3
 	github.com/amery/defaults v0.1.0
 )

--- a/net/go.sum
+++ b/net/go.sum
@@ -1,9 +1,9 @@
 darvaza.org/core v0.19.0 h1:vK56K+4DyvaiFjB5iifzt6BwsldDOWcV2Dut6H0T958=
 darvaza.org/core v0.19.0/go.mod h1:8+rhinVhCzJf814uPOYFRmj1D+8mO7bkbo/hrK0Lmkk=
-darvaza.org/slog v0.8.1 h1:jQJ6re5vKNeF2KCT+hd0kenqwLb5XieKDgPhSFSK4Qo=
-darvaza.org/slog v0.8.1/go.mod h1:hSMqph96u03qsPxWF2HwTbtM8oQxeVkrRouuBh8UyxM=
-darvaza.org/slog/handlers/discard v0.6.2 h1:tDn+TWz2DTln7ckXmLPTdi30UZ/t4lABiACT3uTNJ14=
-darvaza.org/slog/handlers/discard v0.6.2/go.mod h1:h7pH48cX2omYoZQY2E3zRYTpWE/lmlNivWG1r3x7Hlk=
+darvaza.org/slog v0.9.0 h1:4rDJ157J2OPhV66hulXkCZRlAPOBkULowgXtJmJZEs8=
+darvaza.org/slog v0.9.0/go.mod h1:k2vMkKtZNGXo46uo+YVIsFZa4oYQqvvI6Y6IE1h9QHM=
+darvaza.org/slog/handlers/discard v0.7.0 h1:iqALaFsTCPs5roN17chwAd/9VVA+8Xq00EUlxte2zKQ=
+darvaza.org/slog/handlers/discard v0.7.0/go.mod h1:4++w0cXiihdIWHCRALwgQvqYHxzit+4na59avUIgYuM=
 darvaza.org/x/fs v0.5.3 h1:r30+gxHRZL57KHSfliizzPCTJe1sRRf8jjULts8ds2E=
 darvaza.org/x/fs v0.5.3/go.mod h1:Z3VWfHfTr6TUluVytbHzDdPuYZvGSsoTxA4ltN1/Dcs=
 github.com/amery/defaults v0.1.0 h1:4AhTgLUnj8BPjVRBzg4+/cSCwPWPT6+yWCM4rD6Feyc=

--- a/tls/go.mod
+++ b/tls/go.mod
@@ -4,7 +4,7 @@ go 1.24.0
 
 require (
 	darvaza.org/core v0.19.0
-	darvaza.org/slog v0.8.1
+	darvaza.org/slog v0.9.0
 	darvaza.org/x/container v0.3.2
 )
 

--- a/tls/go.sum
+++ b/tls/go.sum
@@ -1,7 +1,7 @@
 darvaza.org/core v0.19.0 h1:vK56K+4DyvaiFjB5iifzt6BwsldDOWcV2Dut6H0T958=
 darvaza.org/core v0.19.0/go.mod h1:8+rhinVhCzJf814uPOYFRmj1D+8mO7bkbo/hrK0Lmkk=
-darvaza.org/slog v0.8.1 h1:jQJ6re5vKNeF2KCT+hd0kenqwLb5XieKDgPhSFSK4Qo=
-darvaza.org/slog v0.8.1/go.mod h1:hSMqph96u03qsPxWF2HwTbtM8oQxeVkrRouuBh8UyxM=
+darvaza.org/slog v0.9.0 h1:4rDJ157J2OPhV66hulXkCZRlAPOBkULowgXtJmJZEs8=
+darvaza.org/slog v0.9.0/go.mod h1:k2vMkKtZNGXo46uo+YVIsFZa4oYQqvvI6Y6IE1h9QHM=
 darvaza.org/x/container v0.3.2 h1:nXaMORQmNY9oTkHT8ZAxJfJsSgP6OEu8XSF5opTIbzI=
 darvaza.org/x/container v0.3.2/go.mod h1:UUbZ0M5H+EIWlaopfjDYet/LJfmzC+0H5MMlSnSMaiA=
 github.com/klauspost/cpuid/v2 v2.3.0 h1:S4CRMLnYUhGeDFDqkGriYKdfoFlDnMtqTiI/sFzhA9Y=


### PR DESCRIPTION
## Summary

Bump `darvaza.org/slog` to v0.9.0 across the two x submodules that
depend on it.

- **net**: `darvaza.org/slog v0.8.1 → v0.9.0`,
  `darvaza.org/slog/handlers/discard v0.6.2 → v0.7.0`
- **tls**: `darvaza.org/slog v0.8.1 → v0.9.0`

The slog v0.9.0 line raises the Go floor to 1.24 (already met by x
since #271) and ships per-tier lint tooling. The discard handler
v0.7.0 picks up the same Go-floor and core v0.19.0 alignment. No
source changes were required in x — only `go.mod` / `go.sum`.

## Test plan

- [x] `make tidy-net tidy-tls` — clean
- [x] `make all test` — all green (cmp, config, container, fs, net,
      sync, tls, web)
- [ ] CI green on push


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated logging library dependencies to newer versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->