### PR TITLE
build: bump core to v0.19.1 + adopt Must/MustNoError helpers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -260,7 +260,7 @@ go tool cover -html=coverage.out
 
 1. The Makefile defines `GOTEST_FLAGS ?=` (empty by default).
 2. The generated rules use it in the test target:
-   `$(GO) test $(GOTEST_FLAGS) ./...`.
+   `$(GO) test -count=1 $(GOTEST_FLAGS) ./...`.
 3. Any flags passed via `GOTEST_FLAGS` are forwarded directly to `go test`.
 
 This provides a clean interface for passing arbitrary test flags without

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ utility libraries that extend Go's standard library capabilities.
 
 Before starting development, ensure you have:
 
-- Go 1.23 or later installed (check with `go version`).
+- Go 1.24 or later installed (check with `go version`).
 - `make` command available (usually pre-installed on Unix systems).
 - `$GOPATH` configured correctly (typically `~/go`).
 - Git configured for proper line endings.
@@ -74,7 +74,7 @@ go mod tidy
 
 - **Minimal dependencies**: Primarily the Go standard library and minimal
   golang.org/x packages.
-- **Generic programming**: Extensive use of Go 1.23+ generics for
+- **Generic programming**: Extensive use of Go 1.24+ generics for
   type-safe utilities.
 - **Interface-driven design**: For extensibility and testability.
 - **Common foundation**: Each package depends on `darvaza.org/core` for
@@ -187,8 +187,8 @@ GitHub Actions workflows split for better performance:
   only.
 - **Test workflow** (`.github/workflows/test.yml`): Dedicated testing
   pipeline.
-  - Race condition detection job with Go 1.23.
-  - Multi-version testing matrix (Go 1.23 and 1.24).
+  - Race condition detection job with Go 1.26.
+  - Multi-version testing matrix (Go 1.24, 1.25 and 1.26).
   - Conditional execution to avoid duplicate runs on PRs.
 - Workflows skip branches ending in `-wip`.
 - Improves parallelism and reduces redundant work.
@@ -269,7 +269,7 @@ configurations for debugging, coverage analysis, or CI/CD pipelines.
 
 ## Important Notes
 
-- Go 1.23 is the minimum required version.
+- Go 1.24 is the minimum required version.
 - Each package maintains its own README.md and AGENTS.md.
 - The Makefile dynamically generates rules for subprojects.
 - Tool versions (golangci-lint, revive) are selected based on Go version.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -118,7 +118,7 @@ Before starting the release process:
 
    Dependencies:
    - darvaza.org/core vX.Y.Z
-   - Go 1.23 or later"
+   - Go 1.24 or later"
    ```
 
    For multiple packages, prefer message files in `.tmp/` (gitignored):
@@ -221,7 +221,7 @@ Before starting the release process:
    Dependencies:
    - darvaza.org/core vX.Y.Z
    - darvaza.org/x/fs v0.5.3
-   - Go 1.23 or later
+   - Go 1.24 or later
    ```
 
 3. Push all Tier 2 tags:
@@ -243,7 +243,7 @@ Before starting the release process:
    go get darvaza.org/x/tls@v0.6.1
    \`\`\`
 
-   All packages now require Go 1.23 or later."
+   All packages now require Go 1.24 or later."
    ```
 
 ## Version Numbering
@@ -256,7 +256,7 @@ Each package maintains its own semantic version. When releasing:
 
 ### Common Release Scenarios
 
-1. **Updating Go version requirement** (e.g., Go 1.22 → 1.23):
+1. **Updating Go version requirement** (e.g., Go 1.24 → 1.25):
    - This is a breaking change requiring minor version bump
    - Update all packages even if no code changes
    - Document clearly in release notes

--- a/cmp/go.mod
+++ b/cmp/go.mod
@@ -2,7 +2,7 @@ module darvaza.org/x/cmp
 
 go 1.24.0
 
-require darvaza.org/core v0.19.0
+require darvaza.org/core v0.19.1
 
 require (
 	golang.org/x/net v0.50.0 // indirect

--- a/cmp/go.sum
+++ b/cmp/go.sum
@@ -1,5 +1,5 @@
-darvaza.org/core v0.19.0 h1:vK56K+4DyvaiFjB5iifzt6BwsldDOWcV2Dut6H0T958=
-darvaza.org/core v0.19.0/go.mod h1:8+rhinVhCzJf814uPOYFRmj1D+8mO7bkbo/hrK0Lmkk=
+darvaza.org/core v0.19.1 h1:Ea6zFi2STXt4QC7Jbu1/unUo5Kd/OX65flZgeNw2iOY=
+darvaza.org/core v0.19.1/go.mod h1:8+rhinVhCzJf814uPOYFRmj1D+8mO7bkbo/hrK0Lmkk=
 golang.org/x/net v0.50.0 h1:ucWh9eiCGyDR3vtzso0WMQinm2Dnt8cFMuQa9K33J60=
 golang.org/x/net v0.50.0/go.mod h1:UgoSli3F/pBgdJBHCTc+tp3gmrU4XswgGRgtnwWTfyM=
 golang.org/x/text v0.34.0 h1:oL/Qq0Kdaqxa1KbNeMKwQq0reLCCaFtqu2eNuSeNHbk=

--- a/config/go.mod
+++ b/config/go.mod
@@ -2,7 +2,7 @@ module darvaza.org/x/config
 
 go 1.24.0
 
-require darvaza.org/core v0.19.0
+require darvaza.org/core v0.19.1
 
 require (
 	github.com/amery/defaults v0.1.0

--- a/config/go.sum
+++ b/config/go.sum
@@ -1,5 +1,5 @@
-darvaza.org/core v0.19.0 h1:vK56K+4DyvaiFjB5iifzt6BwsldDOWcV2Dut6H0T958=
-darvaza.org/core v0.19.0/go.mod h1:8+rhinVhCzJf814uPOYFRmj1D+8mO7bkbo/hrK0Lmkk=
+darvaza.org/core v0.19.1 h1:Ea6zFi2STXt4QC7Jbu1/unUo5Kd/OX65flZgeNw2iOY=
+darvaza.org/core v0.19.1/go.mod h1:8+rhinVhCzJf814uPOYFRmj1D+8mO7bkbo/hrK0Lmkk=
 github.com/amery/defaults v0.1.0 h1:4AhTgLUnj8BPjVRBzg4+/cSCwPWPT6+yWCM4rD6Feyc=
 github.com/amery/defaults v0.1.0/go.mod h1:duOYkvd60q8XOL1+vdSHx5ABTGDMU2iFKr5xJnMEpBk=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/container/go.mod
+++ b/container/go.mod
@@ -2,7 +2,7 @@ module darvaza.org/x/container
 
 go 1.24.0
 
-require darvaza.org/core v0.19.0
+require darvaza.org/core v0.19.1
 
 require (
 	golang.org/x/net v0.50.0 // indirect

--- a/container/go.sum
+++ b/container/go.sum
@@ -1,5 +1,5 @@
-darvaza.org/core v0.19.0 h1:vK56K+4DyvaiFjB5iifzt6BwsldDOWcV2Dut6H0T958=
-darvaza.org/core v0.19.0/go.mod h1:8+rhinVhCzJf814uPOYFRmj1D+8mO7bkbo/hrK0Lmkk=
+darvaza.org/core v0.19.1 h1:Ea6zFi2STXt4QC7Jbu1/unUo5Kd/OX65flZgeNw2iOY=
+darvaza.org/core v0.19.1/go.mod h1:8+rhinVhCzJf814uPOYFRmj1D+8mO7bkbo/hrK0Lmkk=
 golang.org/x/net v0.50.0 h1:ucWh9eiCGyDR3vtzso0WMQinm2Dnt8cFMuQa9K33J60=
 golang.org/x/net v0.50.0/go.mod h1:UgoSli3F/pBgdJBHCTc+tp3gmrU4XswgGRgtnwWTfyM=
 golang.org/x/text v0.34.0 h1:oL/Qq0Kdaqxa1KbNeMKwQq0reLCCaFtqu2eNuSeNHbk=

--- a/container/set/config.go
+++ b/container/set/config.go
@@ -56,11 +56,7 @@ func (cfg Config[K, H, T]) Init(set *Set[K, H, T], items ...T) error {
 
 // Must is equivalent to [New] but it panics on error.
 func (cfg Config[K, H, T]) Must(items ...T) *Set[K, H, T] {
-	set, err := cfg.New(items...)
-	if err != nil {
-		core.Panic(err)
-	}
-	return set
+	return core.Must(cfg.New(items...))
 }
 
 // Equal determines if two Config instances use exactly the same callback functions

--- a/container/slices/set_fn.go
+++ b/container/slices/set_fn.go
@@ -56,11 +56,7 @@ func NewCustomSet[T any](cmp func(T, T) int, initial ...T) (*CustomSet[T], error
 // MustCustomSet creates a new CustomSet, panicking if initialization fails.
 // This is a convenience function for when error handling is not needed.
 func MustCustomSet[T any](cmd func(T, T) int, initial ...T) *CustomSet[T] {
-	set, err := NewCustomSet(cmd, initial...)
-	if err != nil {
-		core.Panic(err)
-	}
-	return set
+	return core.Must(NewCustomSet(cmd, initial...))
 }
 
 // InitCustomSet initializes a pre-allocated CustomSet with thread-safe semantics.

--- a/fs/go.mod
+++ b/fs/go.mod
@@ -2,7 +2,7 @@ module darvaza.org/x/fs
 
 go 1.24.0
 
-require darvaza.org/core v0.19.0
+require darvaza.org/core v0.19.1
 
 require (
 	github.com/gobwas/glob v0.2.3

--- a/fs/go.sum
+++ b/fs/go.sum
@@ -1,5 +1,5 @@
-darvaza.org/core v0.19.0 h1:vK56K+4DyvaiFjB5iifzt6BwsldDOWcV2Dut6H0T958=
-darvaza.org/core v0.19.0/go.mod h1:8+rhinVhCzJf814uPOYFRmj1D+8mO7bkbo/hrK0Lmkk=
+darvaza.org/core v0.19.1 h1:Ea6zFi2STXt4QC7Jbu1/unUo5Kd/OX65flZgeNw2iOY=
+darvaza.org/core v0.19.1/go.mod h1:8+rhinVhCzJf814uPOYFRmj1D+8mO7bkbo/hrK0Lmkk=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 golang.org/x/net v0.50.0 h1:ucWh9eiCGyDR3vtzso0WMQinm2Dnt8cFMuQa9K33J60=

--- a/internal/build/README-coverage.md
+++ b/internal/build/README-coverage.md
@@ -13,7 +13,7 @@ The coverage system generates two types of coverage data:
 
 ## Prerequisites
 
-- Go 1.23 or later.
+- Go 1.24 or later.
 - A monorepo with modules defined in an index file (`.tmp/index`).
 - Make build system with generated rules.
 - Standard directory structure with modules as subdirectories.

--- a/internal/build/gen_mk.sh
+++ b/internal/build/gen_mk.sh
@@ -134,7 +134,7 @@ gen_make_targets() {
 \$(GO) mod tidy"
 		;;
 	test)
-		call="\$(GO) $cmd \$(GOTEST_FLAGS) ./..."
+		call="\$(GO) $cmd -count=1 \$(GOTEST_FLAGS) ./..."
 		;;
 	coverage)
 		call="\$(TOOLSDIR)/make_coverage.sh \"$name\" \".\" \"\$(COVERAGE_DIR)\""

--- a/net/go.mod
+++ b/net/go.mod
@@ -3,7 +3,7 @@ module darvaza.org/x/net
 go 1.24.0
 
 require (
-	darvaza.org/core v0.19.0
+	darvaza.org/core v0.19.1
 	darvaza.org/slog v0.9.0
 	darvaza.org/slog/handlers/discard v0.7.0
 	darvaza.org/x/fs v0.6.0

--- a/net/go.sum
+++ b/net/go.sum
@@ -1,5 +1,5 @@
-darvaza.org/core v0.19.0 h1:vK56K+4DyvaiFjB5iifzt6BwsldDOWcV2Dut6H0T958=
-darvaza.org/core v0.19.0/go.mod h1:8+rhinVhCzJf814uPOYFRmj1D+8mO7bkbo/hrK0Lmkk=
+darvaza.org/core v0.19.1 h1:Ea6zFi2STXt4QC7Jbu1/unUo5Kd/OX65flZgeNw2iOY=
+darvaza.org/core v0.19.1/go.mod h1:8+rhinVhCzJf814uPOYFRmj1D+8mO7bkbo/hrK0Lmkk=
 darvaza.org/slog v0.9.0 h1:4rDJ157J2OPhV66hulXkCZRlAPOBkULowgXtJmJZEs8=
 darvaza.org/slog v0.9.0/go.mod h1:k2vMkKtZNGXo46uo+YVIsFZa4oYQqvvI6Y6IE1h9QHM=
 darvaza.org/slog/handlers/discard v0.7.0 h1:iqALaFsTCPs5roN17chwAd/9VVA+8Xq00EUlxte2zKQ=

--- a/net/reconnect/client.go
+++ b/net/reconnect/client.go
@@ -119,11 +119,7 @@ func New(cfg *Config, options ...OptionFunc) (*Client, error) {
 
 // Must is like [New] but it panics on errors.
 func Must(cfg *Config, options ...OptionFunc) *Client {
-	c, err := New(cfg, options...)
-	if err != nil {
-		core.Panic(err)
-	}
-	return c
+	return core.Must(New(cfg, options...))
 }
 
 func (c *Client) getRemote() (network, addr string) {

--- a/sync/cond/barrier.go
+++ b/sync/cond/barrier.go
@@ -24,9 +24,7 @@ type Barrier struct {
 // initialisation fails. It returns a fully initialised Barrier ready for use.
 func NewBarrier() *Barrier {
 	c := &Barrier{}
-	if err := c.Init(); err != nil {
-		core.Panic(err)
-	}
+	core.MustNoError(c.Init())
 	return c
 }
 

--- a/sync/cond/count.go
+++ b/sync/cond/count.go
@@ -39,9 +39,7 @@ type Count struct {
 // and it's self closing.
 func NewCount(initialValue int, broadcast ...func(int32) bool) *Count {
 	c := new(Count)
-	if err := c.doInit(initialValue, broadcast); err != nil {
-		core.Panic(err)
-	}
+	core.MustNoError(c.doInit(initialValue, broadcast))
 
 	runtime.SetFinalizer(c, func(c *Count) {
 		_ = c.b.Close()

--- a/sync/go.mod
+++ b/sync/go.mod
@@ -2,7 +2,7 @@ module darvaza.org/x/sync
 
 go 1.24.0
 
-require darvaza.org/core v0.19.0
+require darvaza.org/core v0.19.1
 
 require github.com/stretchr/testify v1.10.0
 

--- a/sync/go.sum
+++ b/sync/go.sum
@@ -1,5 +1,5 @@
-darvaza.org/core v0.19.0 h1:vK56K+4DyvaiFjB5iifzt6BwsldDOWcV2Dut6H0T958=
-darvaza.org/core v0.19.0/go.mod h1:8+rhinVhCzJf814uPOYFRmj1D+8mO7bkbo/hrK0Lmkk=
+darvaza.org/core v0.19.1 h1:Ea6zFi2STXt4QC7Jbu1/unUo5Kd/OX65flZgeNw2iOY=
+darvaza.org/core v0.19.1/go.mod h1:8+rhinVhCzJf814uPOYFRmj1D+8mO7bkbo/hrK0Lmkk=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/text/go.mod
+++ b/text/go.mod
@@ -2,7 +2,7 @@ module darvaza.org/x/text
 
 go 1.24.0
 
-require darvaza.org/core v0.19.0
+require darvaza.org/core v0.19.1
 
 require (
 	golang.org/x/net v0.50.0 // indirect

--- a/text/go.sum
+++ b/text/go.sum
@@ -1,5 +1,5 @@
-darvaza.org/core v0.19.0 h1:vK56K+4DyvaiFjB5iifzt6BwsldDOWcV2Dut6H0T958=
-darvaza.org/core v0.19.0/go.mod h1:8+rhinVhCzJf814uPOYFRmj1D+8mO7bkbo/hrK0Lmkk=
+darvaza.org/core v0.19.1 h1:Ea6zFi2STXt4QC7Jbu1/unUo5Kd/OX65flZgeNw2iOY=
+darvaza.org/core v0.19.1/go.mod h1:8+rhinVhCzJf814uPOYFRmj1D+8mO7bkbo/hrK0Lmkk=
 golang.org/x/net v0.50.0 h1:ucWh9eiCGyDR3vtzso0WMQinm2Dnt8cFMuQa9K33J60=
 golang.org/x/net v0.50.0/go.mod h1:UgoSli3F/pBgdJBHCTc+tp3gmrU4XswgGRgtnwWTfyM=
 golang.org/x/text v0.34.0 h1:oL/Qq0Kdaqxa1KbNeMKwQq0reLCCaFtqu2eNuSeNHbk=

--- a/tls/go.mod
+++ b/tls/go.mod
@@ -3,7 +3,7 @@ module darvaza.org/x/tls
 go 1.24.0
 
 require (
-	darvaza.org/core v0.19.0
+	darvaza.org/core v0.19.1
 	darvaza.org/slog v0.9.0
 	darvaza.org/x/container v0.4.0
 )

--- a/tls/go.sum
+++ b/tls/go.sum
@@ -1,5 +1,5 @@
-darvaza.org/core v0.19.0 h1:vK56K+4DyvaiFjB5iifzt6BwsldDOWcV2Dut6H0T958=
-darvaza.org/core v0.19.0/go.mod h1:8+rhinVhCzJf814uPOYFRmj1D+8mO7bkbo/hrK0Lmkk=
+darvaza.org/core v0.19.1 h1:Ea6zFi2STXt4QC7Jbu1/unUo5Kd/OX65flZgeNw2iOY=
+darvaza.org/core v0.19.1/go.mod h1:8+rhinVhCzJf814uPOYFRmj1D+8mO7bkbo/hrK0Lmkk=
 darvaza.org/slog v0.9.0 h1:4rDJ157J2OPhV66hulXkCZRlAPOBkULowgXtJmJZEs8=
 darvaza.org/slog v0.9.0/go.mod h1:k2vMkKtZNGXo46uo+YVIsFZa4oYQqvvI6Y6IE1h9QHM=
 darvaza.org/x/container v0.4.0 h1:p2Jq1vZcYLCD58pg+wZHNbw78+u6kaw2Zt8t/JB9P3A=

--- a/web/assets/json.go
+++ b/web/assets/json.go
@@ -62,9 +62,5 @@ func NewJSONAssetHandler[T any](d time.Duration, v T) (http.Handler, error) {
 // MustJSONAssetHandler creates an [AssetHandler] serving a constant JSON resource,
 // and panics if marshalling fails.
 func MustJSONAssetHandler[T any](d time.Duration, v T) http.Handler {
-	h, err := NewJSONAssetHandler(d, v)
-	if err != nil {
-		core.Panic(err)
-	}
-	return h
+	return core.Must(NewJSONAssetHandler(d, v))
 }

--- a/web/go.mod
+++ b/web/go.mod
@@ -3,7 +3,7 @@ module darvaza.org/x/web
 go 1.24.0
 
 require (
-	darvaza.org/core v0.19.0
+	darvaza.org/core v0.19.1
 	darvaza.org/x/fs v0.6.0
 )
 

--- a/web/go.sum
+++ b/web/go.sum
@@ -1,5 +1,5 @@
-darvaza.org/core v0.19.0 h1:vK56K+4DyvaiFjB5iifzt6BwsldDOWcV2Dut6H0T958=
-darvaza.org/core v0.19.0/go.mod h1:8+rhinVhCzJf814uPOYFRmj1D+8mO7bkbo/hrK0Lmkk=
+darvaza.org/core v0.19.1 h1:Ea6zFi2STXt4QC7Jbu1/unUo5Kd/OX65flZgeNw2iOY=
+darvaza.org/core v0.19.1/go.mod h1:8+rhinVhCzJf814uPOYFRmj1D+8mO7bkbo/hrK0Lmkk=
 darvaza.org/x/fs v0.6.0 h1:aCpfoFxji3l5S8RlfJJ+EPUnLAPPghkSwzumOG0TFMQ=
 darvaza.org/x/fs v0.6.0/go.mod h1:j/Foi0YnxEpMU0ynhJHecD2F22w3Q8G7yMKXv8OtJZc=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=


### PR DESCRIPTION
# Adopt core Must/MustNoError; bump core to v0.19.1

Adopts `darvaza.org/core`'s `Must*` precondition helpers at five
`Must<X>` factory sites and bumps the core dependency across the
nine sibling modules. Carries two small unrelated maintenance
commits at the bottom of the lineage (`make test` cache bypass,
Go-floor doc sweep).

## Behaviour changes

The five refactored factories continue to panic on the same input
shapes as before, but the panic payload now routes through
`*core.PanicError` instead of being a raw `error`:

| Site | Helper | Annotation |
|---|---|---|
| `sync/cond.NewBarrier` | `core.MustNoError` | `core.ErrUnreachable` |
| `sync/cond.NewCount` | `core.MustNoError` | `core.ErrUnreachable` |
| `container/set.Config.Must` | `core.Must` | `"core.Must"` note |
| `container/slices.MustCustomSet` | `core.Must` | `"core.Must"` note |
| `net/reconnect.Must` | `core.Must` | `"core.Must"` note |
| `web/assets.MustJSONAssetHandler` | `core.Must` | `"core.Must"` note |

`errors.Is(recovered, sentinel)` matching against the original
error is unaffected — `*PanicError` and `*WrappedError` both
unwrap cleanly. Only direct type-assertion-based recovery (e.g.
asserting the recovered panic value as a specific concrete error
type) would observe the extra wrap layer.

## Dependency bump

`build: bump darvaza.org/core to v0.19.1` updates nine `go.mod`
/ `go.sum` pairs: cmp, config, container, fs, net, sync, text,
tls, web. Core v0.19.1 is required for the `MustNoError` family
used by `refactor(sync/cond): use core.MustNoError in
constructors`; the four `core.Must` adoptions reuse helpers that
have existed since core v0.18.0.

## Tooling and docs

- The `make test` cache-bypass commit adds `-count=1` to the
  generated `test` rule so an explicit `make test` invocation
  actually re-executes instead of returning cached results. `race`
  already carried the flag.
- The Go-floor docs sweep brings AGENTS.md, RELEASE.md, and
  `internal/build/README-coverage.md` in line with the `go 1.24.0`
  floor every module already declares, and updates the CI matrix
  description to mirror the workflow YAML.

## Test plan

`make all test race` clean locally across all nine modules; CI
green on this branch's tip.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimum Go version requirement from 1.23 to 1.24 across documentation and CI test matrix.
  * Updated `darvaza.org/core` dependency from v0.19.0 to v0.19.1 across all modules.

* **Refactor**
  * Simplified error handling in various initialization functions by delegating to utility helpers.
  * Added caching flag to test invocations for consistent behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/darvaza-proxy/x/pull/280?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->