### PR TITLE
fix(net/reconnect): reliable shutdown and reconnection lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ graph TB
     %% x/ Tier 2 dependencies
     fs --> net
     fs --> web
+    sync --> net
     container --> tls
     slog --> net
     slog --> tls
@@ -176,7 +177,8 @@ graph TB
   * Depend only on core libraries and standard library
 
 * **Tier 2 Packages**: Depend on Tier 1 packages
-  * `net` and `web` depend on `fs`
+  * `net` depends on `fs` and `sync`
+  * `web` depends on `fs`
   * `tls` depends on `container`
   * Must be released after their dependencies
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,8 +7,8 @@ including dependency order and procedures to ensure consistent releases.
 
 ### Release Order
 
-1. **Tier 1** (independent): cmp, config, sync, fs, container
-2. **Tier 2** (dependent): net (→fs), web (→fs), tls (→container)
+1. **Tier 1** (independent): cmp, config, sync, fs, container, text
+2. **Tier 2** (dependent): net (→fs, sync), web (→fs), tls (→container)
 
 ### Essential Commands
 
@@ -33,24 +33,22 @@ go -C package mod tidy
 The following diagram shows the internal dependencies between packages:
 
 ```text
-                Tier 1 - Independent packages:
-┌─────────────┐ ┌──────────────┐ ┌─────────────┐
-│     cmp     │ │    config    │ │     sync    │
-│  (no deps)  │ │  (no deps)   │ │  (no deps)  │
-└─────────────┘ └──────────────┘ └─────────────┘
+        Tier 1 - Independent packages:
+┌─────────┐ ┌─────────┐ ┌───────────┐
+│   cmp   │ │ config  │ │   text    │
+└─────────┘ └─────────┘ └───────────┘
 
-┌─────────────┐                  ┌─────────────┐
-│     fs      │                  │  container  │
-│  (no deps)  │                  │  (no deps)  │
-└──────┬──────┘                  └──────┬──────┘
-       │                                │
-       ├─────────────┐                  │
-       ▼             ▼                  ▼
-┌─────────┐   ┌─────────┐       ┌─────────────┐
-│   net   │   │   web   │       │     tls     │
-└─────────┘   └─────────┘       └─────────────┘
-
-                Tier 2 - Dependent packages
+┌─────────┐ ┌─────────┐ ┌───────────┐
+│   fs    │ │  sync   │ │ container │
+└────┬────┘ └────┬────┘ └─────┬─────┘
+     │           │            │
+     ├───────┐   │            │
+     │       │   │            │
+     ▼       ▼   ▼            ▼
+┌───────┐ ┌─────────┐  ┌───────────┐
+│  web  │ │   net   │  │    tls    │
+└───────┘ └─────────┘  └───────────┘
+        Tier 2 - Dependent packages
 ```
 
 ## Release Tiers
@@ -68,13 +66,14 @@ be released in any order or simultaneously:
 - **darvaza.org/x/sync**
 - **darvaza.org/x/fs**
 - **darvaza.org/x/container**
+- **darvaza.org/x/text**
 
 ### Tier 2 - Dependent Packages
 
 These packages depend on Tier 1 packages and must be released after their
 dependencies:
 
-- **darvaza.org/x/net** (depends on fs)
+- **darvaza.org/x/net** (depends on fs and sync)
 - **darvaza.org/x/web** (depends on fs)
 - **darvaza.org/x/tls** (depends on container)
 
@@ -90,7 +89,7 @@ Before starting the release process:
 - [ ] Review and update CHANGELOG.md for each package (when present)
 - [ ] Ensure all documentation is up to date
 - [ ] Check current versions:
-  `git tag --list | grep -E "^(cmp|config|sync|fs|container)/" | sort -V`
+  `git tag --list | grep -E "^(cmp|config|sync|fs|container|text)/" | sort -V`
 - [ ] Verify no uncommitted changes: `git status`
 
 ### 2. Tier 1 Release
@@ -99,7 +98,7 @@ Before starting the release process:
 
    ```bash
    # List current tags
-   git tag --list | grep -E "^(cmp|config|sync|fs|container)/" | sort -V
+   git tag --list | grep -E "^(cmp|config|sync|fs|container|text)/" | sort -V
    ```
 
 2. Create signed annotated tags with comprehensive release notes:
@@ -134,7 +133,7 @@ Before starting the release process:
 3. Push all tags at once:
 
    ```bash
-   git push origin cmp/v0.2.2 config/v0.5.1 sync/v0.3.1 fs/v0.5.3 container/v0.3.2
+   git push origin cmp/v0.2.2 config/v0.5.1 sync/v0.3.1 fs/v0.5.3 container/v0.3.2 text/v0.1.0
    ```
 
 4. Wait for pkg.go.dev to index the new versions (usually 5-10 minutes).
@@ -153,6 +152,7 @@ Before starting the release process:
    go get darvaza.org/x/sync@v0.3.1
    go get darvaza.org/x/fs@v0.5.3
    go get darvaza.org/x/container@v0.3.2
+   go get darvaza.org/x/text@v0.1.0
    \`\`\`"
    ```
 

--- a/net/AGENTS.md
+++ b/net/AGENTS.md
@@ -46,7 +46,9 @@ For detailed API documentation and usage examples, see [README.md](README.md).
 - `bind/listen.go`: TCP/UDP listener creation.
 - `reconnect/client.go`: Reconnecting client implementation.
 - `reconnect/config.go`: Client configuration.
+- `reconnect/stream.go`: Generic message-based stream sessions.
 - `reconnect/utils.go`: Network address parsing and validation utilities.
+- `reconnect/waiter.go`: Reconnection wait strategies.
 - `reconnect/worker.go`: Background worker management.
 
 ## Architecture Notes
@@ -103,20 +105,21 @@ for _, l := range listeners {
 
 ```go
 cfg := &reconnect.Config{
-    Address: "server:9000",
-    DialTimeout: 5 * time.Second,
-    RetryWait: 1 * time.Second,
-    RetryBackoff: true,
+    Remote:         "server:9000",
+    Logger:         logger,
+    DialTimeout:    5 * time.Second,
+    ReconnectDelay: time.Second,
 }
 
-client := reconnect.NewClient(cfg,
-    reconnect.WithLogger(logger),
-    reconnect.WithOnConnect(onConnect),
-    reconnect.WithOnError(onError),
-)
+client, err := reconnect.New(cfg)
+if err != nil {
+    return err
+}
 
-// Start client with automatic reconnection
-err := client.Spawn(ctx)
+// Start the reconnection loop.
+if err := client.Connect(); err != nil {
+    return err
+}
 ```
 
 ### Socket Control
@@ -134,26 +137,31 @@ ln, err := bind.ListenTCP("tcp", addr, control)
 ### Connection Lifecycle
 
 ```go
-client := reconnect.NewClient(cfg,
-    reconnect.WithOnConnect(func(ctx context.Context, conn net.Conn) error {
-        // Initialize connection
+cfg := &reconnect.Config{
+    Remote: "server:9000",
+
+    OnConnect: func(ctx context.Context, conn net.Conn) error {
+        // Initialise the connection.
         return nil
-    }),
-    reconnect.WithOnSession(func(ctx context.Context) error {
-        // Handle active session
+    },
+    OnSession: func(ctx context.Context) error {
+        // Handle the active session; block until done.
         return nil
-    }),
-    reconnect.WithOnDisconnect(func(ctx context.Context, conn net.Conn) error {
-        // Cleanup on disconnect
+    },
+    OnDisconnect: func(ctx context.Context, conn net.Conn) error {
+        // Clean up after the connection has been closed.
         return nil
-    }),
-)
+    },
+}
+
+client, err := reconnect.New(cfg)
 ```
 
 ## Performance Characteristics
 
 - **Bind**: O(n) for n interfaces/addresses.
-- **Reconnect**: Exponential backoff available for retry delays.
+- **Reconnect**: Constant retry delay by default; custom `Waiter`
+  functions for other strategies.
 - **Socket Control**: Minimal overhead on socket creation.
 
 ## Dependencies

--- a/net/go.mod
+++ b/net/go.mod
@@ -7,6 +7,7 @@ require (
 	darvaza.org/slog v0.9.1
 	darvaza.org/slog/handlers/discard v0.7.1
 	darvaza.org/x/fs v0.6.0
+	darvaza.org/x/sync v0.4.2
 	github.com/amery/defaults v0.1.0
 )
 

--- a/net/go.sum
+++ b/net/go.sum
@@ -6,6 +6,8 @@ darvaza.org/slog/handlers/discard v0.7.1 h1:6n51g+U1upXjC2c91+3dd2e1Lnveun4pF2if
 darvaza.org/slog/handlers/discard v0.7.1/go.mod h1:hiLBlPPGV3ZKzg8diHz5Hpi0JvFfFcdb/1KjauLZv10=
 darvaza.org/x/fs v0.6.0 h1:aCpfoFxji3l5S8RlfJJ+EPUnLAPPghkSwzumOG0TFMQ=
 darvaza.org/x/fs v0.6.0/go.mod h1:j/Foi0YnxEpMU0ynhJHecD2F22w3Q8G7yMKXv8OtJZc=
+darvaza.org/x/sync v0.4.2 h1:woByoWCNWfZXa7kaeB8AzAtlEC8qFX4CsKyN21x60fY=
+darvaza.org/x/sync v0.4.2/go.mod h1:mxbx7HHX7IQeR3wHCJVFy/vr4ouDiRn3QFNTI7/F5mE=
 github.com/amery/defaults v0.1.0 h1:4AhTgLUnj8BPjVRBzg4+/cSCwPWPT6+yWCM4rD6Feyc=
 github.com/amery/defaults v0.1.0/go.mod h1:duOYkvd60q8XOL1+vdSHx5ABTGDMU2iFKr5xJnMEpBk=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=

--- a/net/reconnect/README.md
+++ b/net/reconnect/README.md
@@ -34,10 +34,8 @@ resource clean-up.
 ```go
 import (
     "context"
-    "net"
     "time"
 
-    "darvaza.org/slog"
     "darvaza.org/x/net/reconnect"
 )
 
@@ -104,6 +102,12 @@ cfg := &reconnect.Config{
     Remote: "./app.sock",
     // ... other configuration
 }
+
+// Abstract Unix socket with @ prefix (Linux, auto-detected)
+cfg := &reconnect.Config{
+    Remote: "@app",
+    // ... other configuration
+}
 ```
 
 ## Advanced Configuration
@@ -147,19 +151,21 @@ cfg := &reconnect.Config{
         return handleSession(ctx)
     },
 
-    // Called when connection is about to close.
+    // Called after the connection has been closed.
     OnDisconnect: func(ctx context.Context, conn net.Conn) error {
-        logger.Info().Printf("Disconnecting from %s", conn.RemoteAddr())
+        logger.Info().Printf("Disconnected from %s", conn.RemoteAddr())
         // Clean up connection-specific resources.
         return nil
     },
 
-    // Called when errors occur.
+    // Called when errors occur. The returned error replaces the
+    // original for the reconnection logic.
     OnError: func(ctx context.Context, conn net.Conn, err error) error {
         logger.Error().
             WithField("error", err).
             Printf("Connection error")
-        // Return nil to allow retry, non-nil to stop reconnection.
+        // Return nil to discard the error and keep retrying,
+        // or reconnect.ErrDoNotReconnect to stop the client.
         return nil
     },
 }
@@ -208,10 +214,10 @@ The `Config` structure supports the following fields:
 | `Remote` | `string` | Required | Target address. TCP: `host:port`, Unix: `/path/to/socket` or `unix:/path` |
 | `KeepAlive` | `time.Duration` | `5s` | TCP keep-alive interval (ignored for Unix sockets). |
 | `DialTimeout` | `time.Duration` | `2s` | Connection establishment timeout. |
-| `ReadTimeout` | `time.Duration` | `2s` | Read deadline for connections. |
-| `WriteTimeout` | `time.Duration` | `2s` | Write deadline for connections. |
-| `ReconnectDelay` | `time.Duration` | `0` | Delay between reconnection attempts. |
-| `WaitReconnect` | `Waiter` | Constant waiter | Custom reconnection wait function. |
+| `ReadTimeout` | `time.Duration` | `2s` | Default read deadline, applied via the `Reset*Deadline` helpers, not automatically. |
+| `WriteTimeout` | `time.Duration` | `2s` | Default write deadline, applied via the `Reset*Deadline` helpers, not automatically. |
+| `ReconnectDelay` | `time.Duration` | `0` | Delay between reconnection attempts. Zero means 5s (`DefaultWaitReconnect`); negative disables reconnection. |
+| `WaitReconnect` | `Waiter` | `NewConstantWaiter(ReconnectDelay)` | Custom reconnection wait function. |
 | `OnSocket` | `func` | `nil` | Raw socket configuration callback. |
 | `OnConnect` | `func` | `nil` | Connection establishment callback. |
 | `OnSession` | `func` | `nil` | Session handler (blocks until done). |
@@ -226,7 +232,8 @@ The `Config` structure supports the following fields:
 // New creates a new Client with options.
 func New(cfg *Config, options ...OptionFunc) (*Client, error)
 
-// Connect initiates the connection and starts the reconnection loop.
+// Connect starts the reconnection loop. A nil return doesn't mean
+// a connection is established, only that the loop has started.
 func (c *Client) Connect() error
 
 // Config returns the configuration object.
@@ -236,13 +243,14 @@ func (c *Client) Config() *Config
 // Note: Currently returns ErrTODO.
 func (c *Client) Reload() error
 
-// Wait blocks until the client stops and returns the cancellation reason.
+// Wait blocks until the client stops and returns the cancellation
+// reason, nil when the shutdown was user-initiated.
 func (c *Client) Wait() error
 
 // Err returns the cancellation reason.
 func (c *Client) Err() error
 
-// Done returns a channel that watches the client workers.
+// Done returns a channel that closes once the client has stopped.
 func (c *Client) Done() <-chan struct{}
 
 // Shutdown initiates a shutdown and waits until done or context timeout.
@@ -312,8 +320,15 @@ var (
     ErrConfigBusy = core.QuietWrap(fs.ErrPermission,
         "config already in use")
 
-    // ErrRunning indicates the client is already running.
-    ErrRunning = errors.New("already running")
+    // ErrRunning indicates the client has already been started.
+    ErrRunning = core.QuietWrap(syscall.EBUSY,
+        "client already running")
+
+    // ErrDoNotReconnect tells the client to stop reconnecting.
+    ErrDoNotReconnect = errors.New("don't reconnect")
+
+    // ErrNotConnected indicates the client isn't currently connected.
+    ErrNotConnected = core.QuietWrap(fs.ErrClosed, "not connected")
 
     // Additional errors defined in the errors.go file.
 )
@@ -321,12 +336,15 @@ var (
 
 ### Error Classification
 
-- **Recoverable**: Network timeouts, connection refused, temporary failures.
-- **Non-recoverable**: Context cancellation, configuration errors, explicit
-  stop requests.
+- **Fatal**: `ErrDoNotReconnect`, possibly wrapped, terminates the client.
+- **Context termination**: the client stops retrying once its context is
+  cancelled or its deadline expires.
+- **Recoverable**: everything else — connection refused/reset/aborted,
+  timeouts, and other session errors — leads to a reconnection attempt.
 
-The `OnError` callback can override the default retry behaviour by returning
-a non-nil error to stop reconnection attempts.
+The `OnError` callback observes every error, and its return value replaces
+it: return `nil` to discard the error, or `ErrDoNotReconnect` to stop the
+client.
 
 ## Thread Safety
 
@@ -343,9 +361,9 @@ reuse a configuration for another client returns `ErrConfigBusy`.
 
 The client properly manages resources:
 
-- Connections are automatically closed on errors.
+- Connections are closed at the end of each session.
 - Goroutines are cleaned up on shutdown.
-- Context cancellation is propagated throughout.
+- Context cancellation is propagated to callbacks and workers.
 - The `Wait()` method ensures proper shutdown sequencing.
 
 ## Helper Functions
@@ -398,9 +416,10 @@ The `OnSession` callback should:
 
 - Block until the session is complete.
 - Handle all protocol-specific logic.
-- Return `nil` to trigger reconnection on completion.
-- Return an error to stop reconnection.
-- Respect context cancellation.
+- Return `nil` or a non-fatal error to trigger reconnection.
+- Return `ErrDoNotReconnect`, possibly wrapped, to stop the client.
+- Respect context cancellation — shutdown doesn't close the connection
+  on its own.
 
 ## Integration with darvaza.org/x/net
 
@@ -452,7 +471,7 @@ func createClient(addr string) (*reconnect.Client, error) {
                 return nil
             }
             // Stop on permanent errors.
-            return err
+            return reconnect.ErrDoNotReconnect
         },
     }
 
@@ -510,10 +529,7 @@ string:
 | Pattern | Network Type | Example |
 | --- | --- | --- |
 | `unix:` prefix | Unix socket | `unix:/var/run/app.sock` |
+| `@` prefix | Unix socket (abstract namespace, Linux) | `@app` |
 | Absolute path (`/`) | Unix socket | `/tmp/socket` |
 | Ends with `.sock` | Unix socket | `./app.sock`, `run/app.sock` |
 | All others | TCP | `example.com:8080`, `192.168.1.1:443` |
-
-This implementation provides enterprise-grade reliability for both TCP and Unix
-domain socket connections whilst maintaining simplicity and flexibility for
-various use cases.

--- a/net/reconnect/README.md
+++ b/net/reconnect/README.md
@@ -314,25 +314,15 @@ The client distinguishes between recoverable and non-recoverable errors.
 
 ### Error Types
 
-```go
-var (
-    // ErrConfigBusy indicates the Config is already in use.
-    ErrConfigBusy = core.QuietWrap(fs.ErrPermission,
-        "config already in use")
+- `ErrConfigBusy`: the Config is already in use by another client.
+- `ErrRunning`: the client has already been started.
+- `ErrDoNotReconnect`: instructs the client to stop reconnecting.
+- `ErrClosed`: the client has already been shut down. It wraps
+  `darvaza.org/x/sync/errors.ErrClosed`, the workgroup's sentinel.
+- `ErrNotConnected`: the client isn't currently connected. It wraps
+  `ErrClosed`, so one `errors.Is` target covers both.
 
-    // ErrRunning indicates the client has already been started.
-    ErrRunning = core.QuietWrap(syscall.EBUSY,
-        "client already running")
-
-    // ErrDoNotReconnect tells the client to stop reconnecting.
-    ErrDoNotReconnect = errors.New("don't reconnect")
-
-    // ErrNotConnected indicates the client isn't currently connected.
-    ErrNotConnected = core.QuietWrap(fs.ErrClosed, "not connected")
-
-    // Additional errors defined in the errors.go file.
-)
-```
+See `errors.go` for the full list.
 
 ### Error Classification
 

--- a/net/reconnect/README.md
+++ b/net/reconnect/README.md
@@ -409,8 +409,8 @@ The `OnSession` callback should:
 - Handle all protocol-specific logic.
 - Return `nil` or a non-fatal error to trigger reconnection.
 - Return `ErrDoNotReconnect`, possibly wrapped, to stop the client.
-- Respect context cancellation — shutdown doesn't close the connection
-  on its own.
+- Respect context cancellation for a graceful wind-down; a session left
+  blocked on a read is unblocked by shutdown closing the connection.
 
 ## Integration with darvaza.org/x/net
 

--- a/net/reconnect/README.md
+++ b/net/reconnect/README.md
@@ -317,8 +317,9 @@ The client distinguishes between recoverable and non-recoverable errors.
 - `ErrConfigBusy`: the Config is already in use by another client.
 - `ErrRunning`: the client has already been started.
 - `ErrDoNotReconnect`: instructs the client to stop reconnecting.
-- `ErrClosed`: the client has already been shut down. It wraps
-  `darvaza.org/x/sync/errors.ErrClosed`, the workgroup's sentinel.
+- `ErrClosed`: the client or stream session has already been shut
+  down. It wraps `darvaza.org/x/sync/errors.ErrClosed`, the
+  workgroup's sentinel.
 - `ErrNotConnected`: the client isn't currently connected. It wraps
   `ErrClosed`, so one `errors.Is` target covers both.
 

--- a/net/reconnect/client.go
+++ b/net/reconnect/client.go
@@ -76,6 +76,25 @@ func (c *Client) Connect() error {
 		return err
 	}
 
+	// Enrol the connection-closing watcher before the run loop so a
+	// Shutdown (or a cancelled parent context) can unblock an OnSession
+	// parked on a deadline-less Read: cancelling the context does not
+	// interrupt the read, but closing the live connection does.
+	//
+	// If the group is already cancelled the enrolment fails; close the
+	// freshly dialled connection so it does not leak, and return
+	// ErrClosed — Connect's documented shut-down sentinel and the same
+	// value the run spawn below returns. ErrClosed wraps the group's
+	// errors.ErrClosed, so it satisfies a caller matching either; the
+	// bare err would only match the latter.
+	if err := c.wg.Go(func(ctx context.Context) {
+		<-ctx.Done()
+		c.closeConn()
+	}); err != nil {
+		unsafeClose(conn)
+		return ErrClosed
+	}
+
 	if err := c.wg.Go(func(context.Context) {
 		c.run(conn)
 	}); err != nil {
@@ -88,6 +107,16 @@ func (c *Client) Connect() error {
 	}
 
 	return nil
+}
+
+// closeConn closes the live connection, if any, ignoring the error.
+// It is how the cancellation watcher unblocks a session parked on a
+// blocking Read; the run loop still owns closing the connection on a
+// clean disconnection.
+func (c *Client) closeConn() {
+	if conn, _ := c.getConn(); conn != nil {
+		unsafeClose(conn)
+	}
 }
 
 // New creates a new [Client] using the given [Config] and options.

--- a/net/reconnect/client.go
+++ b/net/reconnect/client.go
@@ -44,7 +44,7 @@ type Client struct {
 	started atomic.Bool
 }
 
-// Config returns the [Config] object used when [Reload] is called.
+// Config returns the [Config] object used when [Client.Reload] is called.
 func (c *Client) Config() *Config {
 	return c.cfg
 }
@@ -59,7 +59,11 @@ func (c *Client) Reload() error {
 	return core.ErrTODO
 }
 
-// Connect launches the [Client].
+// Connect launches the [Client], failing with [ErrRunning] when
+// called more than once. A nil return means the reconnection loop
+// has started, not that a connection is established — a failed
+// first dial is retried in the background like any other
+// disconnection.
 func (c *Client) Connect() error {
 	// once
 	if !c.started.CompareAndSwap(false, true) {

--- a/net/reconnect/client.go
+++ b/net/reconnect/client.go
@@ -10,6 +10,7 @@ import (
 	"darvaza.org/core"
 	"darvaza.org/slog"
 	"darvaza.org/x/net"
+	"darvaza.org/x/sync/workgroup"
 )
 
 var (
@@ -19,8 +20,6 @@ var (
 // Client is a reconnecting network client.
 type Client struct {
 	ctx    context.Context
-	cancel context.CancelCauseFunc
-	err    error
 	conn   net.Conn
 	logger slog.Logger
 	cfg    *Config
@@ -35,8 +34,8 @@ type Client struct {
 	network string
 	address string
 
+	wg workgroup.Group
 	mu sync.Mutex
-	wg sync.WaitGroup
 
 	readTimeout  time.Duration
 	writeTimeout time.Duration
@@ -63,7 +62,8 @@ func (c *Client) Reload() error {
 // called more than once. A nil return means the reconnection loop
 // has started, not that a connection is established — a failed
 // first dial is retried in the background like any other
-// disconnection.
+// disconnection. Calling it on a [Client] that has already been
+// shut down fails with [ErrClosed].
 func (c *Client) Connect() error {
 	// once
 	if !c.started.CompareAndSwap(false, true) {
@@ -76,12 +76,16 @@ func (c *Client) Connect() error {
 		return err
 	}
 
-	c.wg.Add(1)
-	go func() {
-		defer c.wg.Done()
-
+	if err := c.wg.Go(func(context.Context) {
 		c.run(conn)
-	}()
+	}); err != nil {
+		// a concurrent Shutdown/terminate cancelled the group between
+		// the dial and the spawn; don't leak the freshly dialled
+		// connection, and report the client is shut down rather than
+		// leaking the workgroup's internal error.
+		unsafeClose(conn)
+		return ErrClosed
+	}
 
 	return nil
 }
@@ -93,12 +97,10 @@ func New(cfg *Config, options ...OptionFunc) (*Client, error) {
 		return nil, err
 	}
 
-	ctx, cancel := context.WithCancelCause(cfg.Context)
-
 	c := &Client{
-		ctx:    ctx,
-		cancel: cancel,
-
+		wg: workgroup.Group{
+			Parent: cfg.Context,
+		},
 		cfg:    cfg,
 		dialer: cfg.ExportDialer(),
 		logger: cfg.Logger,
@@ -112,6 +114,7 @@ func New(cfg *Config, options ...OptionFunc) (*Client, error) {
 		onDisconnect:  cfg.OnDisconnect,
 		onError:       cfg.OnError,
 	}
+	c.ctx = c.wg.Context()
 
 	c.network, c.address, err = ParseRemote(cfg.Remote)
 	if err != nil {

--- a/net/reconnect/client_conn.go
+++ b/net/reconnect/client_conn.go
@@ -40,17 +40,6 @@ func (c *Client) dial(network, addr string) (net.Conn, error) {
 	return conn, nil
 }
 
-// reconnect waits before dialling.
-func (c *Client) reconnect(network, addr string) (net.Conn, error) {
-	if fn := c.getWaitReconnect(); fn != nil {
-		if err := fn(c.ctx); err != nil {
-			return nil, err
-		}
-	}
-
-	return c.dial(network, addr)
-}
-
 // setConn prepares the Client to use the new net.Conn
 // and returns the previous, if any.
 func (c *Client) setConn(conn net.Conn) net.Conn {

--- a/net/reconnect/client_conn.go
+++ b/net/reconnect/client_conn.go
@@ -89,7 +89,7 @@ func (c *Client) ResetReadDeadline() error {
 	return c.SetReadDeadline(c.readTimeout)
 }
 
-// SetReadDeadline sets the connections' read deadline to
+// SetReadDeadline sets the connection's read deadline to
 // the specified duration. Use zero or negative to disable it.
 func (c *Client) SetReadDeadline(d time.Duration) error {
 	now := time.Now()
@@ -108,7 +108,7 @@ func (c *Client) ResetWriteDeadline() error {
 	return c.SetWriteDeadline(c.writeTimeout)
 }
 
-// SetWriteDeadline sets the connections' write deadline to
+// SetWriteDeadline sets the connection's write deadline to
 // the specified duration. Use zero or negative to disable it.
 func (c *Client) SetWriteDeadline(d time.Duration) error {
 	now := time.Now()
@@ -121,10 +121,10 @@ func (c *Client) SetWriteDeadline(d time.Duration) error {
 	return conn.SetWriteDeadline(t)
 }
 
-// SetDeadline sets the connections's read and write deadlines.
-// if write is zero but read is positive, write is set using the same
+// SetDeadline sets the connection's read and write deadlines.
+// If write is zero but read is positive, write is set using the same
 // value as read.
-// zero or negative can be used to disable the deadline.
+// Zero or negative can be used to disable the deadline.
 func (c *Client) SetDeadline(read, write time.Duration) error {
 	if read > 0 && write == 0 {
 		write = read
@@ -145,7 +145,7 @@ func (c *Client) SetDeadline(read, write time.Duration) error {
 	return conn.SetWriteDeadline(t)
 }
 
-// Read reads from the TCP connection, if connected.
+// Read reads from the current connection, if connected.
 func (c *Client) Read(p []byte) (int, error) {
 	conn, err := c.getConn()
 	if err != nil {
@@ -155,7 +155,7 @@ func (c *Client) Read(p []byte) (int, error) {
 	return conn.Read(p)
 }
 
-// Write writes to the TCP connection, if connected.
+// Write writes to the current connection, if connected.
 func (c *Client) Write(p []byte) (int, error) {
 	conn, err := c.getConn()
 	if err != nil {
@@ -165,7 +165,9 @@ func (c *Client) Write(p []byte) (int, error) {
 	return conn.Write(p)
 }
 
-// Close terminates the current connection
+// Close terminates the current connection, if any. The [Client]
+// keeps running and will reconnect; use [Client.Shutdown] to
+// stop it.
 func (c *Client) Close() error {
 	if conn, _ := c.getConn(); conn != nil {
 		return conn.Close()

--- a/net/reconnect/client_conn_test.go
+++ b/net/reconnect/client_conn_test.go
@@ -1,0 +1,201 @@
+package reconnect_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"darvaza.org/core"
+
+	"darvaza.org/x/net/reconnect"
+)
+
+// Compile-time verification that the test case type implements TestCase.
+var _ core.TestCase = notConnectedTestCase{}
+
+// notConnectedTestCase asserts how a Client connection accessor behaves
+// before any connection exists: the deadline and IO accessors report
+// ErrNotConnected, while Close is a no-op.
+type notConnectedTestCase struct {
+	call    func(*reconnect.Client) error
+	wantErr error
+	name    string
+}
+
+func newNotConnectedTestCase(name string,
+	call func(*reconnect.Client) error, wantErr error) notConnectedTestCase {
+	return notConnectedTestCase{
+		name:    name,
+		call:    call,
+		wantErr: wantErr,
+	}
+}
+
+func (tc notConnectedTestCase) Name() string { return tc.name }
+
+func (tc notConnectedTestCase) Test(t *testing.T) {
+	t.Helper()
+
+	c, err := reconnect.New(&reconnect.Config{
+		Context: context.Background(),
+		Remote:  addrUnused,
+	})
+	core.AssertMustNoError(t, err, "New")
+
+	err = tc.call(c)
+	if tc.wantErr != nil {
+		core.AssertErrorIs(t, err, tc.wantErr, tc.name)
+	} else {
+		core.AssertNoError(t, err, tc.name)
+	}
+}
+
+func notConnectedTestCases() []notConnectedTestCase {
+	return []notConnectedTestCase{
+		newNotConnectedTestCase("SetReadDeadline",
+			func(c *reconnect.Client) error { return c.SetReadDeadline(time.Second) },
+			reconnect.ErrNotConnected),
+		newNotConnectedTestCase("SetWriteDeadline",
+			func(c *reconnect.Client) error { return c.SetWriteDeadline(time.Second) },
+			reconnect.ErrNotConnected),
+		newNotConnectedTestCase("SetDeadline",
+			func(c *reconnect.Client) error { return c.SetDeadline(time.Second, time.Second) },
+			reconnect.ErrNotConnected),
+		newNotConnectedTestCase("ResetReadDeadline",
+			func(c *reconnect.Client) error { return c.ResetReadDeadline() },
+			reconnect.ErrNotConnected),
+		newNotConnectedTestCase("ResetWriteDeadline",
+			func(c *reconnect.Client) error { return c.ResetWriteDeadline() },
+			reconnect.ErrNotConnected),
+		newNotConnectedTestCase("ResetDeadline",
+			func(c *reconnect.Client) error { return c.ResetDeadline() },
+			reconnect.ErrNotConnected),
+		newNotConnectedTestCase("Read",
+			func(c *reconnect.Client) error {
+				_, err := c.Read(make([]byte, 1))
+				return err
+			}, reconnect.ErrNotConnected),
+		newNotConnectedTestCase("Write",
+			func(c *reconnect.Client) error {
+				_, err := c.Write([]byte("x"))
+				return err
+			}, reconnect.ErrNotConnected),
+		newNotConnectedTestCase("Close",
+			func(c *reconnect.Client) error { return c.Close() }, nil),
+	}
+}
+
+// TestClientConnNotConnected exercises every connection accessor on a
+// Client that was created but never connected.
+func TestClientConnNotConnected(t *testing.T) {
+	core.RunTestCases(t, notConnectedTestCases())
+
+	// the address accessors report nil rather than erroring when there
+	// is no connection.
+	c, err := reconnect.New(&reconnect.Config{
+		Context: context.Background(),
+		Remote:  addrUnused,
+	})
+	core.AssertMustNoError(t, err, "New")
+	core.AssertNil(t, c.RemoteAddr(), "RemoteAddr")
+	core.AssertNil(t, c.LocalAddr(), "LocalAddr")
+}
+
+// isTimeout reports whether err is a network timeout, the observable
+// effect of a read deadline elapsing on the live connection.
+func isTimeout(err error) bool {
+	var ne net.Error
+	return errors.As(err, &ne) && ne.Timeout()
+}
+
+// TestClientConnLiveSession drives the connection accessors against a
+// live session. OnSession runs after the Client stores the dialled
+// connection, so the accessors operate on the real socket: a write is
+// echoed back through Read, a short read deadline makes the next Read
+// time out, and Close tears the connection down. Assertions here run in
+// the Client's goroutine, so they use the non-fatal Assert* helpers.
+func TestClientConnLiveSession(t *testing.T) {
+	lsn, err := net.Listen("tcp", addrLoopbackAny)
+	core.AssertMustNoError(t, err, "listen")
+	defer func() { _ = lsn.Close() }()
+
+	// the peer echoes whatever the client writes.
+	go func() {
+		conn, err := lsn.Accept()
+		if err != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		_, _ = io.Copy(conn, conn)
+	}()
+
+	var c *reconnect.Client
+	done := make(chan struct{})
+
+	cfg := &reconnect.Config{
+		Context:       context.Background(),
+		Remote:        lsn.Addr().String(),
+		WaitReconnect: reconnect.NewDoNotReconnectWaiter(nil),
+
+		OnSession: func(context.Context) error {
+			defer close(done)
+
+			// the accessors see the live connection.
+			core.AssertNotNil(t, c.RemoteAddr(), "RemoteAddr")
+			core.AssertNotNil(t, c.LocalAddr(), "LocalAddr")
+
+			// SetDeadline with a zero write timeout substitutes the read
+			// value, so both deadlines stay generous and the round trip
+			// below succeeds within them.
+			core.AssertNoError(t, c.SetDeadline(2*time.Second, 0), "SetDeadline")
+
+			// a write is echoed straight back through Read.
+			_, err := c.Write([]byte("ping\n"))
+			core.AssertNoError(t, err, "Write")
+
+			buf := make([]byte, len("ping\n"))
+			_, err = io.ReadFull(c, buf)
+			core.AssertNoError(t, err, "Read")
+			core.AssertEqual(t, "ping\n", string(buf), "echo")
+
+			// the remaining deadline setters apply cleanly to the live
+			// connection.
+			core.AssertNoError(t, c.ResetDeadline(), "ResetDeadline")
+			core.AssertNoError(t, c.ResetReadDeadline(), "ResetReadDeadline")
+			core.AssertNoError(t, c.ResetWriteDeadline(), "ResetWriteDeadline")
+			core.AssertNoError(t, c.SetWriteDeadline(2*time.Second), "SetWriteDeadline")
+
+			// a short read deadline makes the next read time out, proving
+			// the deadline reached the live connection.
+			core.AssertNoError(t, c.SetReadDeadline(50*time.Millisecond),
+				"SetReadDeadline")
+			_, err = c.Read(buf)
+			core.AssertTrue(t, isTimeout(err), "Read times out")
+
+			// Close tears the live connection down.
+			core.AssertNoError(t, c.Close(), "Close")
+
+			// the connection stays stored after Close, so applying a
+			// deadline now surfaces the socket's error from the
+			// read-deadline arm rather than ErrNotConnected.
+			core.AssertError(t, c.SetDeadline(time.Second, 0),
+				"SetDeadline after Close")
+			return nil
+		},
+	}
+
+	c, err = reconnect.New(cfg)
+	core.AssertMustNoError(t, err, "New")
+	core.AssertMustNoError(t, c.Connect(), "Connect")
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("session did not run")
+	}
+
+	core.AssertNoError(t, c.Wait(), "Wait")
+}

--- a/net/reconnect/client_test.go
+++ b/net/reconnect/client_test.go
@@ -92,6 +92,64 @@ func TestClientOnSessionPanic(t *testing.T) {
 		"OnSession panic reported via OnError")
 }
 
+// TestClientShutdownUnblocksSession verifies Shutdown closes the live
+// connection so an OnSession parked on a blocking Read unwinds. Without
+// it, cancelling the context leaves the read parked, the run loop never
+// returns, and Shutdown blocks until its own deadline instead of
+// completing cleanly.
+func TestClientShutdownUnblocksSession(t *testing.T) {
+	lsn, err := net.Listen("tcp", addrLoopbackAny)
+	core.AssertMustNoError(t, err, "listen")
+	defer func() { _ = lsn.Close() }()
+
+	// accept and hold the peer open without ever writing, so the
+	// client's Read blocks until the connection is closed.
+	peerDone := make(chan struct{})
+	defer close(peerDone)
+	go func() {
+		conn, err := lsn.Accept()
+		if err != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		<-peerDone
+	}()
+
+	var c *reconnect.Client
+	var once sync.Once
+	reading := make(chan struct{})
+
+	cfg := &reconnect.Config{
+		Context: context.Background(),
+		Remote:  lsn.Addr().String(),
+
+		// stop after the session ends rather than redialling.
+		WaitReconnect: reconnect.NewDoNotReconnectWaiter(nil),
+
+		OnSession: func(context.Context) error {
+			once.Do(func() { close(reading) })
+			var buf [1]byte
+			_, err := c.Read(buf[:])
+			return err
+		},
+	}
+
+	c, err = reconnect.New(cfg)
+	core.AssertMustNoError(t, err, "New")
+	core.AssertMustNoError(t, c.Connect(), "Connect")
+
+	// the session is established and about to block on Read.
+	<-reading
+
+	// Shutdown's own deadline bounds the wait and, on success, only
+	// returns once the workers are done — so it both proves the parked
+	// Read was released and fails cleanly (DeadlineExceeded) on a
+	// regression rather than hanging the suite on an unbounded Wait.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	core.AssertNoError(t, c.Shutdown(ctx), "Shutdown")
+}
+
 // runTestClientConnectExpiredContext verifies Connect refuses to
 // start when the context deadline has already expired.
 func runTestClientConnectExpiredContext(t *testing.T) {

--- a/net/reconnect/client_test.go
+++ b/net/reconnect/client_test.go
@@ -3,6 +3,8 @@ package reconnect_test
 import (
 	"context"
 	"net"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -25,13 +27,34 @@ func newOnError(
 	}
 }
 
+// addrUnused is a placeholder Remote for a [reconnect.Client] that is
+// never dialled; only the Config field needs to be populated.
+const addrUnused = "127.0.0.1:1"
+
+// addrLoopbackAny asks the OS for any free loopback port, used to bring
+// up a real listener the client can dial.
+const addrLoopbackAny = "127.0.0.1:0"
+
+// acceptAndDrop accepts every connection on lsn and closes it at once,
+// until lsn is closed. Sessions that end themselves only need the
+// listener backlog kept drained.
+func acceptAndDrop(lsn net.Listener) {
+	for {
+		conn, err := lsn.Accept()
+		if err != nil {
+			return
+		}
+		_ = conn.Close()
+	}
+}
+
 // TestClientOnSessionPanic verifies a panic inside OnSession is
 // surfaced through OnError as a recovered error instead of being
 // silently swallowed as a clean session end.
 func TestClientOnSessionPanic(t *testing.T) {
 	errSessionPanic := errors.New("session panic sentinel")
 
-	lsn, err := net.Listen("tcp", "127.0.0.1:0")
+	lsn, err := net.Listen("tcp", addrLoopbackAny)
 	core.AssertMustNoError(t, err, "listen")
 	defer func() {
 		_ = lsn.Close()
@@ -74,7 +97,7 @@ func TestClientOnSessionPanic(t *testing.T) {
 func runTestClientConnectExpiredContext(t *testing.T) {
 	t.Helper()
 
-	lsn, err := net.Listen("tcp", "127.0.0.1:0")
+	lsn, err := net.Listen("tcp", addrLoopbackAny)
 	core.AssertMustNoError(t, err, "listen")
 	defer func() {
 		_ = lsn.Close()
@@ -103,7 +126,7 @@ func runTestClientConnectExpiredContext(t *testing.T) {
 func runTestClientDeadlineStopsReconnecting(t *testing.T) {
 	t.Helper()
 
-	lsn, err := net.Listen("tcp", "127.0.0.1:0")
+	lsn, err := net.Listen("tcp", addrLoopbackAny)
 	core.AssertMustNoError(t, err, "listen")
 	defer func() {
 		_ = lsn.Close()
@@ -140,4 +163,278 @@ func runTestClientDeadlineStopsReconnecting(t *testing.T) {
 func TestClientContextDeadline(t *testing.T) {
 	t.Run("expired at Connect", runTestClientConnectExpiredContext)
 	t.Run("expires during session", runTestClientDeadlineStopsReconnecting)
+}
+
+// TestClientWaiterErrorStops verifies a Waiter error stops the
+// client instead of busy-looping. Per the Waiter contract any error
+// means "stop reconnecting", even a non-fatal one that IsFatal would
+// otherwise let the connection retry. Regression test for the 100%
+// CPU spin where a custom non-fatal waiter error skipped the dial
+// yet never terminated the client.
+func TestClientWaiterErrorStops(t *testing.T) {
+	errStopWaiting := errors.New("waiter stop sentinel")
+
+	var waiterCalls atomic.Int32
+	waiter := func(ctx context.Context) error {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			waiterCalls.Add(1)
+			return errStopWaiting
+		}
+	}
+
+	// bind a port then release it, so the first dial fails
+	// non-fatally (ECONNREFUSED) and the run loop reaches the waiter.
+	lsn, err := net.Listen("tcp", addrLoopbackAny)
+	core.AssertMustNoError(t, err, "listen")
+	unreachableAddr := lsn.Addr().String()
+	core.AssertMustNoError(t, lsn.Close(), "close listener")
+
+	errs := new(errors.CompoundError)
+
+	cfg := &reconnect.Config{
+		Context:       context.Background(),
+		Remote:        unreachableAddr,
+		WaitReconnect: waiter,
+		OnError:       newOnError(errs),
+	}
+
+	c, err := reconnect.New(cfg)
+	core.AssertMustNoError(t, err, "New")
+	core.AssertMustNoError(t, c.Connect(), "Connect")
+
+	var stopped bool
+	select {
+	case <-c.Done():
+		stopped = true
+	case <-time.After(2 * time.Second):
+	}
+
+	core.AssertMustTrue(t, stopped, "stopped after waiter error")
+
+	// the waiter is consulted exactly once and its error ends the
+	// client; a regression would spin it without bound.
+	core.AssertEqual(t, 1, int(waiterCalls.Load()), "waiter calls")
+	core.AssertErrorIs(t, c.Wait(), errStopWaiting, "Wait")
+
+	// the waiter error must also reach OnError; errors.Is unwraps the
+	// CompoundError to inspect every error the hook collected.
+	core.AssertErrorIs(t, errs.AsError(), errStopWaiting,
+		"OnError observed the waiter error")
+}
+
+// TestClientParentCancelCause verifies that cancelling the parent
+// context surfaces its cause through Wait and Err. The pre-workgroup
+// lifecycle recorded a parent-context cancellation nowhere and
+// reported it as nil.
+func TestClientParentCancelCause(t *testing.T) {
+	errParentCause := errors.New("parent cancel sentinel")
+
+	lsn, err := net.Listen("tcp", addrLoopbackAny)
+	core.AssertMustNoError(t, err, "listen")
+	defer func() {
+		_ = lsn.Close()
+	}()
+
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
+
+	var once sync.Once
+	sessionReady := make(chan struct{})
+
+	cfg := &reconnect.Config{
+		Context: ctx,
+		Remote:  lsn.Addr().String(),
+
+		OnSession: func(ctx context.Context) error {
+			once.Do(func() { close(sessionReady) })
+			<-ctx.Done()
+			return ctx.Err()
+		},
+	}
+
+	c, err := reconnect.New(cfg)
+	core.AssertMustNoError(t, err, "New")
+	core.AssertMustNoError(t, c.Connect(), "Connect")
+
+	// once the session is live, cancel the parent with a custom cause.
+	var ready bool
+	select {
+	case <-sessionReady:
+		ready = true
+	case <-time.After(2 * time.Second):
+	}
+	core.AssertMustTrue(t, ready, "session started")
+	cancel(errParentCause)
+
+	var stopped bool
+	select {
+	case <-c.Done():
+		stopped = true
+	case <-time.After(2 * time.Second):
+	}
+	core.AssertMustTrue(t, stopped, "stopped after parent cancel")
+
+	core.AssertErrorIs(t, c.Wait(), errParentCause, "Wait")
+	core.AssertErrorIs(t, c.Err(), errParentCause, "Err")
+}
+
+// TestClientGoAfterShutdownNoop verifies Go and GoCatch are no-ops
+// once the client is shut down: the worker is dropped rather than run
+// with an already-cancelled context.
+func TestClientGoAfterShutdownNoop(t *testing.T) {
+	cfg := &reconnect.Config{
+		Context: context.Background(),
+		Remote:  addrUnused,
+	}
+
+	c, err := reconnect.New(cfg)
+	core.AssertMustNoError(t, err, "New")
+
+	// shut down before any work is submitted; with no workers Shutdown
+	// returns promptly and reports a clean, user-initiated stop.
+	core.AssertNoError(t, c.Shutdown(context.Background()), "Shutdown")
+
+	var ran atomic.Bool
+	worker := func(context.Context) error {
+		ran.Store(true)
+		return nil
+	}
+	c.Go(worker)
+	c.GoCatch(worker, nil)
+
+	// the drop is synchronous, so neither worker can have run.
+	core.AssertFalse(t, ran.Load(), "worker after shutdown dropped")
+}
+
+// TestClientConnectReturnsClosed verifies Connect reports ErrClosed,
+// not the workgroup's internal error, when a shutdown cancels the
+// group after the dial has a live connection but before the run loop
+// is enrolled. OnConnect provides that window deterministically.
+func TestClientConnectReturnsClosed(t *testing.T) {
+	lsn, err := net.Listen("tcp", addrLoopbackAny)
+	core.AssertMustNoError(t, err, "listen")
+	defer func() {
+		_ = lsn.Close()
+	}()
+
+	var c *reconnect.Client
+
+	cfg := &reconnect.Config{
+		Context: context.Background(),
+		Remote:  lsn.Addr().String(),
+
+		OnConnect: func(context.Context, net.Conn) error {
+			// cancel the group synchronously, with an already-expired
+			// deadline so Shutdown returns at once instead of waiting.
+			expired, cancel := context.WithCancel(context.Background())
+			cancel()
+			_ = c.Shutdown(expired)
+			return nil
+		},
+	}
+
+	c, err = reconnect.New(cfg)
+	core.AssertMustNoError(t, err, "New")
+
+	err = c.Connect()
+	core.AssertErrorIs(t, err, reconnect.ErrClosed, "Connect")
+}
+
+// Compile-time verification that the test case type implements TestCase.
+var _ core.TestCase = connectRejectTestCase{}
+
+// connectRejectTestCase drives handleConnectError's cancellation arm:
+// OnConnect rejects an established connection with a context
+// cancellation, which checkCancellation extracts from the dial error
+// so Connect surfaces it rather than treating it as retryable. The
+// returned error is the rejection itself, so no separate expectation
+// is declared — the invariant is asserted directly.
+type connectRejectTestCase struct {
+	reject error
+	name   string
+}
+
+func newConnectRejectTestCase(name string, reject error) connectRejectTestCase {
+	return connectRejectTestCase{name: name, reject: reject}
+}
+
+func (tc connectRejectTestCase) Name() string { return tc.name }
+
+func (tc connectRejectTestCase) Test(t *testing.T) {
+	t.Helper()
+
+	lsn, err := net.Listen("tcp", addrLoopbackAny)
+	core.AssertMustNoError(t, err, "listen")
+	defer func() { _ = lsn.Close() }()
+
+	go acceptAndDrop(lsn)
+
+	cfg := &reconnect.Config{
+		Context: context.Background(),
+		Remote:  lsn.Addr().String(),
+		OnConnect: func(context.Context, net.Conn) error {
+			return tc.reject
+		},
+	}
+
+	c, err := reconnect.New(cfg)
+	core.AssertMustNoError(t, err, "New")
+
+	// the cancellation carried by the dial error stops Connect, which
+	// surfaces exactly that error.
+	core.AssertErrorIs(t, c.Connect(), tc.reject, "Connect")
+}
+
+func connectRejectTestCases() []connectRejectTestCase {
+	return []connectRejectTestCase{
+		newConnectRejectTestCase("cancelled", context.Canceled),
+		newConnectRejectTestCase("deadline exceeded", context.DeadlineExceeded),
+	}
+}
+
+func TestClientConnectReject(t *testing.T) {
+	core.RunTestCases(t, connectRejectTestCases())
+}
+
+// TestClientConnectStopsWhenContextDone drives handleConnectError's
+// context-done arm: OnConnect shuts the client down and then rejects
+// the connection with a plain error that carries no cancellation of
+// its own. checkCancellation therefore does not fire, so it is the
+// already-cancelled client context that stops Connect from looping on
+// doomed reconnection attempts.
+func TestClientConnectStopsWhenContextDone(t *testing.T) {
+	errPlainReject := errors.New("plain reject sentinel")
+
+	lsn, err := net.Listen("tcp", addrLoopbackAny)
+	core.AssertMustNoError(t, err, "listen")
+	defer func() { _ = lsn.Close() }()
+
+	go acceptAndDrop(lsn)
+
+	var c *reconnect.Client
+
+	cfg := &reconnect.Config{
+		Context: context.Background(),
+		Remote:  lsn.Addr().String(),
+
+		OnConnect: func(context.Context, net.Conn) error {
+			// cancel the client first, with an already-cancelled context
+			// so Shutdown returns at once, then reject with a plain
+			// error that carries no cancellation itself.
+			done, cancel := context.WithCancel(context.Background())
+			cancel()
+			_ = c.Shutdown(done)
+			return errPlainReject
+		},
+	}
+
+	c, err = reconnect.New(cfg)
+	core.AssertMustNoError(t, err, "New")
+
+	// the cancelled context stops Connect; it surfaces the context
+	// error rather than the plain rejection or a reconnect spin.
+	core.AssertErrorIs(t, c.Connect(), context.Canceled, "Connect")
 }

--- a/net/reconnect/client_test.go
+++ b/net/reconnect/client_test.go
@@ -1,0 +1,69 @@
+package reconnect_test
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"darvaza.org/core"
+
+	"darvaza.org/x/net/reconnect"
+	"darvaza.org/x/sync/errors"
+)
+
+// newOnError returns a Config.OnError hook that records every error it
+// receives into errs, so a test can assert on them once the client stops.
+// errs is the concurrency-safe accumulator; the hook may fire from several
+// client goroutines at once.
+func newOnError(
+	errs *errors.CompoundError,
+) func(context.Context, net.Conn, error) error {
+	return func(_ context.Context, _ net.Conn, err error) error {
+		_ = errs.AppendError(err)
+		return err
+	}
+}
+
+// TestClientOnSessionPanic verifies a panic inside OnSession is
+// surfaced through OnError as a recovered error instead of being
+// silently swallowed as a clean session end.
+func TestClientOnSessionPanic(t *testing.T) {
+	errSessionPanic := errors.New("session panic sentinel")
+
+	lsn, err := net.Listen("tcp", "127.0.0.1:0")
+	core.AssertMustNoError(t, err, "listen")
+	defer func() {
+		_ = lsn.Close()
+	}()
+
+	errs := new(errors.CompoundError)
+
+	cfg := &reconnect.Config{
+		Context: context.Background(),
+		Remote:  lsn.Addr().String(),
+
+		// stop after the first session instead of retrying
+		WaitReconnect: reconnect.NewDoNotReconnectWaiter(nil),
+
+		OnSession: func(context.Context) error {
+			panic(errSessionPanic)
+		},
+		OnError: newOnError(errs),
+	}
+
+	c, err := reconnect.New(cfg)
+	core.AssertMustNoError(t, err, "New")
+	core.AssertMustNotNil(t, c, "client")
+
+	core.AssertMustNoError(t, c.Connect(), "Connect")
+
+	// the panic is not fatal, so the do-not-reconnect waiter stops
+	// the client and Wait reports a user-initiated shutdown.
+	core.AssertNoError(t, c.Wait(), "Wait")
+
+	// the sentinel only reaches OnError if the panic was recovered and
+	// surfaced there; a swallowed panic leaves errs empty. errors.Is unwraps
+	// the CompoundError to inspect every error it collected.
+	core.AssertErrorIs(t, errs.AsError(), errSessionPanic,
+		"OnSession panic reported via OnError")
+}

--- a/net/reconnect/client_test.go
+++ b/net/reconnect/client_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net"
 	"testing"
+	"time"
 
 	"darvaza.org/core"
 
@@ -66,4 +67,77 @@ func TestClientOnSessionPanic(t *testing.T) {
 	// the CompoundError to inspect every error it collected.
 	core.AssertErrorIs(t, errs.AsError(), errSessionPanic,
 		"OnSession panic reported via OnError")
+}
+
+// runTestClientConnectExpiredContext verifies Connect refuses to
+// start when the context deadline has already expired.
+func runTestClientConnectExpiredContext(t *testing.T) {
+	t.Helper()
+
+	lsn, err := net.Listen("tcp", "127.0.0.1:0")
+	core.AssertMustNoError(t, err, "listen")
+	defer func() {
+		_ = lsn.Close()
+	}()
+
+	ctx, cancel := context.WithDeadline(context.Background(),
+		time.Now().Add(-time.Second))
+	defer cancel()
+
+	cfg := &reconnect.Config{
+		Context: ctx,
+		Remote:  lsn.Addr().String(),
+	}
+
+	c, err := reconnect.New(cfg)
+	core.AssertMustNoError(t, err, "New")
+
+	err = c.Connect()
+	core.AssertError(t, err, "Connect")
+	core.AssertErrorIs(t, err, context.DeadlineExceeded, "Connect")
+}
+
+// runTestClientDeadlineStopsReconnecting verifies the client stops
+// instead of spinning on reconnection attempts once the context
+// deadline expires.
+func runTestClientDeadlineStopsReconnecting(t *testing.T) {
+	t.Helper()
+
+	lsn, err := net.Listen("tcp", "127.0.0.1:0")
+	core.AssertMustNoError(t, err, "listen")
+	defer func() {
+		_ = lsn.Close()
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(),
+		150*time.Millisecond)
+	defer cancel()
+
+	cfg := &reconnect.Config{
+		Context: ctx,
+		Remote:  lsn.Addr().String(),
+
+		OnSession: func(ctx context.Context) error {
+			<-ctx.Done()
+			return ctx.Err()
+		},
+	}
+
+	c, err := reconnect.New(cfg)
+	core.AssertMustNoError(t, err, "New")
+	core.AssertMustNoError(t, c.Connect(), "Connect")
+
+	var stopped bool
+	select {
+	case <-c.Done():
+		stopped = true
+	case <-time.After(5 * time.Second):
+	}
+
+	core.AssertMustTrue(t, stopped, "stopped after context deadline")
+}
+
+func TestClientContextDeadline(t *testing.T) {
+	t.Run("expired at Connect", runTestClientConnectExpiredContext)
+	t.Run("expires during session", runTestClientDeadlineStopsReconnecting)
 }

--- a/net/reconnect/client_test.go
+++ b/net/reconnect/client_test.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"sync"
 	"sync/atomic"
+	"syscall"
 	"testing"
 	"time"
 
@@ -495,4 +496,236 @@ func TestClientConnectStopsWhenContextDone(t *testing.T) {
 	// the cancelled context stops Connect; it surfaces the context
 	// error rather than the plain rejection or a reconnect spin.
 	core.AssertErrorIs(t, c.Connect(), context.Canceled, "Connect")
+}
+
+// newReconnectWaiter returns a Waiter that permits the first `permit`
+// reconnect attempts and then returns stop, alongside a counter of how
+// many times it was consulted. A cancelled context always wins.
+func newReconnectWaiter(permit int32, stop error) (
+	func(context.Context) error, *atomic.Int32) {
+	calls := new(atomic.Int32)
+	fn := func(ctx context.Context) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if calls.Add(1) <= permit {
+			return nil
+		}
+		return stop
+	}
+	return fn, calls
+}
+
+// clientStopTimeout bounds how long a stopped client may take to close
+// its Done channel before the wait is treated as a hang.
+const clientStopTimeout = 2 * time.Second
+
+// assertStopped fails unless the client's Done channel closes before
+// ctx expires, turning a stuck client into a clean failure rather than
+// a hung suite.
+func assertStopped(ctx context.Context, t *testing.T, c *reconnect.Client) {
+	t.Helper()
+
+	select {
+	case <-c.Done():
+	case <-ctx.Done():
+		t.Fatal("client did not stop in time")
+	}
+}
+
+// countMatchingErrors reports how many errors in errs match target.
+func countMatchingErrors(errs []error, target error) int {
+	var n int
+	for _, e := range errs {
+		if errors.Is(e, target) {
+			n++
+		}
+	}
+	return n
+}
+
+// TestClientReconnectDialFails drives the reconnect-dial failure path:
+// the waiter permits one reconnect attempt, so tryReconnect proceeds to
+// the dial, the dial fails, and the failure is routed through
+// handleReconnectError before the next waiter call stops the client.
+// This is the complement of TestClientWaiterErrorStops, where the
+// waiter errors on its first call and the dial is never reached.
+func TestClientReconnectDialFails(t *testing.T) {
+	errStopWaiting := errors.New("waiter stop sentinel")
+
+	// the waiter permits exactly one reconnect attempt, then stops the
+	// client. The permitted attempt dials the unreachable address, so
+	// tryReconnect routes that dial failure through handleReconnectError
+	// before the second waiter call ends the loop.
+	waiter, waiterCalls := newReconnectWaiter(1, errStopWaiting)
+
+	// bind a port then release it, so every dial fails non-fatally
+	// (ECONNREFUSED): the synchronous Connect dial and the reconnect
+	// dial alike.
+	lsn, err := net.Listen("tcp", addrLoopbackAny)
+	core.AssertMustNoError(t, err, "listen")
+	unreachableAddr := lsn.Addr().String()
+	core.AssertMustNoError(t, lsn.Close(), "close listener")
+
+	errs := new(errors.CompoundError)
+
+	cfg := &reconnect.Config{
+		Context:       context.Background(),
+		Remote:        unreachableAddr,
+		WaitReconnect: waiter,
+		OnError:       newOnError(errs),
+	}
+
+	c, err := reconnect.New(cfg)
+	core.AssertMustNoError(t, err, "New")
+	core.AssertMustNoError(t, c.Connect(), "Connect")
+
+	ctx, cancel := core.WithTimeout(context.Background(), clientStopTimeout)
+	defer cancel()
+	assertStopped(ctx, t, c)
+
+	// two waiter calls: one permitting the failed reconnect dial, one
+	// stopping the loop. A single call would mean the dial — and so
+	// handleReconnectError — was never reached.
+	core.AssertEqual(t, 2, int(waiterCalls.Load()), "waiter calls")
+	core.AssertErrorIs(t, c.Wait(), errStopWaiting, "Wait")
+
+	// both dials are refused and reported: the synchronous Connect dial
+	// and the reconnect dial routed through handleReconnectError.
+	core.AssertEqual(t, 2,
+		countMatchingErrors(errs.Errors(), syscall.ECONNREFUSED),
+		"refused dials reported")
+}
+
+// TestClientReconnectSucceeds drives the reconnect-success path: the
+// waiter permits one reconnect, the redial succeeds against the live
+// listener, and a second session runs before the waiter stops the
+// client. This exercises tryReconnect's ready return and the run
+// loop's re-entry with a freshly dialled connection.
+func TestClientReconnectSucceeds(t *testing.T) {
+	lsn, err := net.Listen("tcp", addrLoopbackAny)
+	core.AssertMustNoError(t, err, "listen")
+	defer func() { _ = lsn.Close() }()
+
+	// the peer accepts every dial and drops it; OnSession ends each
+	// session itself, so the listener only needs its backlog drained.
+	go acceptAndDrop(lsn)
+
+	errStopWaiting := errors.New("waiter stop sentinel")
+	waiter, waiterCalls := newReconnectWaiter(1, errStopWaiting)
+
+	var sessions atomic.Int32
+
+	cfg := &reconnect.Config{
+		Context:       context.Background(),
+		Remote:        lsn.Addr().String(),
+		WaitReconnect: waiter,
+		OnSession: func(context.Context) error {
+			sessions.Add(1)
+			return nil
+		},
+	}
+
+	c, err := reconnect.New(cfg)
+	core.AssertMustNoError(t, err, "New")
+	core.AssertMustNoError(t, c.Connect(), "Connect")
+
+	ctx, cancel := core.WithTimeout(context.Background(), clientStopTimeout)
+	defer cancel()
+	assertStopped(ctx, t, c)
+
+	// the permitted waiter call let tryReconnect redial successfully,
+	// so a second session ran before the waiter stopped the client.
+	core.AssertEqual(t, 2, int(sessions.Load()), "sessions")
+	core.AssertEqual(t, 2, int(waiterCalls.Load()), "waiter calls")
+	core.AssertErrorIs(t, c.Wait(), errStopWaiting, "Wait")
+}
+
+// TestClientConnectFatalRejection drives handleConnectError's fatal
+// arm: OnConnect rejects an established connection with the only fatal
+// sentinel, ErrDoNotReconnect. dial surfaces it as the connect error,
+// so Connect terminates the client and returns it unfiltered instead
+// of retrying.
+func TestClientConnectFatalRejection(t *testing.T) {
+	lsn, err := net.Listen("tcp", addrLoopbackAny)
+	core.AssertMustNoError(t, err, "listen")
+	defer func() { _ = lsn.Close() }()
+
+	go acceptAndDrop(lsn)
+
+	errs := new(errors.CompoundError)
+
+	cfg := &reconnect.Config{
+		Context: context.Background(),
+		Remote:  lsn.Addr().String(),
+
+		OnConnect: func(context.Context, net.Conn) error {
+			return reconnect.ErrDoNotReconnect
+		},
+		OnError: newOnError(errs),
+	}
+
+	c, err := reconnect.New(cfg)
+	core.AssertMustNoError(t, err, "New")
+
+	// the fatal rejection is returned by Connect itself, not retried.
+	core.AssertErrorIs(t, c.Connect(), reconnect.ErrDoNotReconnect, "Connect")
+
+	// the client is terminated, and the fatal error was observed by
+	// OnError on its way through handlePossiblyFatalError.
+	ctx, cancel := core.WithTimeout(context.Background(), clientStopTimeout)
+	defer cancel()
+	assertStopped(ctx, t, c)
+	core.AssertEqual(t, 1,
+		countMatchingErrors(errs.Errors(), reconnect.ErrDoNotReconnect),
+		"fatal rejection reported")
+}
+
+// TestClientDisconnectPanic drives run's recovery arm: a panic from
+// OnDisconnect escapes doOnDisconnect, which unlike OnSession has no
+// catcher, so it unwinds to run's deferred recover. The recover
+// surfaces it through OnError and terminates the client instead of
+// leaking the panic out of the worker goroutine.
+func TestClientDisconnectPanic(t *testing.T) {
+	errDisconnectPanic := errors.New("disconnect panic sentinel")
+
+	lsn, err := net.Listen("tcp", addrLoopbackAny)
+	core.AssertMustNoError(t, err, "listen")
+	defer func() { _ = lsn.Close() }()
+
+	go acceptAndDrop(lsn)
+
+	errs := new(errors.CompoundError)
+
+	cfg := &reconnect.Config{
+		Context: context.Background(),
+		Remote:  lsn.Addr().String(),
+
+		// the session ends at once; the panic comes from the disconnect
+		// hook, which runs outside the session catcher.
+		OnSession: func(context.Context) error {
+			return nil
+		},
+		OnDisconnect: func(context.Context, net.Conn) error {
+			panic(errDisconnectPanic)
+		},
+		OnError: newOnError(errs),
+	}
+
+	c, err := reconnect.New(cfg)
+	core.AssertMustNoError(t, err, "New")
+	core.AssertMustNoError(t, c.Connect(), "Connect")
+
+	ctx, cancel := core.WithTimeout(context.Background(), clientStopTimeout)
+	defer cancel()
+	assertStopped(ctx, t, c)
+
+	// the recovered panic is reported through OnError as a PanicError
+	// and recorded as the termination cause. The type match matters:
+	// it proves the error travelled through run's deferred recover.
+	var found *core.PanicError
+	core.AssertMustTrue(t, errors.As(errs.AsError(), &found),
+		"OnDisconnect panic reported via OnError")
+	core.AssertErrorIs(t, found, errDisconnectPanic, "panic payload")
+	core.AssertErrorIs(t, c.Wait(), errDisconnectPanic, "Wait")
 }

--- a/net/reconnect/client_work.go
+++ b/net/reconnect/client_work.go
@@ -12,39 +12,27 @@ import (
 // and returns the cancellation reason, nil if the shutdown
 // was user-initiated.
 func (c *Client) Wait() error {
-	c.wg.Wait()
-	return c.Err()
+	return filterNonError(c.wg.Wait())
 }
 
 // Err returns the cancellation reason.
 // It will return nil if the cause was initiated
 // by the user.
 func (c *Client) Err() error {
-	c.mu.Lock()
-	err := c.err
-	c.mu.Unlock()
-
-	return filterNonError(err)
+	return filterNonError(c.wg.Err())
 }
 
 // Done returns a channel that is closed once the [Client]
 // workers have finished. Use [Client.Err] to learn the
 // cancellation reason.
 func (c *Client) Done() <-chan struct{} {
-	barrier := make(chan struct{})
-
-	go func() {
-		defer close(barrier)
-		c.wg.Wait()
-	}()
-
-	return barrier
+	return c.wg.Done()
 }
 
 // Shutdown initiates a shutdown and waits until the workers
 // are done, or the given context times out.
 func (c *Client) Shutdown(ctx context.Context) error {
-	_ = c.terminate(nil)
+	c.terminate(nil)
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
@@ -53,30 +41,26 @@ func (c *Client) Shutdown(ctx context.Context) error {
 	}
 }
 
-func (c *Client) terminate(cause error) error {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	if err := c.err; err != nil {
-		// already cancelled
-		return filterNonError(err)
-	}
-
+// terminate cancels the [Client] with the given cause, defaulting
+// to [context.Canceled]. It is idempotent: only the first call
+// records a cause and logs the termination.
+func (c *Client) terminate(cause error) {
 	if cause == nil {
 		cause = context.Canceled
 	}
 
-	if l, ok := c.WithDebug(nil); ok {
-		l = l.WithField(slog.ErrorFieldName, cause)
-		l.Print("client terminated")
+	if c.wg.Cancel(cause) {
+		// first cancellation
+		if l, ok := c.WithDebug(nil); ok {
+			l = l.WithField(slog.ErrorFieldName, cause)
+			l.Print("client terminated")
+		}
 	}
-
-	c.err = cause
-	c.cancel(cause)
-	return filterNonError(cause)
 }
 
-// Go spawns a goroutine within the [Client]'s context.
+// Go spawns a goroutine within the [Client]'s context. Submissions
+// after shutdown are no-ops: the worker is dropped rather than run
+// with an already-cancelled context.
 func (c *Client) Go(funcs ...WorkerFunc) {
 	for _, fn := range funcs {
 		if fn != nil {
@@ -87,6 +71,7 @@ func (c *Client) Go(funcs ...WorkerFunc) {
 
 // GoCatch spawns a goroutine within the [Client]'s context,
 // optionally allowing filtering the error to stop cascading.
+// Submissions after shutdown are no-ops, as with [Client.Go].
 func (c *Client) GoCatch(run WorkerFunc, catch CatcherFunc) {
 	if run != nil {
 		c.spawnOne(run, catch)
@@ -94,23 +79,28 @@ func (c *Client) GoCatch(run WorkerFunc, catch CatcherFunc) {
 }
 
 func (c *Client) spawnOne(run WorkerFunc, catch CatcherFunc) {
-	c.wg.Add(1)
-
-	go func() {
+	err := c.wg.Go(func(ctx context.Context) {
 		var catcher core.Catcher
 
-		defer c.wg.Done()
-
 		err := catcher.Do(func() error {
-			return run(c.ctx)
+			return run(ctx)
 		})
 
 		if err != nil && catch != nil {
-			err = catch(c.ctx, err)
+			err = catch(ctx, err)
 		}
 
 		_ = c.handlePossiblyFatalError(nil, err)
-	}()
+	})
+	if err != nil {
+		// the group is already shutting down; the worker is dropped
+		// rather than run with a cancelled context. Surface it at
+		// debug so a late submission isn't lost silently.
+		if l, ok := c.WithDebug(nil); ok {
+			l = l.WithField(slog.ErrorFieldName, err)
+			l.Print("worker submitted after shutdown; dropped")
+		}
+	}
 }
 
 // run implements the main loop.
@@ -122,7 +112,7 @@ func (c *Client) run(conn net.Conn) {
 		if err := core.AsRecovered(recover()); err != nil {
 			// report and terminate
 			_ = c.doOnError(nil, err, "reconnect.Client")
-			_ = c.terminate(err)
+			c.terminate(err)
 		}
 	}()
 
@@ -172,15 +162,24 @@ func (c *Client) runSession(conn net.Conn) error {
 }
 
 func (c *Client) tryReconnect() (net.Conn, bool) {
+	if fn := c.getWaitReconnect(); fn != nil {
+		if err := fn(c.ctx); err != nil {
+			// Per the [Waiter] contract any error means "stop
+			// reconnecting". Unlike a dial failure it is terminal
+			// regardless of [IsFatal], which classifies connection
+			// errors, not the waiter's stop decision.
+			return nil, c.handleWaiterError(err)
+		}
+	}
+
 	network, address := c.getRemote()
-	conn, err := c.reconnect(network, address)
+	conn, err := c.dial(network, address)
 	if conn != nil {
 		// ready
 		return conn, false
 	}
 
-	abort := c.handleReconnectError(err)
-	return nil, abort
+	return nil, c.handleReconnectError(err)
 }
 
 func (c *Client) doOnDisconnect() error {
@@ -224,7 +223,7 @@ func (c *Client) handlePossiblyFatalError(conn net.Conn, err error) error {
 	if err != nil {
 		err = c.doOnError(conn, err, "")
 		if IsFatal(err) {
-			_ = c.terminate(err)
+			c.terminate(err)
 			return err // unfiltered
 		}
 	}
@@ -273,4 +272,14 @@ func checkCancellation(err error) error {
 func (c *Client) handleReconnectError(err error) bool {
 	err = c.handleConnectError(nil, err)
 	return err != nil
+}
+
+// handleWaiterError stops the [Client] after a [Waiter] declined to
+// continue. The waiter is the reconnection-policy authority, so any
+// error terminates unconditionally; [Config.OnError] still observes
+// it and may rewrite the recorded cause.
+func (c *Client) handleWaiterError(err error) bool {
+	err = c.doOnError(nil, err, "reconnect waiter")
+	c.terminate(err)
+	return true
 }

--- a/net/reconnect/client_work.go
+++ b/net/reconnect/client_work.go
@@ -9,7 +9,8 @@ import (
 )
 
 // Wait blocks until the [Client] workers have finished,
-// and returns the cancellation reason.
+// and returns the cancellation reason, nil if the shutdown
+// was user-initiated.
 func (c *Client) Wait() error {
 	c.wg.Wait()
 	return c.Err()
@@ -26,8 +27,9 @@ func (c *Client) Err() error {
 	return filterNonError(err)
 }
 
-// Done returns a channel that watches the [Client] workers,
-// and provides the cancellation reason.
+// Done returns a channel that is closed once the [Client]
+// workers have finished. Use [Client.Err] to learn the
+// cancellation reason.
 func (c *Client) Done() <-chan struct{} {
 	barrier := make(chan struct{})
 

--- a/net/reconnect/client_work.go
+++ b/net/reconnect/client_work.go
@@ -155,8 +155,8 @@ func (c *Client) runSession(conn net.Conn) error {
 	if fn := c.getOnSession(); fn != nil {
 		var catch core.Catcher
 
-		// hand over
-		return catch.Try(func() error {
+		// hand over, surfacing recovered panics as errors
+		return catch.Do(func() error {
 			return fn(c.ctx)
 		})
 	}

--- a/net/reconnect/client_work.go
+++ b/net/reconnect/client_work.go
@@ -231,22 +231,38 @@ func (c *Client) handlePossiblyFatalError(conn net.Conn, err error) error {
 }
 
 func (c *Client) handleConnectError(conn net.Conn, err error) error {
-	var cancelled bool
-
-	switch err {
-	case nil:
+	if err == nil {
 		return nil
-	case context.Canceled:
-		cancelled = true
-	default:
 	}
 
-	err = c.handlePossiblyFatalError(conn, err)
-	switch {
-	case err != nil:
+	// remember context terminations before the non-fatal
+	// handling swallows the error.
+	cancellation := checkCancellation(err)
+
+	if err = c.handlePossiblyFatalError(conn, err); err != nil {
 		return err
-	case cancelled:
+	}
+
+	switch {
+	case cancellation != nil:
+		return cancellation
+	case c.ctx.Err() != nil:
+		// the [Client]'s context is done; stop instead of
+		// spinning on doomed reconnection attempts.
+		return c.ctx.Err()
+	default:
+		return nil
+	}
+}
+
+// checkCancellation extracts a context termination from the
+// error chain, if any.
+func checkCancellation(err error) error {
+	switch {
+	case core.IsError(err, context.Canceled):
 		return context.Canceled
+	case core.IsError(err, context.DeadlineExceeded):
+		return context.DeadlineExceeded
 	default:
 		return nil
 	}

--- a/net/reconnect/client_work.go
+++ b/net/reconnect/client_work.go
@@ -138,11 +138,31 @@ func (c *Client) runError(conn net.Conn, e1, e2 error) bool {
 	return e1 != nil || e2 != nil
 }
 
+// runSessionBeforeSetConn, when non-nil, is invoked at the top of
+// runSession before the dialled connection is stored, receiving the
+// Client's context. It is a white-box test seam for the cancel-before-
+// setConn window (see client_work_private_test.go) and stays nil in
+// production.
+var runSessionBeforeSetConn func(context.Context)
+
 func (c *Client) runSession(conn net.Conn) error {
 	defer unsafeClose(conn)
 
+	if hook := runSessionBeforeSetConn; hook != nil {
+		hook(c.ctx)
+	}
+
 	// initialize
 	c.setConn(conn)
+
+	// A cancellation that landed in the window between the dial and here
+	// was consumed by the cancel watcher against a not-yet-stored conn, so
+	// it will not close this one. Don't hand a cancelled context to
+	// OnSession only for it to park on a read nothing will unblock; wind
+	// down instead.
+	if c.ctx.Err() != nil {
+		return context.Cause(c.ctx)
+	}
 
 	if fn := c.getOnSession(); fn != nil {
 		var catch core.Catcher

--- a/net/reconnect/client_work_private_test.go
+++ b/net/reconnect/client_work_private_test.go
@@ -1,0 +1,84 @@
+package reconnect
+
+import (
+	"context"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"darvaza.org/core"
+)
+
+// TestClientRunSessionSkipsCancelledSession reproduces the publish-after-
+// cancel window: a cancellation landing between the dial and setConn is
+// consumed by the cancel watcher against a not-yet-stored connection, so
+// the live connection it stores next is never closed and an OnSession parked
+// on a read hangs to the Shutdown deadline. The runSessionBeforeSetConn seam
+// cancels the parent context and blocks on c.ctx.Done(), so the cancellation
+// has landed before setConn runs — deterministically, without depending on
+// the watcher's timing.
+//
+// The invariant asserted is that runSession does not enter OnSession with an
+// already-cancelled context: it fails while runSession runs OnSession
+// unconditionally and passes once the post-setConn guard winds the session
+// down instead.
+func TestClientRunSessionSkipsCancelledSession(t *testing.T) {
+	lsn, err := net.Listen("tcp", "127.0.0.1:0")
+	core.AssertMustNoError(t, err, "listen")
+	defer func() { _ = lsn.Close() }()
+
+	// accept every dial and drop it; the session is expected never to
+	// start, so the listener only needs its backlog drained.
+	go func() {
+		for {
+			conn, err := lsn.Accept()
+			if err != nil {
+				return
+			}
+			_ = conn.Close()
+		}
+	}()
+
+	parent, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var entered atomic.Bool
+
+	// fire in the dial-to-setConn window: cancel the parent, then block
+	// until the derived context observes it, so the guard under test sees a
+	// cancelled context the moment runSession reaches it.
+	runSessionBeforeSetConn = func(ctx context.Context) {
+		cancel()
+		<-ctx.Done()
+	}
+	t.Cleanup(func() { runSessionBeforeSetConn = nil })
+
+	cfg := &Config{
+		Context: parent,
+		Remote:  lsn.Addr().String(),
+
+		// stop after the first session rather than redialling.
+		WaitReconnect: NewDoNotReconnectWaiter(nil),
+
+		OnSession: func(context.Context) error {
+			entered.Store(true)
+			return nil
+		},
+	}
+
+	c, err := New(cfg)
+	core.AssertMustNoError(t, err, "New")
+	core.AssertMustNoError(t, c.Connect(), "Connect")
+
+	// the cancelled context winds the client down.
+	select {
+	case <-c.Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("client did not stop")
+	}
+
+	// OnSession must not run once the context is already cancelled.
+	core.AssertFalse(t, entered.Load(),
+		"OnSession entered with an already-cancelled context")
+}

--- a/net/reconnect/config.go
+++ b/net/reconnect/config.go
@@ -14,7 +14,8 @@ import (
 	"darvaza.org/x/net"
 )
 
-// An OptionFunc modifies a [Config] consistently before SetDefaults() and Validate().
+// An OptionFunc modifies a [Config] before [Config.SetDefaults] and
+// [Config.Valid] run.
 type OptionFunc func(*Config) error
 
 var (
@@ -37,13 +38,17 @@ type Config struct {
 	// OnConnect is called, when defined, immediately after the connection is established
 	// but before the session is created.
 	OnConnect func(context.Context, net.Conn) error
-	// OnSession is expected to block until it's done.
+	// OnSession, when defined, owns the connection and is expected
+	// to block until the session is done. Returning nil or a
+	// non-fatal error leads to a reconnection attempt; return
+	// [ErrDoNotReconnect], possibly wrapped, to stop the [Client].
 	OnSession func(context.Context) error
 	// OnDisconnect is called after closing the connection and can be used to
-	// prevent further connection retries.
+	// prevent further connection retries by returning [ErrDoNotReconnect].
 	OnDisconnect func(context.Context, net.Conn) error
-	// OnError is called after all errors and gives us the opportunity to
-	// decide how the error should be treated by the reconnection logic.
+	// OnError is called after all errors, and its return value replaces
+	// the error for the reconnection logic. Return nil to discard the
+	// error, or [ErrDoNotReconnect] to stop the [Client].
 	OnError func(context.Context, net.Conn, error) error
 
 	// immutable data
@@ -55,19 +60,26 @@ type Config struct {
 	Remote string
 
 	// KeepAlive indicates the value to be set to TCP connections
-	// for the low level keep alive messages.
+	// for the low-level keep-alive messages.
 	KeepAlive time.Duration `default:"5s"`
 	// DialTimeout indicates how long are we willing to wait for new
 	// connections getting established.
 	DialTimeout time.Duration `default:"2s"`
-	// ReadTimeout is the default read deadline for the connection.
+	// ReadTimeout is the default read deadline for the connection,
+	// applied via [Client.ResetReadDeadline] and [Client.ResetDeadline].
+	// It is not set automatically on new connections.
 	// Zero or negative disables the deadline.
 	ReadTimeout time.Duration `default:"2s"`
-	// WriteTimeout is the default write deadline for the connection.
-	// Zero or negative disables the deadline.
+	// WriteTimeout is the default write deadline for the connection,
+	// applied via [Client.ResetWriteDeadline] and [Client.ResetDeadline].
+	// It is not set automatically on new connections.
+	// Zero or negative disables the deadline, except [Client.ResetDeadline]
+	// substitutes ReadTimeout when WriteTimeout is zero (see [Client.SetDeadline]).
 	WriteTimeout time.Duration `default:"2s"`
 	// ReconnectDelay specifies how long to wait between re-connections
-	// unless [WaitReconnect] is specified. Negative implies reconnecting is disabled.
+	// unless [WaitReconnect] is specified. Zero means
+	// [DefaultWaitReconnect], and negative implies reconnecting
+	// is disabled.
 	ReconnectDelay time.Duration
 }
 

--- a/net/reconnect/config_test.go
+++ b/net/reconnect/config_test.go
@@ -1,4 +1,4 @@
-package reconnect
+package reconnect_test
 
 import (
 	"context"
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	"darvaza.org/core"
+
+	"darvaza.org/x/net/reconnect"
 )
 
 // Compile-time verification that test case types implement TestCase interface
@@ -33,7 +35,7 @@ func (tc validateRemoteTestCase) Name() string {
 func (tc validateRemoteTestCase) Test(t *testing.T) {
 	t.Helper()
 
-	err := ValidateRemote(tc.input)
+	err := reconnect.ValidateRemote(tc.input)
 	if tc.wantErr {
 		core.AssertError(t, err, "ValidateRemote")
 	} else {
@@ -80,7 +82,7 @@ func TestValidateRemote(t *testing.T) {
 
 func runTestConfigValidValidConfig(t *testing.T) {
 	t.Helper()
-	cfg := &Config{
+	cfg := &reconnect.Config{
 		Context: context.Background(),
 		Remote:  "example.com:8080",
 	}
@@ -93,7 +95,7 @@ func runTestConfigValidValidConfig(t *testing.T) {
 
 func runTestConfigValidInvalidRemote(t *testing.T) {
 	t.Helper()
-	cfg := &Config{
+	cfg := &reconnect.Config{
 		Context: context.Background(),
 		Remote:  "invalid-remote",
 	}
@@ -106,7 +108,7 @@ func runTestConfigValidInvalidRemote(t *testing.T) {
 
 func runTestConfigValidMissingContext(t *testing.T) {
 	t.Helper()
-	cfg := &Config{
+	cfg := &reconnect.Config{
 		Remote: "example.com:8080",
 	}
 	err := cfg.SetDefaults()
@@ -120,7 +122,7 @@ func runTestConfigValidMissingContext(t *testing.T) {
 
 func runTestConfigValidMissingLogger(t *testing.T) {
 	t.Helper()
-	cfg := &Config{
+	cfg := &reconnect.Config{
 		Context: context.Background(),
 		Remote:  "example.com:8080",
 	}
@@ -135,7 +137,7 @@ func runTestConfigValidMissingLogger(t *testing.T) {
 
 func runTestConfigValidMissingWaitReconnect(t *testing.T) {
 	t.Helper()
-	cfg := &Config{
+	cfg := &reconnect.Config{
 		Context: context.Background(),
 		Remote:  "example.com:8080",
 	}
@@ -158,36 +160,36 @@ func TestConfigValid(t *testing.T) {
 
 func runTestNewValidConfig(t *testing.T) {
 	t.Helper()
-	cfg := &Config{
+	cfg := &reconnect.Config{
 		Context: context.Background(),
 		Remote:  "example.com:8080",
 	}
 
-	client, err := New(cfg)
+	client, err := reconnect.New(cfg)
 	core.AssertNoError(t, err, "new client")
 	core.AssertNotNil(t, client, "client")
 }
 
 func runTestNewUnixSocketConfig(t *testing.T) {
 	t.Helper()
-	cfg := &Config{
+	cfg := &reconnect.Config{
 		Context: context.Background(),
 		Remote:  "/var/run/app.sock",
 	}
 
-	client, err := New(cfg)
+	client, err := reconnect.New(cfg)
 	core.AssertNoError(t, err, "new unix client")
 	core.AssertNotNil(t, client, "client")
 }
 
 func runTestNewInvalidConfig(t *testing.T) {
 	t.Helper()
-	cfg := &Config{
+	cfg := &reconnect.Config{
 		Context: context.Background(),
 		Remote:  "invalid-remote",
 	}
 
-	client, err := New(cfg)
+	client, err := reconnect.New(cfg)
 	core.AssertError(t, err, "new client with invalid config")
 	core.AssertNil(t, client, "client should be nil")
 }

--- a/net/reconnect/errors.go
+++ b/net/reconnect/errors.go
@@ -22,7 +22,7 @@ var (
 	// ErrNotConnected indicates the [Client] isn't currently connected.
 	ErrNotConnected = core.QuietWrap(fs.ErrClosed, "not connected")
 
-	// ErrRunning indicates the [Client] has already being started.
+	// ErrRunning indicates the [Client] has already been started.
 	ErrRunning = core.QuietWrap(syscall.EBUSY, "client already running")
 
 	// ErrNameEmpty indicates a name is empty
@@ -34,6 +34,8 @@ var (
 
 // IsFatal tells if the error means the connection
 // should be closed and not retried.
+// Only [ErrDoNotReconnect], possibly wrapped, is considered
+// fatal; anything else is treated as recoverable.
 func IsFatal(err error) bool {
 	if err != nil {
 		is, _ := core.IsErrorFn2(checkIsFatal, err)
@@ -89,8 +91,8 @@ func filterNonError(err error) error {
 	return err
 }
 
-// IsNonError checks if the error is an actual error instead of
-// a manual shutdown.
+// IsNonError reports whether the error represents a
+// user-initiated shutdown instead of an actual failure.
 func IsNonError(err error) bool {
 	if err == nil {
 		return true

--- a/net/reconnect/errors.go
+++ b/net/reconnect/errors.go
@@ -2,12 +2,12 @@ package reconnect
 
 import (
 	"context"
-	"errors"
 	"io/fs"
 	"os"
 	"syscall"
 
 	"darvaza.org/core"
+	"darvaza.org/x/sync/errors"
 )
 
 var (
@@ -20,10 +20,18 @@ var (
 	ErrDoNotReconnect = errors.New("don't reconnect")
 
 	// ErrNotConnected indicates the [Client] isn't currently connected.
-	ErrNotConnected = core.QuietWrap(fs.ErrClosed, "not connected")
+	// It wraps [ErrClosed] so a single errors.Is target covers both a
+	// closed client and the not-connected window.
+	ErrNotConnected = core.QuietWrap(ErrClosed, "client not connected")
 
 	// ErrRunning indicates the [Client] has already been started.
 	ErrRunning = core.QuietWrap(syscall.EBUSY, "client already running")
+
+	// ErrClosed indicates the [Client] has already been shut down
+	// and can no longer be started. It wraps the workgroup's
+	// sentinel so the shutdown signal still matches the one the
+	// group returns across the lifecycle stack.
+	ErrClosed = core.QuietWrap(errors.ErrClosed, "already closed")
 
 	// ErrNameEmpty indicates a name is empty
 	ErrNameEmpty = errors.New("name missing")

--- a/net/reconnect/errors.go
+++ b/net/reconnect/errors.go
@@ -27,10 +27,10 @@ var (
 	// ErrRunning indicates the [Client] has already been started.
 	ErrRunning = core.QuietWrap(syscall.EBUSY, "client already running")
 
-	// ErrClosed indicates the [Client] has already been shut down
-	// and can no longer be started. It wraps the workgroup's
-	// sentinel so the shutdown signal still matches the one the
-	// group returns across the lifecycle stack.
+	// ErrClosed indicates the [Client] or [StreamSession] has
+	// already been shut down. It wraps the workgroup's sentinel so
+	// the shutdown signal still matches the one the group returns
+	// across the lifecycle stack.
 	ErrClosed = core.QuietWrap(errors.ErrClosed, "already closed")
 
 	// ErrNameEmpty indicates a name is empty

--- a/net/reconnect/stream.go
+++ b/net/reconnect/stream.go
@@ -17,6 +17,9 @@ var (
 
 // StreamSession provides an asynchronous stream session
 // using message types for receiving and sending.
+// Exported fields are configured before calling
+// [StreamSession.Spawn] and must not be modified afterwards.
+// The session must be spawned before using any other method.
 type StreamSession[Input, Output any] struct {
 	in  chan Input
 	out chan Output
@@ -27,26 +30,26 @@ type StreamSession[Input, Output any] struct {
 	Context context.Context
 
 	// Split identifies the next encoded [Input] type in the inbound stream.
-	// If not set, [bufio.SplitLine] will be used.
+	// If not set, [bufio.ScanLines] will be used.
 	Split bufio.SplitFunc
 	// Marshal is used, if MarshalTo isn't set, to encode an [Output] type.
-	// If neither is set, [StreamSession.Go] will fail.
+	// If neither is set, [StreamSession.Spawn] will fail.
 	Marshal func(Output) ([]byte, error)
 	// MarshalTo, if set, is used to write the encoded representation of
-	// and [Output] type.
+	// an [Output] type.
 	MarshalTo func(Output, io.Writer) error
 	// Unmarshal is used to decode an [Input] type previously identified
 	// by [StreamSession.Split].
-	// If not net, [StreamSession.Go] will fail.
+	// If not set, [StreamSession.Spawn] will fail.
 	Unmarshal func([]byte) (Input, error)
 
-	// SetReadDeadline is an optional hook called before reading the a message
+	// SetReadDeadline is an optional hook called before reading a message
 	SetReadDeadline func() error
 	// SetWriteDeadline is an optional hook called before writing a message
 	SetWriteDeadline func() error
 	// UnsetReadDeadline is an optional hook called after having read a message
 	UnsetReadDeadline func() error
-	// UnsetWriteDeadline is an optional hook called after having wrote a message
+	// UnsetWriteDeadline is an optional hook called after having written a message
 	UnsetWriteDeadline func() error
 
 	// OnError is optionally called when an error occurs
@@ -146,7 +149,9 @@ func doMarshalTo[T any](v T, w io.Writer, fn func(T) ([]byte, error)) error {
 	return nil
 }
 
-// Spawn starts the [StreamSession].
+// Spawn starts the [StreamSession]'s workers. It fails if the
+// session has already been started, or if Conn, Unmarshal, or
+// a marshalling function is missing.
 func (s *StreamSession[_, _]) Spawn() error {
 	if err := s.init(); err != nil {
 		return err
@@ -291,7 +296,9 @@ func (s *StreamSession[Input, Output]) Err() error {
 	return s.wg.Err()
 }
 
-// Send sends a message asynchronously, unless the queue is full.
+// Send queues a message for asynchronous delivery, blocking
+// while the queue is full. It fails with [fs.ErrClosed] once
+// the session has been shut down.
 func (s *StreamSession[_, Output]) Send(m Output) error {
 	// TODO: implement TrySend() non-blocking variant via counter.
 	var err error
@@ -309,14 +316,16 @@ func (s *StreamSession[_, Output]) trySend(m Output, err *error) {
 	s.out <- m
 }
 
-// Recv returns a channel where inbound messages can be received.
+// Recv returns the channel where inbound messages are delivered.
+// The channel is closed when the inbound stream ends.
 func (s *StreamSession[Input, _]) Recv() <-chan Input {
 	mustStarted(s)
 
 	return s.in
 }
 
-// Next blocks until a new message is received.
+// Next blocks until a new message is received, returning false
+// once the inbound stream has ended.
 func (s *StreamSession[Input, _]) Next() (Input, bool) {
 	mustStarted(s)
 

--- a/net/reconnect/stream.go
+++ b/net/reconnect/stream.go
@@ -168,18 +168,28 @@ func (s *StreamSession[_, _]) Spawn() error {
 	return nil
 }
 
-// goWithKill runs run as a supervised worker and, replacing the
-// shutdown argument of the former core.ErrGroup.Go, invokes kill
-// once the group's context is cancelled so a blocked run can unwind.
+// goWithKill supervises run and fires kill once the group's context is
+// cancelled, replacing the shutdown argument of the former
+// core.ErrGroup.Go so a worker blocked on I/O can unwind.
+//
+// The kill watcher is enrolled before run so an early cancellation —
+// the reader reaching EOF and winding the group down before the writer
+// is wired up — cannot drop it. If the group is already cancelled the
+// watcher cannot be enrolled, so run is never started and kill closes
+// the resource directly.
 func (s *StreamSession[_, _]) goWithKill(run WorkerFunc, kill func() error) {
-	_ = s.wg.GoCatch(run, nil)
-	_ = s.wg.Go(func(ctx context.Context) {
+	if err := s.wg.Go(func(ctx context.Context) {
 		<-ctx.Done()
 		_ = kill()
-	})
+	}); err != nil {
+		_ = kill()
+		return
+	}
+
+	_ = s.wg.GoCatch(run, nil)
 }
 
-func (s *StreamSession[_, _]) runReader(_ context.Context) error {
+func (s *StreamSession[_, _]) runReader(ctx context.Context) error {
 	r := bufio.NewScanner(s.Conn)
 	r.Split(s.Split)
 
@@ -190,15 +200,23 @@ func (s *StreamSession[_, _]) runReader(_ context.Context) error {
 	}
 
 	for r.Scan() {
-		if err := s.readerStep(r.Bytes()); err != nil {
+		if err := s.readerStep(ctx, r.Bytes()); err != nil {
 			return err
 		}
 	}
 
-	return r.Err()
+	if err := r.Err(); err != nil {
+		return err
+	}
+
+	// A clean EOF ends the inbound stream but does not cancel the group
+	// on its own; do it here so the writer and the kill watchers unwind
+	// instead of parking forever and leaving Wait to block.
+	s.wg.Cancel(nil)
+	return nil
 }
 
-func (s *StreamSession[_, _]) readerStep(raw []byte) error {
+func (s *StreamSession[_, _]) readerStep(ctx context.Context, raw []byte) error {
 	if err := s.UnsetReadDeadline(); err != nil {
 		return err
 	}
@@ -208,7 +226,14 @@ func (s *StreamSession[_, _]) readerStep(raw []byte) error {
 		return err
 	}
 
-	s.in <- msg
+	select {
+	case s.in <- msg:
+	case <-ctx.Done():
+		// A shutdown raced the delivery. Stop reading rather than
+		// parking on the unbuffered channel, which closing the
+		// connection would not unblock.
+		return context.Cause(ctx)
+	}
 
 	return s.SetReadDeadline()
 }
@@ -314,9 +339,11 @@ func (s *StreamSession[Input, Output]) Err() error {
 }
 
 // Send queues a message for asynchronous delivery, blocking
-// while the queue is full. It fails with [fs.ErrClosed] once
+// while the queue is full. It fails with [ErrClosed] once
 // the session has been shut down.
 func (s *StreamSession[_, Output]) Send(m Output) error {
+	mustStarted(s)
+
 	// TODO: implement TrySend() non-blocking variant via counter.
 	var err error
 	s.trySend(m, &err)
@@ -326,7 +353,7 @@ func (s *StreamSession[_, Output]) Send(m Output) error {
 func (s *StreamSession[_, Output]) trySend(m Output, err *error) {
 	defer func() {
 		if e := recover(); e != nil {
-			*err = fs.ErrClosed
+			*err = ErrClosed
 		}
 	}()
 

--- a/net/reconnect/stream.go
+++ b/net/reconnect/stream.go
@@ -8,6 +8,7 @@ import (
 
 	"darvaza.org/core"
 	"darvaza.org/x/fs"
+	"darvaza.org/x/sync/workgroup"
 )
 
 var (
@@ -55,12 +56,21 @@ type StreamSession[Input, Output any] struct {
 	// OnError is optionally called when an error occurs
 	OnError func(error)
 
-	wg core.ErrGroup
+	wg workgroup.Group
 
 	// QueueSize specifies how many [Output] type entries can be buffered
 	// for delivery before [StreamSession.Send] blocks.
 	QueueSize uint
 }
+
+// streamInitCancelHook, when non-nil, is invoked during init once
+// setDefaults has realised the workgroup context — the point where a
+// cancellation can first fire OnCancel. By then init has already wired the
+// OnError->OnCancel bridge (ahead of setDefaults), so a cancel here must
+// still reach OnError; regressing that order makes the seam's test go red.
+// It is a white-box test seam (see stream_private_test.go) and stays nil in
+// production.
+var streamInitCancelHook func(*workgroup.Group)
 
 func (s *StreamSession[Input, Output]) init() error {
 	switch {
@@ -74,54 +84,50 @@ func (s *StreamSession[Input, Output]) init() error {
 		return core.QuietWrap(fs.ErrInvalid, "missing Marshal/MarshalTo")
 	}
 
-	if err := s.setDefaults(); err != nil {
-		return err
+	if fn := s.OnError; fn != nil {
+		// the former core.ErrGroup delivered the cancellation cause
+		// to OnError; OnCancel is its workgroup.Group equivalent. Wire
+		// it before setDefaults realises the workgroup context: that
+		// registers the context.AfterFunc cancel watcher, after which
+		// the group may fire OnCancel, and a bridge wired later would be
+		// read nil and drop the cause.
+		s.wg.OnCancel = func(_ context.Context, cause error) {
+			fn(cause)
+		}
 	}
 
-	s.wg = core.ErrGroup{
-		Parent: s.Context,
-	}
+	s.setDefaults()
 
-	s.wg.OnError(s.OnError)
-	s.wg.SetDefaults()
+	if hook := streamInitCancelHook; hook != nil {
+		hook(&s.wg)
+	}
 
 	s.in = make(chan Input)
 	s.out = make(chan Output, s.QueueSize)
 	return nil
 }
 
-// revive:disable:cognitive-complexity
-func (s *StreamSession[_, _]) setDefaults() error {
-	// revive:enable:cognitive-complexity
-	if s.Context == nil {
-		s.Context = context.Background()
-	}
+// noopHook is the default for the optional read/write deadline hooks.
+var noopHook = func() error { return nil }
 
-	if s.Split == nil {
-		s.Split = bufio.ScanLines
+func (s *StreamSession[_, _]) setDefaults() {
+	s.Context = core.Coalesce(s.Context, context.Background())
+	if s.wg.Parent == nil {
+		s.wg.Parent = s.Context
 	}
+	_ = s.wg.Context() // ensure the context is initialised
 
+	s.Split = core.Coalesce(s.Split, bufio.ScanLines)
 	if s.MarshalTo == nil {
+		// keep the branch: newMarshalTo panics on a nil Marshal, so it
+		// must not be evaluated when MarshalTo is already set.
 		s.MarshalTo = newMarshalTo(s.Marshal)
 	}
 
-	if s.SetReadDeadline == nil {
-		s.SetReadDeadline = func() error { return nil }
-	}
-
-	if s.SetWriteDeadline == nil {
-		s.SetWriteDeadline = func() error { return nil }
-	}
-
-	if s.UnsetReadDeadline == nil {
-		s.UnsetReadDeadline = func() error { return nil }
-	}
-
-	if s.UnsetWriteDeadline == nil {
-		s.UnsetWriteDeadline = func() error { return nil }
-	}
-
-	return nil
+	s.SetReadDeadline = core.Coalesce(s.SetReadDeadline, noopHook)
+	s.SetWriteDeadline = core.Coalesce(s.SetWriteDeadline, noopHook)
+	s.UnsetReadDeadline = core.Coalesce(s.UnsetReadDeadline, noopHook)
+	s.UnsetWriteDeadline = core.Coalesce(s.UnsetWriteDeadline, noopHook)
 }
 
 func newMarshalTo[T any](fn func(T) ([]byte, error)) func(T, io.Writer) error {
@@ -157,9 +163,20 @@ func (s *StreamSession[_, _]) Spawn() error {
 		return err
 	}
 
-	s.wg.Go(s.runReader, s.killReader)
-	s.wg.Go(s.runWriter, s.killWriter)
+	s.goWithKill(s.runReader, s.killReader)
+	s.goWithKill(s.runWriter, s.killWriter)
 	return nil
+}
+
+// goWithKill runs run as a supervised worker and, replacing the
+// shutdown argument of the former core.ErrGroup.Go, invokes kill
+// once the group's context is cancelled so a blocked run can unwind.
+func (s *StreamSession[_, _]) goWithKill(run WorkerFunc, kill func() error) {
+	_ = s.wg.GoCatch(run, nil)
+	_ = s.wg.Go(func(ctx context.Context) {
+		<-ctx.Done()
+		_ = kill()
+	})
 }
 
 func (s *StreamSession[_, _]) runReader(_ context.Context) error {
@@ -238,7 +255,7 @@ func (s *StreamSession[_, _]) Go(funcs ...WorkerFunc) {
 
 	for _, fn := range funcs {
 		if fn != nil {
-			s.wg.Go(fn, nil)
+			_ = s.wg.GoCatch(fn, nil)
 		}
 	}
 }
@@ -249,7 +266,7 @@ func (s *StreamSession[_, _]) GoCatch(run WorkerFunc, catch CatcherFunc) {
 	mustStarted(s)
 
 	if run != nil {
-		s.wg.GoCatch(run, catch)
+		_ = s.wg.GoCatch(run, catch)
 	}
 }
 

--- a/net/reconnect/stream_private_test.go
+++ b/net/reconnect/stream_private_test.go
@@ -1,0 +1,67 @@
+package reconnect
+
+import (
+	"errors"
+	"net"
+	"testing"
+	"time"
+
+	"darvaza.org/core"
+	"darvaza.org/x/sync/workgroup"
+)
+
+// TestStreamSessionOnErrorFiresOnInitWindowCancel guards the bridge-
+// ordering fix: if the OnError->OnCancel bridge is wired after setDefaults
+// realises the workgroup context, a cancellation landing in between makes
+// markCancelled read a nil OnCancel and the cause never reaches OnError. The
+// streamInitCancelHook seam fires wg.Cancel at exactly that point — the
+// moment the context is live; Cancel blocks until the OnCancel handler has
+// started, so whether the cause reaches OnError is decided before Cancel
+// returns, deterministically rather than as a race.
+//
+// It fails while the bridge is wired after setDefaults and passes once the
+// bridge moves ahead of it, complementing
+// TestStreamSessionOnErrorFiresOnParentCancel, which covers the post-Spawn
+// cancellation where the bridge is already in place.
+func TestStreamSessionOnErrorFiresOnInitWindowCancel(t *testing.T) {
+	wantErr := errors.New("cancelled in init window")
+
+	streamInitCancelHook = func(wg *workgroup.Group) {
+		wg.Cancel(wantErr)
+	}
+	t.Cleanup(func() { streamInitCancelHook = nil })
+
+	c1, c2 := net.Pipe()
+	defer func() { _ = c2.Close() }()
+
+	got := make(chan error, 1)
+	s := &StreamSession[string, string]{
+		Conn:      c1,
+		Marshal:   func(v string) ([]byte, error) { return []byte(v + "\n"), nil },
+		Unmarshal: func(b []byte) (string, error) { return string(b), nil },
+		OnError: func(err error) {
+			select {
+			case got <- err:
+			default:
+			}
+		},
+	}
+	core.AssertMustNoError(t, s.Spawn(), "Spawn")
+
+	// the cancellation observed during init must still reach OnError.
+	select {
+	case err := <-got:
+		core.AssertErrorIs(t, err, wantErr, "OnError cause")
+	case <-time.After(2 * time.Second):
+		t.Fatal("OnError did not fire for an in-init-window cancellation")
+	}
+
+	// the session winds down without hanging.
+	done := make(chan error, 1)
+	go func() { done <- s.Wait() }()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Wait did not return")
+	}
+}

--- a/net/reconnect/stream_test.go
+++ b/net/reconnect/stream_test.go
@@ -1,0 +1,256 @@
+package reconnect_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"darvaza.org/core"
+	"darvaza.org/x/fs"
+
+	"darvaza.org/x/net/reconnect"
+)
+
+// Compile-time verification that test case types implement TestCase.
+var _ core.TestCase = streamSpawnTestCase{}
+
+func newlineMarshal(s string) ([]byte, error) {
+	return []byte(s + "\n"), nil
+}
+
+func identityUnmarshal(b []byte) (string, error) {
+	return string(b), nil
+}
+
+func newStringSession(conn net.Conn) *reconnect.StreamSession[string, string] {
+	return &reconnect.StreamSession[string, string]{
+		Conn:      conn,
+		Marshal:   newlineMarshal,
+		Unmarshal: identityUnmarshal,
+	}
+}
+
+// dummyConn is a non-nil connection for cases where Spawn fails before
+// the connection is ever touched.
+type dummyConn struct{}
+
+func (dummyConn) Read([]byte) (int, error)    { return 0, io.EOF }
+func (dummyConn) Write(b []byte) (int, error) { return len(b), nil }
+func (dummyConn) Close() error                { return nil }
+
+// streamSpawnTestCase checks the error Spawn returns for a given
+// session state: an incomplete configuration rejected before any
+// worker starts, or an already-started session.
+type streamSpawnTestCase struct {
+	wantErr error
+	session *reconnect.StreamSession[string, string]
+	name    string
+	started bool
+}
+
+func newStreamSpawnTestCase(name string,
+	session *reconnect.StreamSession[string, string],
+	wantErr error) streamSpawnTestCase {
+	return streamSpawnTestCase{
+		name:    name,
+		session: session,
+		wantErr: wantErr,
+	}
+}
+
+// newStreamSpawnTestCaseStarted builds a fully configured session that
+// is Spawned once before the asserted Spawn, so the second call hits
+// init's "already started" arm and returns fs.ErrExist.
+func newStreamSpawnTestCaseStarted(name string,
+	session *reconnect.StreamSession[string, string]) streamSpawnTestCase {
+	return streamSpawnTestCase{
+		name:    name,
+		session: session,
+		wantErr: fs.ErrExist,
+		started: true,
+	}
+}
+
+func (tc streamSpawnTestCase) Name() string {
+	return tc.name
+}
+
+func (tc streamSpawnTestCase) Test(t *testing.T) {
+	t.Helper()
+
+	if tc.started {
+		core.AssertMustNoError(t, tc.session.Spawn(), "initial Spawn")
+		t.Cleanup(func() {
+			_ = tc.session.Close()
+			_ = tc.session.Wait()
+		})
+	}
+
+	core.AssertErrorIs(t, tc.session.Spawn(), tc.wantErr, "Spawn")
+}
+
+func streamSpawnTestCases() []streamSpawnTestCase {
+	return []streamSpawnTestCase{
+		newStreamSpawnTestCase("missing Conn",
+			&reconnect.StreamSession[string, string]{
+				Unmarshal: identityUnmarshal,
+				Marshal:   newlineMarshal,
+			}, fs.ErrInvalid),
+		newStreamSpawnTestCase("missing Unmarshal",
+			&reconnect.StreamSession[string, string]{
+				Conn:    dummyConn{},
+				Marshal: newlineMarshal,
+			}, fs.ErrInvalid),
+		newStreamSpawnTestCase("missing Marshal and MarshalTo",
+			&reconnect.StreamSession[string, string]{
+				Conn:      dummyConn{},
+				Unmarshal: identityUnmarshal,
+			}, fs.ErrInvalid),
+		newStreamSpawnTestCaseStarted("already started",
+			&reconnect.StreamSession[string, string]{
+				Conn:      dummyConn{},
+				Unmarshal: identityUnmarshal,
+				Marshal:   newlineMarshal,
+			}),
+	}
+}
+
+func TestStreamSessionSpawn(t *testing.T) {
+	core.RunTestCases(t, streamSpawnTestCases())
+}
+
+// TestStreamSessionBeforeSpawn verifies every guarded method panics
+// via mustStarted rather than dereferencing the nil work group when
+// called before Spawn. Send is intentionally excluded: it is not
+// guarded (a known bug) and would block on a nil channel.
+func TestStreamSessionBeforeSpawn(t *testing.T) {
+	fresh := func() *reconnect.StreamSession[string, string] {
+		return &reconnect.StreamSession[string, string]{}
+	}
+
+	core.AssertPanic(t, func() { fresh().Go(nil) }, fs.ErrInvalid, "Go")
+	core.AssertPanic(t, func() { fresh().GoCatch(nil, nil) }, fs.ErrInvalid, "GoCatch")
+	core.AssertPanic(t, func() { _ = fresh().Close() }, fs.ErrInvalid, "Close")
+	core.AssertPanic(t, func() { _ = fresh().Shutdown(context.Background()) },
+		fs.ErrInvalid, "Shutdown")
+	core.AssertPanic(t, func() { _ = fresh().Wait() }, fs.ErrInvalid, "Wait")
+	core.AssertPanic(t, func() { _ = fresh().Done() }, fs.ErrInvalid, "Done")
+	core.AssertPanic(t, func() { _ = fresh().Err() }, fs.ErrInvalid, "Err")
+	core.AssertPanic(t, func() { _ = fresh().Recv() }, fs.ErrInvalid, "Recv")
+	core.AssertPanic(t, func() { fresh().Next() }, fs.ErrInvalid, "Next")
+}
+
+// nextWithin bounds a blocking Next with a deadline, turning a
+// regression that would otherwise hang the suite into a clean failure.
+// It returns Next's result; asserting on ok stays with the caller.
+func nextWithin(t *testing.T, s *reconnect.StreamSession[string, string],
+	name string) (string, bool) {
+	t.Helper()
+
+	type result struct {
+		value string
+		ok    bool
+	}
+
+	res := make(chan result, 1)
+	go func() {
+		v, ok := s.Next()
+		res <- result{value: v, ok: ok}
+	}()
+
+	select {
+	case r := <-res:
+		return r.value, r.ok
+	case <-time.After(2 * time.Second):
+		t.Fatalf("%s: Next did not return", name)
+		return "", false
+	}
+}
+
+// echoPeer copies conn's inbound byte stream straight back to it until
+// conn is closed, echoing every frame the session writes.
+func echoPeer(conn net.Conn) {
+	_, _ = io.Copy(conn, conn)
+}
+
+// TestStreamSessionEcho drives a full round trip through an echo peer
+// and a clean shutdown, exercising the migrated workgroup.Group
+// lifecycle end to end.
+func TestStreamSessionEcho(t *testing.T) {
+	c1, c2 := net.Pipe()
+	defer func() { _ = c2.Close() }()
+
+	go echoPeer(c2)
+
+	s := newStringSession(c1)
+	core.AssertMustNoError(t, s.Spawn(), "Spawn")
+
+	// a second Spawn is rejected.
+	core.AssertErrorIs(t, s.Spawn(), fs.ErrExist, "second Spawn")
+
+	// round trip: the peer echoes what we send back to us.
+	core.AssertMustNoError(t, s.Send("ping"), "Send")
+	got, ok := nextWithin(t, s, "Next")
+	core.AssertMustTrue(t, ok, "Next")
+	core.AssertEqual(t, "ping", got, "echo")
+
+	// clean shutdown stops the workers and reports the cancellation
+	// cause; Wait then returns nil for a user-initiated stop.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	core.AssertErrorIs(t, s.Shutdown(ctx), context.Canceled, "Shutdown")
+	core.AssertNoError(t, s.Wait(), "Wait")
+
+	// the inbound channel is closed once the reader stops.
+	_, ok = s.Next()
+	core.AssertFalse(t, ok, "Next after shutdown")
+}
+
+// TestStreamSessionOnErrorFiresOnParentCancel verifies the OnError
+// bridge wired in init: the workgroup enrols OnCancel as a task driven
+// by context.AfterFunc, so cancelling the parent context forwards the
+// cancellation cause to the configured OnError hook.
+func TestStreamSessionOnErrorFiresOnParentCancel(t *testing.T) {
+	c1, c2 := net.Pipe()
+	defer func() { _ = c2.Close() }()
+
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
+
+	got := make(chan error, 1)
+	s := newStringSession(c1)
+	s.Context = ctx
+	s.OnError = func(err error) {
+		select {
+		case got <- err:
+		default:
+		}
+	}
+	core.AssertMustNoError(t, s.Spawn(), "Spawn")
+
+	// cancelling the parent context drives the group's OnCancel
+	// transition, which forwards the cause to OnError.
+	wantErr := errors.New("parent cancelled")
+	cancel(wantErr)
+
+	select {
+	case err := <-got:
+		core.AssertErrorIs(t, err, wantErr, "OnError cause")
+	case <-time.After(2 * time.Second):
+		t.Fatal("OnError did not fire")
+	}
+
+	// the cause recorded by the parent cancellation is what Wait
+	// surfaces once the workers wind down.
+	done := make(chan error, 1)
+	go func() { done <- s.Wait() }()
+	select {
+	case err := <-done:
+		core.AssertErrorIs(t, err, wantErr, "Wait cause")
+	case <-time.After(2 * time.Second):
+		t.Fatal("Wait did not return")
+	}
+}

--- a/net/reconnect/stream_test.go
+++ b/net/reconnect/stream_test.go
@@ -123,9 +123,8 @@ func TestStreamSessionSpawn(t *testing.T) {
 }
 
 // TestStreamSessionBeforeSpawn verifies every guarded method panics
-// via mustStarted rather than dereferencing the nil work group when
-// called before Spawn. Send is intentionally excluded: it is not
-// guarded (a known bug) and would block on a nil channel.
+// via mustStarted rather than dereferencing the nil work group or
+// blocking on a nil channel when called before Spawn.
 func TestStreamSessionBeforeSpawn(t *testing.T) {
 	fresh := func() *reconnect.StreamSession[string, string] {
 		return &reconnect.StreamSession[string, string]{}
@@ -139,6 +138,7 @@ func TestStreamSessionBeforeSpawn(t *testing.T) {
 	core.AssertPanic(t, func() { _ = fresh().Wait() }, fs.ErrInvalid, "Wait")
 	core.AssertPanic(t, func() { _ = fresh().Done() }, fs.ErrInvalid, "Done")
 	core.AssertPanic(t, func() { _ = fresh().Err() }, fs.ErrInvalid, "Err")
+	core.AssertPanic(t, func() { _ = fresh().Send("x") }, fs.ErrInvalid, "Send")
 	core.AssertPanic(t, func() { _ = fresh().Recv() }, fs.ErrInvalid, "Recv")
 	core.AssertPanic(t, func() { fresh().Next() }, fs.ErrInvalid, "Next")
 }
@@ -207,6 +207,47 @@ func TestStreamSessionEcho(t *testing.T) {
 	// the inbound channel is closed once the reader stops.
 	_, ok = s.Next()
 	core.AssertFalse(t, ok, "Next after shutdown")
+
+	// Send after shutdown fails with the package sentinel.
+	core.AssertErrorIs(t, s.Send("late"), reconnect.ErrClosed,
+		"Send after shutdown")
+}
+
+// assertWaitReturns fails if the session does not finish winding down
+// within a short deadline, turning a regression that would otherwise
+// hang the suite into a clean failure.
+func assertWaitReturns(t *testing.T, s *reconnect.StreamSession[string, string],
+	name string) {
+	t.Helper()
+
+	done := make(chan error, 1)
+	go func() { done <- s.Wait() }()
+
+	select {
+	case err := <-done:
+		core.AssertNoError(t, err, name)
+	case <-time.After(2 * time.Second):
+		t.Fatalf("%s: did not return", name)
+	}
+}
+
+// TestStreamSessionReaderEOF verifies a clean remote EOF ends the
+// session: the reader winds the group down so Wait returns and Recv
+// closes, instead of leaving the writer and kill watchers parked.
+func TestStreamSessionReaderEOF(t *testing.T) {
+	c1, c2 := net.Pipe()
+	s := newStringSession(c1)
+	core.AssertMustNoError(t, s.Spawn(), "Spawn")
+
+	// the peer disconnects; the reader observes a clean EOF.
+	core.AssertMustNoError(t, c2.Close(), "peer Close")
+
+	// the inbound channel closes...
+	_, ok := nextWithin(t, s, "Next after EOF")
+	core.AssertFalse(t, ok, "Next after EOF")
+
+	// ...and the session winds down without hanging.
+	assertWaitReturns(t, s, "Wait after EOF")
 }
 
 // TestStreamSessionOnErrorFiresOnParentCancel verifies the OnError
@@ -253,4 +294,40 @@ func TestStreamSessionOnErrorFiresOnParentCancel(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("Wait did not return")
 	}
+}
+
+// TestStreamSessionShutdownUnblocksReader verifies a shutdown frees a
+// reader parked on the unbuffered inbound channel. The peer sends a
+// frame the consumer never drains; closing the connection alone would
+// not release the pending send, so the reader must also observe the
+// cancelled context.
+func TestStreamSessionShutdownUnblocksReader(t *testing.T) {
+	c1, c2 := net.Pipe()
+	defer func() { _ = c2.Close() }()
+
+	// UnsetReadDeadline fires after a frame is scanned and before it is
+	// delivered, so it signals that the reader is about to block on the
+	// undrained channel.
+	reading := make(chan struct{}, 1)
+	s := newStringSession(c1)
+	s.UnsetReadDeadline = func() error {
+		select {
+		case reading <- struct{}{}:
+		default:
+		}
+		return nil
+	}
+	core.AssertMustNoError(t, s.Spawn(), "Spawn")
+
+	go func() { _, _ = c2.Write([]byte("stuck\n")) }()
+	select {
+	case <-reading:
+	case <-time.After(2 * time.Second):
+		t.Fatal("reader did not reach the delivery point")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	core.AssertErrorIs(t, s.Shutdown(ctx), context.Canceled, "Shutdown")
+	assertWaitReturns(t, s, "Wait after shutdown")
 }

--- a/net/reconnect/utils.go
+++ b/net/reconnect/utils.go
@@ -29,8 +29,15 @@ func newDialer(keepalive, timeout time.Duration) *stdnet.Dialer {
 	}
 }
 
-func unsafeClose(f io.Closer) {
-	_ = f.Close()
+// unsafeClose closes each closer ignoring any error. A nil closer is
+// skipped, so callers can close a resource that may never have been
+// established without guarding the call site.
+func unsafeClose(ff ...io.Closer) {
+	for _, f := range ff {
+		if f != nil {
+			_ = f.Close()
+		}
+	}
 }
 
 // TimeoutToAbsoluteTime adds the given [time.Duration] to a

--- a/net/reconnect/utils_private_test.go
+++ b/net/reconnect/utils_private_test.go
@@ -1,0 +1,41 @@
+package reconnect
+
+import (
+	"net"
+	"testing"
+
+	"darvaza.org/core"
+)
+
+// TestUnsafeClose lives in the white-box test package because
+// unsafeClose is unexported and has no public equivalent to drive its
+// nil-safe, variadic behaviour through.
+func TestUnsafeClose(t *testing.T) {
+	t.Run("nil is a no-op", runTestUnsafeCloseNil)
+	t.Run("closes the connections", runTestUnsafeCloseConn)
+}
+
+func runTestUnsafeCloseNil(t *testing.T) {
+	t.Helper()
+
+	// a nil closer must be a no-op, not a panic: Connect closes the
+	// conn on a failed worker spawn even after a non-fatal dial miss
+	// left it nil.
+	core.AssertNoPanic(t, func() { unsafeClose(nil) }, "unsafeClose(nil)")
+}
+
+func runTestUnsafeCloseConn(t *testing.T) {
+	t.Helper()
+
+	c1, c2 := net.Pipe()
+
+	// a nil closer mixed into the variadic list is skipped; the real
+	// connections still close.
+	unsafeClose(c1, nil, c2)
+
+	// both ends are closed: a write now fails on either.
+	_, err := c1.Write([]byte("x"))
+	core.AssertError(t, err, "write after close (c1)")
+	_, err = c2.Write([]byte("x"))
+	core.AssertError(t, err, "write after close (c2)")
+}

--- a/net/reconnect/utils_test.go
+++ b/net/reconnect/utils_test.go
@@ -1,10 +1,12 @@
-package reconnect
+package reconnect_test
 
 import (
 	"testing"
 	"time"
 
 	"darvaza.org/core"
+
+	"darvaza.org/x/net/reconnect"
 )
 
 // Compile-time verification that test case types implement TestCase interface
@@ -37,7 +39,7 @@ func (tc parseRemoteTestCase) Name() string {
 func (tc parseRemoteTestCase) Test(t *testing.T) {
 	t.Helper()
 
-	network, address, err := ParseRemote(tc.input)
+	network, address, err := reconnect.ParseRemote(tc.input)
 	if tc.wantErr {
 		core.AssertError(t, err, "ParseRemote")
 		return
@@ -119,7 +121,7 @@ func (tc timeoutToAbsoluteTimeTestCase) Name() string {
 func (tc timeoutToAbsoluteTimeTestCase) Test(t *testing.T) {
 	t.Helper()
 
-	result := TimeoutToAbsoluteTime(tc.base, tc.duration)
+	result := reconnect.TimeoutToAbsoluteTime(tc.base, tc.duration)
 	core.AssertEqual(t, tc.expected, result, "timeout")
 }
 
@@ -144,7 +146,7 @@ func makeTimeoutToAbsoluteTimeTestCases() []core.TestCase {
 func runTestTimeoutToAbsoluteTimePositiveDurationWithZeroBase(t *testing.T) {
 	t.Helper()
 	before := time.Now()
-	result := TimeoutToAbsoluteTime(time.Time{}, 5*time.Second)
+	result := reconnect.TimeoutToAbsoluteTime(time.Time{}, 5*time.Second)
 	after := time.Now()
 
 	// Result should be between before+5s and after+5s

--- a/net/reconnect/waiter.go
+++ b/net/reconnect/waiter.go
@@ -6,20 +6,21 @@ import (
 )
 
 const (
-	// DefaultWaitReconnect specifies how long we will wait for
-	// to reconnect by default
+	// DefaultWaitReconnect specifies how long [NewConstantWaiter]
+	// waits between reconnection attempts by default.
 	DefaultWaitReconnect = 5 * time.Second
 )
 
-// A Waiter is a function that blocks and returns an
-// error when cancelled or nil when we are good to continue.
+// A Waiter is a function that blocks between reconnection
+// attempts. It returns nil when the [Client] is good to try
+// again, or an error to stop reconnecting.
 type Waiter func(context.Context) error
 
 // NewConstantWaiter blocks for a given amount of time, or until
 // the context is cancelled.
-// If the given duration is negative, the [Waiter] won't wait, but
-// it will still check for context terminations.
-// If zero, the [Waiter] will wait the default amount.
+// If the given duration is zero, [DefaultWaitReconnect] is used.
+// If negative, reconnecting is disabled, failing with
+// [ErrDoNotReconnect].
 func NewConstantWaiter(d time.Duration) func(context.Context) error {
 	if d < 0 {
 		return NewImmediateErrorWaiter(ErrDoNotReconnect)
@@ -39,9 +40,10 @@ func NewConstantWaiter(d time.Duration) func(context.Context) error {
 	}
 }
 
-// NewImmediateErrorWaiter returns a Waiter that will return the
-// context cancellation cause or the specified error, if any.
-// There is no actual waiting.
+// NewImmediateErrorWaiter returns a [Waiter] that doesn't wait.
+// It returns the context's error if the context has already
+// terminated, or the given error otherwise. A nil error allows
+// an immediate reconnection attempt.
 func NewImmediateErrorWaiter(err error) func(context.Context) error {
 	return func(ctx context.Context) error {
 		select {
@@ -53,8 +55,10 @@ func NewImmediateErrorWaiter(err error) func(context.Context) error {
 	}
 }
 
-// NewDoNotReconnectWaiter returns a Waiter that will return the
-// context cancellation cause, the specified error, or ErrDoNotReconnect.
+// NewDoNotReconnectWaiter returns a [Waiter] that stops
+// reconnection attempts, failing with the given error, or
+// [ErrDoNotReconnect] when nil. The context's error takes
+// precedence if the context has already terminated.
 func NewDoNotReconnectWaiter(err error) func(context.Context) error {
 	if err == nil {
 		err = ErrDoNotReconnect

--- a/net/reconnect/worker.go
+++ b/net/reconnect/worker.go
@@ -7,13 +7,14 @@ import (
 	"darvaza.org/core"
 )
 
-// WorkerFunc is a run function for core.ErrGroup's GoCatch.
+// WorkerFunc is a run function for [WorkGroup.GoCatch].
 type WorkerFunc func(context.Context) error
 
-// CatcherFunc is a catch function for core.ErrGroup's GoCatch.
+// CatcherFunc is a catch function for [WorkGroup.GoCatch].
 type CatcherFunc func(context.Context, error) error
 
-// A WorkGroup is an error group interface.
+// A WorkGroup is an error group interface. Submissions through Go and
+// GoCatch after shutdown are no-ops.
 type WorkGroup interface {
 	Go(...WorkerFunc)
 	GoCatch(WorkerFunc, CatcherFunc)


### PR DESCRIPTION
## Why

`net/reconnect` could not be shut down or relied on to reconnect
correctly. A `Shutdown` blocked until its own deadline whenever
`OnSession` was parked on a deadline-less `Read`; a non-fatal waiter
error or an expired (rather than literally cancelled) context spun the
reconnection loop at 100% CPU; and a panicking `OnSession` was
swallowed entirely, the client reconnecting as if nothing had gone
wrong. This branch makes the lifecycle behave the way the documentation
already promised.

## What changes

### Shutdown and cancellation actually unwind the session

- **close the live connection on cancel** — `Shutdown` cancelled the
  context but left the connection open, so an `OnSession` blocked on a
  deadline-less `Read` never noticed and `Shutdown` blocked until its
  own deadline. A watcher now closes the live connection once the
  context is cancelled, freeing the read; because it keys off the
  context, a cancelled *parent* context unblocks the session too. A
  cancellation landing between the dial and the connection being stored
  is consumed against nothing, so `runSession` now winds down with the
  cancellation cause instead of entering `OnSession`.
- **make StreamSession shutdown reliable** — closes four
  shutdown-correctness gaps: a clean inbound EOF left the session
  running (the reader now cancels the group when its stream ends); a
  reader parked on the unbuffered inbound channel ignored a shutdown
  (delivery now selects against the group context); `Send` before
  `Spawn` blocked on a nil channel instead of panicking via
  `mustStarted`; and `Send` after shutdown reported the foreign
  `fs.ErrClosed` instead of the package's `ErrClosed`. It also fixes
  the kill-watcher enrolment race that cancelling-on-EOF exposed.

### The reconnection loop stops when it should

- **stop reconnecting once the context is done** — `handleConnectError`
  only recognised a literal `context.Canceled`. A deadline expiry
  (`context.DeadlineExceeded`) or a wrapped cancellation classified as
  temporary, spinning the loop at full CPU. Detection now walks the
  error chain with `core.IsError` and falls back to the client's own
  context; `Connect` also refuses to start against an already-expired
  context.
- **surface OnSession panics through the error path** — `runSession`
  used `Catcher.Try`, storing the recovered value in a `Catcher` that
  was never read, so a panic returned nil — indistinguishable from a
  clean end. It now uses `Catcher.Do`, so the panic flows through
  `doOnError`/`IsFatal` as a `core.PanicError`.

### Lifecycle migrated to workgroup.Group

- **adopt workgroup.Group for the lifecycle** — replaces the
  hand-rolled `sync.WaitGroup` + cancel func + mutex-guarded error with
  a `workgroup.Group`. As a result a waiter error now stops the client
  unconditionally (its contract), and parent-context cancellation
  causes now surface through `Err`/`Wait` instead of reporting nil.
  `Connect` returns the new `ErrClosed` sentinel when a shutdown wins
  the dial-vs-spawn race, and `Go`/`GoCatch` after shutdown are no-ops
  that log the dropped worker at debug. `ErrNotConnected` wraps
  `ErrClosed`, so one `errors.Is` target covers both a closed client
  and the not-connected window.
- **migrate StreamSession to workgroup.Group** — the same primitive for
  `StreamSession`, with `goWithKill` restoring the per-worker kill hook
  `ErrGroup` provided. `Wait` now returns nil on a clean shutdown,
  matching `workgroup.Group`'s contract. The `OnError` bridge is wired
  ahead of `setDefaults()`, so a cancellation landing while the
  workgroup context is being realised still delivers its cause.

This adds a dependency on `darvaza.org/x/sync v0.4.2`, recorded in the
repo dependency graph (`README.md`, `RELEASE.md`); `RELEASE.md` also
gains the `text` package its tier-1 list had been missing.

### Supporting changes

- **make unsafeClose nil-safe and variadic** — so a call site can close
  a resource that may never have been established without guarding the
  call.
- **align documentation with the contract** — the README, doc comments
  and `net/AGENTS.md` had drifted from the real API (fatal-error rules,
  waiter semantics, timeout application, the fictional
  `NewClient`/`With*` examples) and described behaviour the code never
  had.
- **exercise config and utils via the public package** — move
  `config_test.go`/`utils_test.go` to `package reconnect_test`, testing
  through the exported surface per convention.

## Tests

Each behavioural fix lands with a regression test that bounds the
lifecycle so a regression fails cleanly rather than hanging the suite:
`Shutdown` releases a parked `Read` within its deadline; a clean remote
EOF winds the session down; a shutdown frees a parked reader; `Send`
before `Spawn` panics and `Send` after shutdown reports `ErrClosed`;
the loop stops once a deadline fires mid-session and `Connect` refuses
an already-expired context; an `OnSession` panic reaches `OnError` as a
`core.PanicError` while `Wait` reports a clean stop; a waiter error
stops the client; and white-box seams deterministically pin the two
cancellation windows (during `StreamSession` init, and between the
`Client`'s dial and the connection being stored). `stream.go`, previously
uncovered, gains its first tests, and a final commit covers the
reconnect paths (`tryReconnect`/`handleReconnectError`) and the
connection accessors end to end (`client_conn_test.go`), lifting
`net/reconnect` self-coverage from 69% to 81%.

`make all race` passes repo-wide; CI (Test, Race Detection, Codecov,
Build) re-runs on push.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated reconnecting-client and stream-session guides: clarified callback ownership/blocking expectations, connection lifecycle timing, reconnect-delay semantics, and error-handling contracts (including `OnError` stop/continue behavior).
  * Expanded Unix socket guidance (including Linux abstract namespace) and refined method/timeout documentation.
* **Improvements**
  * Enhanced shutdown and reconnection sequencing to reliably unblock blocked I/O and improve reconnection orchestration.
* **Bug Fixes**
  * Aligned “not connected” errors with closed/shutdown behavior.
* **Tests**
  * Added broader client and stream-session coverage for cancellation causes, panic→error routing, and reconnect outcomes.
* **Dependencies**
  * Added `darvaza.org/x/sync`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

