### PR TITLE
container/set: add Len, migrate tests to TESTING.md, close coverage gaps

### DIFF
--- a/container/set/config_test.go
+++ b/container/set/config_test.go
@@ -1,0 +1,52 @@
+package set_test
+
+import (
+	"testing"
+
+	"darvaza.org/core"
+
+	"darvaza.org/x/container/set"
+)
+
+func testConfigEqualDifferentItemKey(t *testing.T) {
+	hashFn := func(k int) (int, error) { return k, nil }
+	matchFn := func(k int, v testItem) bool { return k == v.ID }
+	cfg1 := set.Config[int, int, testItem]{
+		ItemKey: func(v testItem) (int, error) { return v.ID, nil }, Hash: hashFn, ItemMatch: matchFn,
+	}
+	cfg2 := set.Config[int, int, testItem]{
+		ItemKey: func(v testItem) (int, error) { return v.ID, nil }, Hash: hashFn, ItemMatch: matchFn,
+	}
+
+	core.AssertFalse(t, cfg1.Equal(cfg2), "differing ItemKey")
+}
+
+func testConfigEqualDifferentItemMatch(t *testing.T) {
+	keyFn := func(v testItem) (int, error) { return v.ID, nil }
+	hashFn := func(k int) (int, error) { return k, nil }
+	cfg1 := set.Config[int, int, testItem]{
+		ItemKey: keyFn, Hash: hashFn, ItemMatch: func(k int, v testItem) bool { return k == v.ID },
+	}
+	cfg2 := set.Config[int, int, testItem]{
+		ItemKey: keyFn, Hash: hashFn, ItemMatch: func(k int, v testItem) bool { return k == v.ID },
+	}
+
+	core.AssertFalse(t, cfg1.Equal(cfg2), "differing ItemMatch")
+}
+
+func testConfigEqualNilCallbacks(t *testing.T) {
+	full := testConfig()
+	var empty set.Config[int, int, testItem]
+
+	// two configs with nil callbacks compare equal (both nil).
+	core.AssertTrue(t, empty.Equal(empty), "two empty configs")
+	// a nil callback never matches a non-nil one.
+	core.AssertFalse(t, empty.Equal(full), "empty versus full")
+	core.AssertFalse(t, full.Equal(empty), "full versus empty")
+}
+
+func TestConfigEqualPartial(t *testing.T) {
+	t.Run("different ItemKey", testConfigEqualDifferentItemKey)
+	t.Run("different ItemMatch", testConfigEqualDifferentItemMatch)
+	t.Run("nil callbacks", testConfigEqualNilCallbacks)
+}

--- a/container/set/set_copy_test.go
+++ b/container/set/set_copy_test.go
@@ -1,0 +1,156 @@
+package set_test
+
+import (
+	"testing"
+
+	"darvaza.org/core"
+
+	"darvaza.org/x/container/set"
+)
+
+func testCopyIntoUninitialisedDst(t *testing.T) {
+	cfg := testConfig()
+	src := cfg.Must(testItem{ID: 1, Name: "one"}, testItem{ID: 2, Name: "two"})
+	dst := &set.Set[int, int, testItem]{}
+
+	got := src.Copy(dst, nil)
+
+	core.AssertSame(t, dst, got, "dst returned")
+	assertHasIDs(t, dst, 1, 2)
+
+	// the copy must be independent: mutating src must not touch dst.
+	_, _ = src.Push(testItem{ID: 3, Name: "three"})
+	core.AssertFalse(t, dst.Contains(3), "dst independent of src")
+}
+
+func testCopyIntoCompatibleDst(t *testing.T) {
+	// src and dst share the same Config, so Copy takes the append path.
+	cfg := testConfig()
+	src := cfg.Must(
+		testItem{ID: 1, Name: "one"},     // hash 1, also present in dst
+		testItem{ID: 11, Name: "eleven"}, // hash 1, new entry in existing bucket
+		testItem{ID: 2, Name: "two"},     // hash 2, new bucket
+	)
+	dst := cfg.Must(
+		testItem{ID: 1, Name: "one"},
+		testItem{ID: 3, Name: "three"},
+	)
+
+	got := src.Copy(dst, nil)
+
+	core.AssertSame(t, dst, got, "dst returned")
+	// union with ID 1 deduplicated, not doubled.
+	assertHasIDs(t, dst, 1, 2, 3, 11)
+}
+
+func testCopyIntoCompatibleDstFiltered(t *testing.T) {
+	cfg := testConfig()
+	src := cfg.Must(
+		testItem{ID: 1, Name: "one"},
+		testItem{ID: 2, Name: "two"},
+		testItem{ID: 3, Name: "three"},
+	)
+	dst := cfg.Must(testItem{ID: 4, Name: "four"})
+
+	got := src.Copy(dst, func(v testItem) bool { return v.ID != 2 })
+
+	core.AssertSame(t, dst, got, "dst returned")
+	assertHasIDs(t, dst, 1, 3, 4)
+}
+
+func testCopyIntoEmptyCompatibleDst(t *testing.T) {
+	// dst is initialised but empty, exercising the bucket preallocation.
+	cfg := testConfig()
+	src := cfg.Must(testItem{ID: 1, Name: "one"}, testItem{ID: 2, Name: "two"})
+	dst := cfg.Must()
+
+	got := src.Copy(dst, nil)
+
+	core.AssertSame(t, dst, got, "dst returned")
+	assertHasIDs(t, dst, 1, 2)
+}
+
+func testCopyIntoIncompatibleDst(t *testing.T) {
+	// distinct Config instances are not Equal, so Copy falls back to Push.
+	src := testConfig().Must(testItem{ID: 1, Name: "one"}, testItem{ID: 2, Name: "two"})
+	dst := testConfig().Must(testItem{ID: 3, Name: "three"})
+
+	got := src.Copy(dst, nil)
+
+	core.AssertSame(t, dst, got, "dst returned")
+	assertHasIDs(t, dst, 1, 2, 3)
+}
+
+func testCopyIntoIncompatibleDstFiltered(t *testing.T) {
+	src := testConfig().Must(
+		testItem{ID: 1, Name: "one"},
+		testItem{ID: 2, Name: "two"},
+		testItem{ID: 3, Name: "three"},
+	)
+	dst := testConfig().Must()
+
+	got := src.Copy(dst, func(v testItem) bool { return v.ID%2 == 0 })
+
+	core.AssertSame(t, dst, got, "dst returned")
+	assertHasIDs(t, dst, 2)
+}
+
+func TestCopyIntoDestination(t *testing.T) {
+	t.Run("uninitialised dst", testCopyIntoUninitialisedDst)
+	t.Run("compatible dst", testCopyIntoCompatibleDst)
+	t.Run("compatible dst filtered", testCopyIntoCompatibleDstFiltered)
+	t.Run("empty compatible dst", testCopyIntoEmptyCompatibleDst)
+	t.Run("incompatible dst", testCopyIntoIncompatibleDst)
+	t.Run("incompatible dst filtered", testCopyIntoIncompatibleDstFiltered)
+}
+
+func testCopySameSrcDst(t *testing.T) {
+	cfg := testConfig()
+	s := cfg.Must(testItem{ID: 1, Name: "one"}, testItem{ID: 2, Name: "two"})
+
+	got := s.Copy(s, nil)
+
+	core.AssertSame(t, s, got, "source returned unchanged")
+	assertHasIDs(t, s, 1, 2)
+}
+
+func testCopyNilSource(t *testing.T) {
+	var src *set.Set[int, int, testItem]
+	dst := testConfig().Must(testItem{ID: 1, Name: "one"})
+
+	got := src.Copy(dst, nil)
+
+	core.AssertSame(t, dst, got, "dst returned unchanged")
+	assertHasIDs(t, dst, 1)
+}
+
+func testCopyUninitialisedSource(t *testing.T) {
+	src := &set.Set[int, int, testItem]{}
+	dst := testConfig().Must(testItem{ID: 1, Name: "one"})
+
+	got := src.Copy(dst, nil)
+
+	core.AssertSame(t, dst, got, "dst returned unchanged")
+	assertHasIDs(t, dst, 1)
+}
+
+func TestCopyNoOp(t *testing.T) {
+	t.Run("source equals destination", testCopySameSrcDst)
+	t.Run("nil source", testCopyNilSource)
+	t.Run("uninitialised source", testCopyUninitialisedSource)
+}
+
+func testCloneNilReceiver(t *testing.T) {
+	var s *set.Set[int, int, testItem]
+	core.AssertNil(t, s.Clone(), "clone of nil receiver")
+}
+
+func testCloneUninitialised(t *testing.T) {
+	s := &set.Set[int, int, testItem]{}
+	core.AssertNil(t, s.Clone(), "clone of uninitialised set")
+}
+
+func TestCloneInvalid(t *testing.T) {
+	t.Run("nil receiver", testCloneNilReceiver)
+	t.Run("uninitialised", testCloneUninitialised)
+}

--- a/container/set/set_foreach.go
+++ b/container/set/set_foreach.go
@@ -1,5 +1,22 @@
 package set
 
+// Len returns the number of values in the [Set].
+func (set *Set[K, H, T]) Len() int {
+	if set == nil {
+		return 0
+	}
+
+	// RO
+	set.mu.RLock()
+	defer set.mu.RUnlock()
+
+	var count int
+	for _, l := range set.buckets {
+		count += l.Len()
+	}
+	return count
+}
+
 // Values returns all values in the [Set].
 func (set *Set[K, H, T]) Values() []T {
 	if set == nil {

--- a/container/set/set_foreach_test.go
+++ b/container/set/set_foreach_test.go
@@ -47,3 +47,46 @@ func TestForEachEdge(t *testing.T) {
 	t.Run("nil function", testForEachNilFunc)
 	t.Run("uninitialised", testForEachUninitialised)
 }
+
+var _ core.TestCase = lenTestCase{}
+
+// lenTestCase verifies Set.Len across receiver states and bucket layouts.
+type lenTestCase struct {
+	name string
+	set  *set.Set[int, int, testItem]
+	want int
+}
+
+func newLenTestCase(name string, s *set.Set[int, int, testItem], want int) lenTestCase {
+	return lenTestCase{
+		name: name,
+		set:  s,
+		want: want,
+	}
+}
+
+func (tc lenTestCase) Name() string {
+	return tc.name
+}
+
+func (tc lenTestCase) Test(t *testing.T) {
+	t.Helper()
+	core.AssertEqual(t, tc.want, tc.set.Len(), "len")
+}
+
+func lenTestCases() []lenTestCase {
+	cfg := testConfig()
+	return []lenTestCase{
+		newLenTestCase("nil receiver", nil, 0),
+		newLenTestCase("uninitialised", &set.Set[int, int, testItem]{}, 0),
+		newLenTestCase("empty", cfg.Must(), 0),
+		newLenTestCase("populated", cfg.Must(makeTestItems()...), 2),
+		// IDs 1, 11, 21 and 31 all hash to bucket 1, so a single bucket
+		// holds every entry; Len must sum the list, not count buckets.
+		newLenTestCase("hash collisions", cfg.Must(makeHashCollisionItems()...), 4),
+	}
+}
+
+func TestLen(t *testing.T) {
+	core.RunTestCases(t, lenTestCases())
+}

--- a/container/set/set_foreach_test.go
+++ b/container/set/set_foreach_test.go
@@ -1,0 +1,49 @@
+package set_test
+
+import (
+	"testing"
+
+	"darvaza.org/core"
+
+	"darvaza.org/x/container/set"
+)
+
+func testValuesNilReceiver(t *testing.T) {
+	var s *set.Set[int, int, testItem]
+	core.AssertNil(t, s.Values(), "values on nil receiver")
+}
+
+func testValuesUninitialised(t *testing.T) {
+	s := &set.Set[int, int, testItem]{}
+	core.AssertNil(t, s.Values(), "values on uninitialised")
+}
+
+func TestValuesEdge(t *testing.T) {
+	t.Run("nil receiver", testValuesNilReceiver)
+	t.Run("uninitialised", testValuesUninitialised)
+}
+
+func testForEachNilReceiver(t *testing.T) {
+	var s *set.Set[int, int, testItem]
+	count := 0
+	s.ForEach(func(testItem) bool { count++; return true })
+	core.AssertEqual(t, 0, count, "no iteration on nil receiver")
+}
+
+func testForEachNilFunc(t *testing.T) {
+	s := testConfig().Must(testItem{ID: 1, Name: "one"})
+	core.AssertNoPanic(t, func() { s.ForEach(nil) }, "nil function is a no-op")
+}
+
+func testForEachUninitialised(t *testing.T) {
+	s := &set.Set[int, int, testItem]{}
+	count := 0
+	s.ForEach(func(testItem) bool { count++; return true })
+	core.AssertEqual(t, 0, count, "no iteration on uninitialised")
+}
+
+func TestForEachEdge(t *testing.T) {
+	t.Run("nil receiver", testForEachNilReceiver)
+	t.Run("nil function", testForEachNilFunc)
+	t.Run("uninitialised", testForEachUninitialised)
+}

--- a/container/set/set_private_test.go
+++ b/container/set/set_private_test.go
@@ -1,0 +1,16 @@
+package set
+
+import (
+	"testing"
+
+	"darvaza.org/core"
+)
+
+// TestInitNilReceiver covers Set.init's nil-receiver guard. The public
+// Config.Init rejects a nil set before delegating, so this branch is only
+// reachable white-box.
+func TestInitNilReceiver(t *testing.T) {
+	var s *Set[int, int, int]
+	core.AssertErrorIs(t, s.init(Config[int, int, int]{}), core.ErrNilReceiver,
+		"init on nil receiver")
+}

--- a/container/set/set_simple_test.go
+++ b/container/set/set_simple_test.go
@@ -1,51 +1,47 @@
-package set
+package set_test
 
 import (
 	"fmt"
 	"sync"
 	"testing"
+
+	"darvaza.org/core"
+
+	"darvaza.org/x/container/set"
 )
 
-func doTestPush(t *testing.T, s *Set[int, int, testItem]) {
-	item := testItem{ID: 1, Name: "test"}
-	if _, err := s.Push(item); err != nil {
-		t.Fatalf("Push failed: %v", err)
-	}
+func doTestPush(t *testing.T, s *set.Set[int, int, testItem]) {
+	t.Helper()
+	_, err := s.Push(testItem{ID: 1, Name: "test"})
+	core.AssertMustNoError(t, err, "push")
 }
 
-func doTestContains(t *testing.T, s *Set[int, int, testItem]) {
-	if !s.Contains(1) {
-		t.Error("Contains should return true")
-	}
+func doTestContains(t *testing.T, s *set.Set[int, int, testItem]) {
+	t.Helper()
+	core.AssertTrue(t, s.Contains(1), "contains")
 }
 
-func doTestGet(t *testing.T, s *Set[int, int, testItem]) {
-	if v, err := s.Get(1); err != nil {
-		t.Errorf("Get failed: %v", err)
-	} else if v.ID != 1 {
-		t.Errorf("Get returned wrong item: %+v", v)
-	}
+func doTestGet(t *testing.T, s *set.Set[int, int, testItem]) {
+	t.Helper()
+	v, err := s.Get(1)
+	core.AssertNoError(t, err, "get")
+	core.AssertEqual(t, 1, v.ID, "id")
 }
 
-func doTestPop(t *testing.T, s *Set[int, int, testItem]) {
-	if _, err := s.Pop(1); err != nil {
-		t.Errorf("Pop failed: %v", err)
-	}
+func doTestPop(t *testing.T, s *set.Set[int, int, testItem]) {
+	t.Helper()
+	_, err := s.Pop(1)
+	core.AssertNoError(t, err, "pop")
 }
 
-func doTestVerifyRemoved(t *testing.T, s *Set[int, int, testItem]) {
-	if s.Contains(1) {
-		t.Error("Item should be removed")
-	}
+func doTestVerifyRemoved(t *testing.T, s *set.Set[int, int, testItem]) {
+	t.Helper()
+	core.AssertFalse(t, s.Contains(1), "removed")
 }
 
-// Simple test to ensure basic functionality works
+// TestSetBasicOperations exercises the push/contains/get/pop lifecycle.
 func TestSetBasicOperations(t *testing.T) {
-	cfg := testConfig()
-	s, err := cfg.New()
-	if err != nil {
-		t.Fatalf("New failed: %v", err)
-	}
+	s := testConfig().Must()
 
 	doTestPush(t, s)
 	doTestContains(t, s)
@@ -54,20 +50,15 @@ func TestSetBasicOperations(t *testing.T) {
 	doTestVerifyRemoved(t, s)
 }
 
-func runConcurrentAdds(s *Set[int, int, testItem], wg *sync.WaitGroup, base, itemsPerGoroutine int) {
+func runConcurrentAdds(s *set.Set[int, int, testItem], wg *sync.WaitGroup, base, itemsPerGoroutine int) {
 	defer wg.Done()
 	for j := range itemsPerGoroutine {
 		id := base*itemsPerGoroutine + j
-		item := testItem{
-			ID:    id,
-			Name:  "test",
-			Value: "value",
-		}
-		_, _ = s.Push(item)
+		_, _ = s.Push(testItem{ID: id, Name: "test", Value: "value"})
 	}
 }
 
-func runConcurrentRemoves(s *Set[int, int, testItem], wg *sync.WaitGroup, base, itemsPerGoroutine int) {
+func runConcurrentRemoves(s *set.Set[int, int, testItem], wg *sync.WaitGroup, base, itemsPerGoroutine int) {
 	defer wg.Done()
 	for j := range itemsPerGoroutine {
 		id := base*itemsPerGoroutine + j
@@ -77,48 +68,33 @@ func runConcurrentRemoves(s *Set[int, int, testItem], wg *sync.WaitGroup, base, 
 	}
 }
 
-// TestSetConcurrency tests thread safety of set operations
+// TestSetConcurrency tests thread safety of set operations.
 func TestSetConcurrency(t *testing.T) {
-	cfg := testConfig()
-	s, err := cfg.New()
-	if err != nil {
-		t.Fatalf("New failed: %v", err)
-	}
+	s := testConfig().Must()
 
 	const numGoroutines = 10
 	const itemsPerGoroutine = 100
 
 	var wg sync.WaitGroup
-	wg.Add(numGoroutines * 2) // Half adding, half removing
+	wg.Add(numGoroutines * 2) // half adding, half removing
 
-	// Start goroutines that add items
 	for i := range numGoroutines {
 		go runConcurrentAdds(s, &wg, i, itemsPerGoroutine)
 	}
-
-	// Start goroutines that remove items
 	for i := range numGoroutines {
 		go runConcurrentRemoves(s, &wg, i, itemsPerGoroutine)
 	}
 
 	wg.Wait()
 
-	// Verify the set is in a consistent state
-	// Just check that we can iterate without panic
-	count := 0
-	s.ForEach(func(_ testItem) bool {
-		count++
-		return false
-	})
-	t.Logf("Set contains %d items after concurrent operations", count)
+	// the set must remain iterable without panicking.
+	core.AssertNoPanic(t, func() { s.ForEach(func(testItem) bool { return true }) }, "iterable")
 }
 
-func makeFilledSet(b *testing.B, size int) *Set[int, int, testItem] {
-	cfg := testConfig()
-	s, _ := cfg.New()
+func makeFilledSet(b *testing.B, size int) *set.Set[int, int, testItem] {
+	s := testConfig().Must()
 	for i := range size {
-		_, err := s.Push(testItem{ID: i})
-		if err != nil {
+		if _, err := s.Push(testItem{ID: i}); err != nil {
 			b.Fatalf("Failed to populate set: %v", err)
 		}
 	}
@@ -129,12 +105,11 @@ func doBenchmarkSetPush(b *testing.B, size int) {
 	s := makeFilledSet(b, size)
 	b.ResetTimer()
 	for i := range b.N {
-		item := testItem{ID: size + i}
-		_, err := s.Push(item)
-		if err != nil && err != ErrExist {
+		_, err := s.Push(testItem{ID: size + i})
+		if err != nil && err != set.ErrExist {
 			b.Fatalf("Push failed: %v", err)
 		}
-		_, _ = s.Pop(size + i) // Clean up to maintain size
+		_, _ = s.Pop(size + i) // clean up to maintain size
 	}
 }
 
@@ -144,8 +119,7 @@ func doBenchmarkSetPop(b *testing.B, size int) {
 	for i := range b.N {
 		id := i % size
 		_, _ = s.Pop(id)
-		_, err := s.Push(testItem{ID: id}) // Re-add to maintain set
-		if err != nil {
+		if _, err := s.Push(testItem{ID: id}); err != nil { // re-add to maintain set
 			b.Fatalf("Re-add failed: %v", err)
 		}
 	}
@@ -162,8 +136,7 @@ func doBenchmarkSetContains(b *testing.B, size int) {
 // Benchmarks
 
 func BenchmarkSetPush(b *testing.B) {
-	sizes := []int{10, 1000, 10000}
-	for _, size := range sizes {
+	for _, size := range core.S(10, 1000, 10000) {
 		b.Run(fmt.Sprintf("size=%d", size), func(b *testing.B) {
 			doBenchmarkSetPush(b, size)
 		})
@@ -171,8 +144,7 @@ func BenchmarkSetPush(b *testing.B) {
 }
 
 func BenchmarkSetPop(b *testing.B) {
-	sizes := []int{10, 1000, 10000}
-	for _, size := range sizes {
+	for _, size := range core.S(10, 1000, 10000) {
 		b.Run(fmt.Sprintf("size=%d", size), func(b *testing.B) {
 			doBenchmarkSetPop(b, size)
 		})
@@ -180,8 +152,7 @@ func BenchmarkSetPop(b *testing.B) {
 }
 
 func BenchmarkSetContains(b *testing.B) {
-	sizes := []int{10, 1000, 10000}
-	for _, size := range sizes {
+	for _, size := range core.S(10, 1000, 10000) {
 		b.Run(fmt.Sprintf("size=%d", size), func(b *testing.B) {
 			doBenchmarkSetContains(b, size)
 		})

--- a/container/set/set_test.go
+++ b/container/set/set_test.go
@@ -362,3 +362,81 @@ func TestHashCollisions(t *testing.T) {
 	assertGetAll(t, s, items)
 	assertHasIDs(t, s, 1, 11, 21, 31)
 }
+
+// errKeyConfig is a valid Config whose ItemKey rejects negative IDs, used to
+// drive the error paths of Push and the initial bulk insert.
+func errKeyConfig() set.Config[int, int, testItem] {
+	cfg := testConfig()
+	cfg.ItemKey = func(v testItem) (int, error) {
+		if v.ID < 0 {
+			return 0, core.ErrInvalid
+		}
+		return v.ID, nil
+	}
+	return cfg
+}
+
+func TestInitItemKeyError(t *testing.T) {
+	cfg := errKeyConfig()
+	_, err := cfg.New(testItem{ID: -1, Name: "negative"})
+	core.AssertErrorIs(t, err, core.ErrInvalid, "New with failing ItemKey")
+}
+
+func testResetNilReceiver(t *testing.T) {
+	var s *set.Set[int, int, testItem]
+	core.AssertErrorIs(t, s.Reset(), core.ErrNilReceiver, "reset nil receiver")
+}
+
+func testResetUninitialised(t *testing.T) {
+	s := &set.Set[int, int, testItem]{}
+	core.AssertErrorIs(t, s.Reset(), core.ErrInvalid, "reset uninitialised")
+}
+
+func TestResetErrors(t *testing.T) {
+	t.Run("nil receiver", testResetNilReceiver)
+	t.Run("uninitialised", testResetUninitialised)
+}
+
+func testPopNilReceiver(t *testing.T) {
+	var s *set.Set[int, int, testItem]
+	_, err := s.Pop(1)
+	core.AssertErrorIs(t, err, core.ErrNilReceiver, "pop nil receiver")
+}
+
+func testPopHashCollisionMiss(t *testing.T) {
+	// ID 1 and 11 share hash 1; popping 11 finds the bucket but no match.
+	s := testConfig().Must(testItem{ID: 1, Name: "one"})
+
+	_, err := s.Pop(11)
+
+	core.AssertErrorIs(t, err, set.ErrNotExist, "pop absent key in existing bucket")
+	core.AssertTrue(t, s.Contains(1), "original entry retained")
+}
+
+func TestPopErrors(t *testing.T) {
+	t.Run("nil receiver", testPopNilReceiver)
+	t.Run("hash collision miss", testPopHashCollisionMiss)
+}
+
+func testGetUninitialised(t *testing.T) {
+	s := &set.Set[int, int, testItem]{}
+	_, err := s.Get(1)
+	core.AssertErrorIs(t, err, core.ErrNotImplemented, "get on uninitialised")
+}
+
+func testContainsUninitialised(t *testing.T) {
+	s := &set.Set[int, int, testItem]{}
+	core.AssertFalse(t, s.Contains(1), "contains on uninitialised")
+}
+
+func testPushUninitialised(t *testing.T) {
+	s := &set.Set[int, int, testItem]{}
+	_, err := s.Push(testItem{ID: 1, Name: "one"})
+	core.AssertErrorIs(t, err, core.ErrNotImplemented, "push on uninitialised")
+}
+
+func TestUninitialisedAccess(t *testing.T) {
+	t.Run("get", testGetUninitialised)
+	t.Run("contains", testContainsUninitialised)
+	t.Run("push", testPushUninitialised)
+}

--- a/container/set/set_test.go
+++ b/container/set/set_test.go
@@ -1,691 +1,299 @@
-package set
+package set_test
 
 import (
 	"testing"
 
 	"darvaza.org/core"
+
+	"darvaza.org/x/container/set"
 )
 
-// Test types
-type testItem struct {
-	ID    int
-	Name  string
-	Value string
-}
-
-// testCase represents a single test case
-type testCase struct {
-	name string
-	test func(t *testing.T)
-}
-
-func testConfig() Config[int, int, testItem] {
-	return Config[int, int, testItem]{
-		ItemKey:   func(v testItem) (int, error) { return v.ID, nil },
-		Hash:      func(k int) (int, error) { return k % 10, nil },
-		ItemMatch: func(k int, v testItem) bool { return k == v.ID },
-	}
-}
-
-func makeTestItems() []testItem {
-	return []testItem{
-		{ID: 1, Name: "one", Value: "first"},
-		{ID: 2, Name: "two", Value: "second"},
-	}
-}
-
-func verifySetContains(t *testing.T, s *Set[int, int, testItem], items []testItem) {
-	for _, item := range items {
-		if v, err := s.Get(item.ID); err != nil {
-			t.Errorf("Get(%d) failed: %v", item.ID, err)
-		} else if v.ID != item.ID {
-			t.Errorf("Get(%d) returned wrong item: %+v", item.ID, v)
-		}
-	}
-}
-
-func doTestConfigNew(t *testing.T) {
-	cfg := testConfig()
-	items := makeTestItems()
-
-	s, err := cfg.New(items...)
-	if err != nil {
-		t.Fatalf("New failed: %v", err)
-	}
-
-	if s == nil {
-		t.Fatal("New returned nil")
-	}
-
-	verifySetContains(t, s, items)
-}
-
 func TestConfigNew(t *testing.T) {
-	tests := []testCase{
-		{"basic new", doTestConfigNew},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, tc.test)
-	}
-}
-
-func doTestConfigInit(t *testing.T) {
-	cfg := testConfig()
 	items := makeTestItems()
-
-	var s Set[int, int, testItem]
-	if err := cfg.Init(&s, items...); err != nil {
-		t.Fatalf("Init failed: %v", err)
-	}
-
-	verifySetContains(t, &s, items)
+	s, err := testConfig().New(items...)
+	core.AssertMustNoError(t, err, "new")
+	core.AssertMustNotNil(t, s, "set")
+	assertGetAll(t, s, items)
 }
 
-func doTestConfigInitTwice(t *testing.T) {
-	cfg := testConfig()
-	var s Set[int, int, testItem]
+func testConfigInitBasic(t *testing.T) {
+	var s set.Set[int, int, testItem]
+	items := makeTestItems()
+	core.AssertMustNoError(t, testConfig().Init(&s, items...), "init")
+	assertGetAll(t, &s, items)
+}
 
-	if err := cfg.Init(&s); err != nil {
-		t.Fatalf("First Init failed: %v", err)
-	}
-
-	// Try to init again - should fail
-	if err := cfg.Init(&s); err == nil {
-		t.Error("Second Init should fail")
-	}
+func testConfigInitTwice(t *testing.T) {
+	var s set.Set[int, int, testItem]
+	core.AssertMustNoError(t, testConfig().Init(&s), "first init")
+	core.AssertErrorIs(t, testConfig().Init(&s), core.ErrInvalid, "second init")
 }
 
 func TestConfigInit(t *testing.T) {
-	tests := []testCase{
-		{"basic init", doTestConfigInit},
-		{"init twice", doTestConfigInitTwice},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, tc.test)
-	}
+	t.Run("basic", testConfigInitBasic)
+	t.Run("twice", testConfigInitTwice)
 }
 
 func testConfigMustValid(t *testing.T) {
-	cfg := testConfig()
-	items := []testItem{
-		{ID: 1, Name: "one", Value: "first"},
-	}
-
-	// Should not panic
-	s := cfg.Must(items...)
-	if s == nil {
-		t.Fatal("Must returned nil")
-	}
+	s := testConfig().Must(testItem{ID: 1, Name: "one"})
+	core.AssertNotNil(t, s, "set")
 }
 
 func testConfigMustPanic(t *testing.T) {
-	items := []testItem{
-		{ID: 1, Name: "one", Value: "first"},
-	}
-
-	// Test panic with invalid config
-	defer func() {
-		if r := recover(); r == nil {
-			t.Error("Must should panic with invalid config")
-		}
-	}()
-
-	// This should panic
-	invalidCfg := Config[int, int, testItem]{}
-	_ = invalidCfg.Must(items...)
+	var invalid set.Config[int, int, testItem]
+	core.AssertPanic(t, func() { _ = invalid.Must(testItem{ID: 1}) }, nil, "invalid config")
 }
 
 func TestConfigMust(t *testing.T) {
-	tests := []testCase{
-		{"valid config", testConfigMustValid},
-		{"panic on invalid", testConfigMustPanic},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, tc.test)
-	}
-}
-
-func verifyPushSuccess(t *testing.T, stored testItem, err error, expected testItem) {
-	if err != nil {
-		t.Errorf("Push failed: %v", err)
-	} else if stored.ID != expected.ID {
-		t.Errorf("Push returned wrong item: %+v", stored)
-	}
-}
-
-func verifyPushDuplicate(t *testing.T, err error) {
-	if err != ErrExist {
-		t.Errorf("Push duplicate should return ErrExist, got: %v", err)
-	}
-}
-
-//revive:disable-next-line:flag-parameter
-func testPushItem(t *testing.T, s *Set[int, int, testItem], item testItem, shouldFail bool) {
-	stored, err := s.Push(item)
-	if shouldFail {
-		verifyPushDuplicate(t, err)
-	} else {
-		verifyPushSuccess(t, stored, err, item)
-	}
+	t.Run("valid", testConfigMustValid)
+	t.Run("invalid panics", testConfigMustPanic)
 }
 
 func testPushNew(t *testing.T) {
-	cfg := testConfig()
-	s, err := cfg.New()
-	if err != nil {
-		t.Fatalf("New failed: %v", err)
-	}
-
-	testPushItem(t, s, testItem{ID: 1, Name: "one", Value: "first"}, false)
-	testPushItem(t, s, testItem{ID: 2, Name: "two", Value: "second"}, false)
+	s := testConfig().Must()
+	stored, err := s.Push(testItem{ID: 1, Name: "one"})
+	core.AssertNoError(t, err, "push")
+	core.AssertEqual(t, 1, stored.ID, "stored id")
 }
 
 func testPushDuplicate(t *testing.T) {
-	cfg := testConfig()
-	s, err := cfg.New(testItem{ID: 1, Name: "one", Value: "first"})
-	if err != nil {
-		t.Fatalf("New failed: %v", err)
-	}
-
-	testPushItem(t, s, testItem{ID: 1, Name: "one-dup", Value: "duplicate"}, true)
+	s := testConfig().Must(testItem{ID: 1, Name: "one"})
+	_, err := s.Push(testItem{ID: 1, Name: "duplicate"})
+	core.AssertErrorIs(t, err, set.ErrExist, "duplicate")
 }
 
 func TestPush(t *testing.T) {
-	tests := []testCase{
-		{"push new items", testPushNew},
-		{"push duplicate", testPushDuplicate},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, tc.test)
-	}
+	t.Run("new", testPushNew)
+	t.Run("duplicate", testPushDuplicate)
 }
 
 func testGetExisting(t *testing.T) {
-	cfg := testConfig()
-	items := []testItem{
-		{ID: 1, Name: "one", Value: "first"},
-		{ID: 2, Name: "two", Value: "second"},
-	}
-
-	s, err := cfg.New(items...)
-	if err != nil {
-		t.Fatalf("New failed: %v", err)
-	}
-
-	for _, item := range items {
-		if v, err := s.Get(item.ID); err != nil {
-			t.Errorf("Get(%d) failed: %v", item.ID, err)
-		} else if v.ID != item.ID {
-			t.Errorf("Get(%d) returned wrong item: %+v", item.ID, v)
-		}
-	}
+	items := makeTestItems()
+	assertGetAll(t, testConfig().Must(items...), items)
 }
 
-func testGetWithCollisions(t *testing.T) {
-	cfg := testConfig()
-	items := []testItem{
-		{ID: 1, Name: "one", Value: "first"},
-		{ID: 11, Name: "eleven", Value: "collision"}, // Same hash as 1
-	}
-
-	s, err := cfg.New(items...)
-	if err != nil {
-		t.Fatalf("New failed: %v", err)
-	}
-
-	for _, item := range items {
-		if v, err := s.Get(item.ID); err != nil {
-			t.Errorf("Get(%d) failed: %v", item.ID, err)
-		} else if v.ID != item.ID {
-			t.Errorf("Get(%d) returned wrong item: %+v", item.ID, v)
-		}
-	}
+func testGetCollisions(t *testing.T) {
+	items := makeHashCollisionItems()
+	assertGetAll(t, testConfig().Must(items...), items)
 }
 
 func testGetNonExistent(t *testing.T) {
-	cfg := testConfig()
-	s, err := cfg.New()
-	if err != nil {
-		t.Fatalf("New failed: %v", err)
-	}
-
-	if _, err := s.Get(999); err != ErrNotExist {
-		t.Errorf("Get(999) should return ErrNotExist, got: %v", err)
-	}
+	_, err := testConfig().Must().Get(999)
+	core.AssertErrorIs(t, err, set.ErrNotExist, "missing key")
 }
 
 func TestGet(t *testing.T) {
-	tests := []testCase{
-		{"get existing", testGetExisting},
-		{"get with collisions", testGetWithCollisions},
-		{"get non-existent", testGetNonExistent},
-	}
+	t.Run("existing", testGetExisting)
+	t.Run("collisions", testGetCollisions)
+	t.Run("non-existent", testGetNonExistent)
+}
 
-	for _, tc := range tests {
-		t.Run(tc.name, tc.test)
+var _ core.TestCase = containsTestCase{}
+
+// containsTestCase checks Set.Contains against a shared populated set.
+type containsTestCase struct {
+	name string
+	set  *set.Set[int, int, testItem]
+	key  int
+	want bool
+}
+
+func newContainsTestCase(name string, s *set.Set[int, int, testItem], key int,
+	want bool) containsTestCase {
+	return containsTestCase{
+		name: name,
+		set:  s,
+		key:  key,
+		want: want,
 	}
 }
 
-func testContainsExisting(t *testing.T) {
-	cfg := testConfig()
-	s, err := cfg.New(testItem{ID: 1, Name: "one"})
-	if err != nil {
-		t.Fatalf("New failed: %v", err)
-	}
-
-	if !s.Contains(1) {
-		t.Error("Contains(1) should return true")
-	}
+func (tc containsTestCase) Name() string {
+	return tc.name
 }
 
-func testContainsNonExistent(t *testing.T) {
-	cfg := testConfig()
-	s, err := cfg.New(testItem{ID: 1, Name: "one"})
-	if err != nil {
-		t.Fatalf("New failed: %v", err)
-	}
+func (tc containsTestCase) Test(t *testing.T) {
+	t.Helper()
+	core.AssertEqual(t, tc.want, tc.set.Contains(tc.key), "contains %d", tc.key)
+}
 
-	if s.Contains(2) {
-		t.Error("Contains(2) should return false")
+func containsTestCases() []containsTestCase {
+	// IDs 1 and 11 share bucket 1, so the absent sibling 21 probes a
+	// populated bucket while 2 probes an empty one.
+	s := testConfig().Must(testItem{ID: 1, Name: "one"}, testItem{ID: 11, Name: "eleven"})
+	return []containsTestCase{
+		newContainsTestCase("existing", s, 1, true),
+		newContainsTestCase("collision sibling", s, 11, true),
+		newContainsTestCase("absent in empty bucket", s, 2, false),
+		newContainsTestCase("absent in populated bucket", s, 21, false),
 	}
 }
 
 func TestContains(t *testing.T) {
-	tests := []testCase{
-		{"contains existing", testContainsExisting},
-		{"contains non-existent", testContainsNonExistent},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, tc.test)
-	}
+	core.RunTestCases(t, containsTestCases())
 }
 
 func testPopExisting(t *testing.T) {
-	cfg := testConfig()
-	item := testItem{ID: 1, Name: "one", Value: "first"}
-	s, err := cfg.New(item)
-	if err != nil {
-		t.Fatalf("New failed: %v", err)
-	}
-
-	if v, err := s.Pop(1); err != nil {
-		t.Errorf("Pop failed: %v", err)
-	} else if v.ID != item.ID {
-		t.Errorf("Pop returned wrong item: %+v", v)
-	}
-
-	if s.Contains(1) {
-		t.Error("Item should be removed after Pop")
-	}
+	s := testConfig().Must(testItem{ID: 1, Name: "one"})
+	v, err := s.Pop(1)
+	core.AssertNoError(t, err, "pop")
+	core.AssertEqual(t, 1, v.ID, "popped id")
+	core.AssertFalse(t, s.Contains(1), "removed")
 }
 
 func testPopNonExistent(t *testing.T) {
-	cfg := testConfig()
-	s, err := cfg.New()
-	if err != nil {
-		t.Fatalf("New failed: %v", err)
-	}
-
-	if _, err := s.Pop(1); err != ErrNotExist {
-		t.Errorf("Pop non-existent should return ErrNotExist, got: %v", err)
-	}
+	_, err := testConfig().Must().Pop(1)
+	core.AssertErrorIs(t, err, set.ErrNotExist, "missing key")
 }
 
 func TestPop(t *testing.T) {
-	tests := []testCase{
-		{"pop existing", testPopExisting},
-		{"pop non-existent", testPopNonExistent},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, tc.test)
-	}
-}
-
-func doTestReset(t *testing.T) {
-	cfg := testConfig()
-	s, err := cfg.New(
-		testItem{ID: 1, Name: "one"},
-		testItem{ID: 2, Name: "two"},
-		testItem{ID: 3, Name: "three"},
-	)
-	if err != nil {
-		t.Fatalf("New failed: %v", err)
-	}
-
-	// Verify items exist
-	if !s.Contains(1) || !s.Contains(2) || !s.Contains(3) {
-		t.Error("Items should exist before reset")
-	}
-
-	// Reset
-	if err := s.Reset(); err != nil {
-		t.Errorf("Reset failed: %v", err)
-	}
-
-	// Verify all items are removed
-	if s.Contains(1) || s.Contains(2) || s.Contains(3) {
-		t.Error("Items should not exist after reset")
-	}
+	t.Run("existing", testPopExisting)
+	t.Run("non-existent", testPopNonExistent)
 }
 
 func TestReset(t *testing.T) {
-	tests := []testCase{
-		{"reset set", doTestReset},
-	}
+	items := makeTriple()
+	s := testConfig().Must(items...)
+	assertGetAll(t, s, items)
 
-	for _, tc := range tests {
-		t.Run(tc.name, tc.test)
-	}
-}
-
-func doTestClone(t *testing.T) {
-	cfg := testConfig()
-	items := []testItem{
-		{ID: 1, Name: "one", Value: "first"},
-		{ID: 2, Name: "two", Value: "second"},
-	}
-
-	s1, err := cfg.New(items...)
-	if err != nil {
-		t.Fatalf("New failed: %v", err)
-	}
-
-	s2 := s1.Clone()
-	if s2 == nil {
-		t.Fatal("Clone returned nil")
-	}
-
-	// Verify clone has same items
+	core.AssertMustNoError(t, s.Reset(), "reset")
 	for _, item := range items {
-		if !s2.Contains(item.ID) {
-			t.Errorf("Clone missing item %d", item.ID)
-		}
-	}
-
-	// Modify original
-	if _, err := s1.Push(testItem{ID: 3, Name: "three", Value: "third"}); err != nil {
-		t.Errorf("Push failed: %v", err)
-	}
-
-	// Verify clone is independent
-	if s2.Contains(3) {
-		t.Error("Clone should not be affected by original modification")
+		core.AssertFalse(t, s.Contains(item.ID), "cleared %d", item.ID)
 	}
 }
 
 func TestClone(t *testing.T) {
-	tests := []testCase{
-		{"clone set", doTestClone},
-	}
+	items := makeTestItems()
+	s1 := testConfig().Must(items...)
 
-	for _, tc := range tests {
-		t.Run(tc.name, tc.test)
-	}
+	s2 := s1.Clone()
+	core.AssertMustNotNil(t, s2, "clone")
+	assertGetAll(t, s2, items)
+
+	_, _ = s1.Push(testItem{ID: 3, Name: "three"})
+	core.AssertFalse(t, s2.Contains(3), "clone independent of original")
 }
 
 func testCopyFilter(t *testing.T) {
-	cfg := testConfig()
-	items := []testItem{
-		{ID: 1, Name: "one", Value: "first"},
-		{ID: 2, Name: "two", Value: "second"},
-		{ID: 3, Name: "three", Value: "third"},
-	}
+	s1 := testConfig().Must(makeTriple()...)
+	s2 := s1.Copy(nil, func(v testItem) bool { return v.ID%2 == 0 })
 
-	s1, err := cfg.New(items...)
-	if err != nil {
-		t.Fatalf("New failed: %v", err)
-	}
-
-	// Copy only even IDs
-	s2 := s1.Copy(nil, func(v testItem) bool {
-		return v.ID%2 == 0
-	})
-
-	if s2.Contains(1) || s2.Contains(3) {
-		t.Error("Copy should not contain odd IDs")
-	}
-
-	if !s2.Contains(2) {
-		t.Error("Copy should contain even IDs")
-	}
+	core.AssertFalse(t, s2.Contains(1), "odd excluded")
+	core.AssertTrue(t, s2.Contains(2), "even included")
+	core.AssertFalse(t, s2.Contains(3), "odd excluded")
 }
 
 func testCopyAll(t *testing.T) {
-	cfg := testConfig()
-	items := []testItem{
-		{ID: 1, Name: "one", Value: "first"},
-		{ID: 2, Name: "two", Value: "second"},
-		{ID: 3, Name: "three", Value: "third"},
-	}
-
-	s1, err := cfg.New(items...)
-	if err != nil {
-		t.Fatalf("New failed: %v", err)
-	}
-
-	// Copy all items
-	s2 := s1.Copy(nil, nil)
-
-	for _, item := range items {
-		if v, err := s2.Get(item.ID); err != nil {
-			t.Errorf("Get(%d) failed: %v", item.ID, err)
-		} else if v.Value != item.Value {
-			t.Errorf("Value mismatch: got %s, expected %s", v.Value, item.Value)
-		}
-	}
+	items := makeTriple()
+	s2 := testConfig().Must(items...).Copy(nil, nil)
+	assertGetAll(t, s2, items)
 }
 
 func TestCopy(t *testing.T) {
-	tests := []testCase{
-		{"copy with filter", testCopyFilter},
-		{"copy all", testCopyAll},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, tc.test)
-	}
-}
-
-func doTestValues(t *testing.T) {
-	cfg := testConfig()
-	items := []testItem{
-		{ID: 1, Name: "one", Value: "first"},
-		{ID: 2, Name: "two", Value: "second"},
-		{ID: 3, Name: "three", Value: "third"},
-	}
-
-	s, err := cfg.New(items...)
-	if err != nil {
-		t.Fatalf("New failed: %v", err)
-	}
-
-	values := s.Values()
-	if len(values) != len(items) {
-		t.Errorf("Values returned %d items, expected %d", len(values), len(items))
-	}
-
-	// Verify all items are present
-	found := make(map[int]bool)
-	for _, v := range values {
-		found[v.ID] = true
-	}
-
-	for _, item := range items {
-		if !found[item.ID] {
-			t.Errorf("Values missing item %d", item.ID)
-		}
-	}
+	t.Run("filter", testCopyFilter)
+	t.Run("all", testCopyAll)
 }
 
 func TestValues(t *testing.T) {
-	tests := []testCase{
-		{"get values", doTestValues},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, tc.test)
-	}
+	s := testConfig().Must(makeTriple()...)
+	assertHasIDs(t, s, 1, 2, 3)
 }
 
 func testForEachAll(t *testing.T) {
-	cfg := testConfig()
-	items := []testItem{
-		{ID: 1, Name: "one", Value: "first"},
-		{ID: 2, Name: "two", Value: "second"},
-		{ID: 3, Name: "three", Value: "third"},
-	}
-
-	s, err := cfg.New(items...)
-	if err != nil {
-		t.Fatalf("New failed: %v", err)
-	}
-
+	s := testConfig().Must(makeTriple()...)
 	count := 0
-	s.ForEach(func(_ testItem) bool {
-		count++
-		return true // continue
-	})
-
-	if count != len(items) {
-		t.Errorf("ForEach visited %d items, expected %d", count, len(items))
-	}
+	s.ForEach(func(testItem) bool { count++; return true })
+	core.AssertEqual(t, 3, count, "visited all")
 }
 
 func testForEachEarlyTermination(t *testing.T) {
-	cfg := testConfig()
-	items := []testItem{
-		{ID: 1, Name: "one", Value: "first"},
-		{ID: 2, Name: "two", Value: "second"},
-		{ID: 3, Name: "three", Value: "third"},
-	}
-
-	s, err := cfg.New(items...)
-	if err != nil {
-		t.Fatalf("New failed: %v", err)
-	}
-
+	s := testConfig().Must(makeTriple()...)
 	count := 0
-	s.ForEach(func(_ testItem) bool {
-		count++
-		return count < 2 // stop after 2 items
-	})
-
-	if count != 2 {
-		t.Errorf("ForEach should stop after 2 items, visited %d", count)
-	}
+	s.ForEach(func(testItem) bool { count++; return count < 2 })
+	core.AssertEqual(t, 2, count, "stopped after two")
 }
 
 func TestForEach(t *testing.T) {
-	tests := []testCase{
-		{"all items", testForEachAll},
-		{"early termination", testForEachEarlyTermination},
-	}
+	t.Run("all items", testForEachAll)
+	t.Run("early termination", testForEachEarlyTermination)
+}
 
-	for _, tc := range tests {
-		t.Run(tc.name, tc.test)
+var _ core.TestCase = configValidationTestCase{}
+
+// configValidationTestCase checks Config.Validate across missing callbacks.
+type configValidationTestCase struct {
+	cfg     set.Config[int, int, testItem]
+	name    string
+	wantErr bool
+}
+
+func newConfigValidationTestCase(name string, cfg set.Config[int, int, testItem],
+	wantErr bool) configValidationTestCase {
+	return configValidationTestCase{
+		cfg:     cfg,
+		name:    name,
+		wantErr: wantErr,
 	}
 }
 
-func testConfigValidationMissingItemKey(t *testing.T) {
-	cfg := Config[int, int, testItem]{
-		Hash:      func(k int) (int, error) { return k, nil },
-		ItemMatch: func(_ int, _ testItem) bool { return true },
-	}
-
-	if err := cfg.Validate(); err == nil {
-		t.Error("Validate should fail without ItemKey function")
-	}
+func (tc configValidationTestCase) Name() string {
+	return tc.name
 }
 
-func testConfigValidationMissingHash(t *testing.T) {
-	cfg := Config[int, int, testItem]{
-		ItemKey:   func(v testItem) (int, error) { return v.ID, nil },
-		ItemMatch: func(_ int, _ testItem) bool { return true },
+func (tc configValidationTestCase) Test(t *testing.T) {
+	t.Helper()
+	err := tc.cfg.Validate()
+	if tc.wantErr {
+		core.AssertError(t, err, "validate")
+		return
 	}
-
-	if err := cfg.Validate(); err == nil {
-		t.Error("Validate should fail without Hash function")
-	}
+	core.AssertNoError(t, err, "validate")
 }
 
-func testConfigValidationMissingItemMatch(t *testing.T) {
-	cfg := Config[int, int, testItem]{
-		ItemKey: func(v testItem) (int, error) { return v.ID, nil },
-		Hash:    func(k int) (int, error) { return k, nil },
-	}
-
-	if err := cfg.Validate(); err == nil {
-		t.Error("Validate should fail without ItemMatch function")
-	}
-}
-
-func testConfigValidationValid(t *testing.T) {
-	cfg := testConfig()
-	if err := cfg.Validate(); err != nil {
-		t.Errorf("Validate failed on valid config: %v", err)
+func configValidationTestCases() []configValidationTestCase {
+	full := testConfig()
+	return []configValidationTestCase{
+		newConfigValidationTestCase("missing ItemKey",
+			set.Config[int, int, testItem]{Hash: full.Hash, ItemMatch: full.ItemMatch}, true),
+		newConfigValidationTestCase("missing Hash",
+			set.Config[int, int, testItem]{ItemKey: full.ItemKey, ItemMatch: full.ItemMatch}, true),
+		newConfigValidationTestCase("missing ItemMatch",
+			set.Config[int, int, testItem]{ItemKey: full.ItemKey, Hash: full.Hash}, true),
+		newConfigValidationTestCase("valid", full, false),
 	}
 }
 
 func TestConfigValidation(t *testing.T) {
-	tests := []testCase{
-		{"missing ItemKey", testConfigValidationMissingItemKey},
-		{"missing Hash", testConfigValidationMissingHash},
-		{"missing ItemMatch", testConfigValidationMissingItemMatch},
-		{"valid config", testConfigValidationValid},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, tc.test)
-	}
+	core.RunTestCases(t, configValidationTestCases())
 }
 
 func testConfigEqualSame(t *testing.T) {
 	keyFn := func(v testItem) (int, error) { return v.ID, nil }
 	hashFn := func(k int) (int, error) { return k, nil }
 	matchFn := func(k int, v testItem) bool { return k == v.ID }
+	cfg1 := set.Config[int, int, testItem]{ItemKey: keyFn, Hash: hashFn, ItemMatch: matchFn}
+	cfg2 := set.Config[int, int, testItem]{ItemKey: keyFn, Hash: hashFn, ItemMatch: matchFn}
 
-	cfg1 := Config[int, int, testItem]{ItemKey: keyFn, Hash: hashFn, ItemMatch: matchFn}
-	cfg2 := Config[int, int, testItem]{ItemKey: keyFn, Hash: hashFn, ItemMatch: matchFn}
-
-	if !cfg1.Equal(cfg2) {
-		t.Error("Configs with same functions should be equal")
-	}
+	core.AssertTrue(t, cfg1.Equal(cfg2), "same functions")
 }
 
 func testConfigEqualDifferent(t *testing.T) {
-	cfg1 := testConfig()
-	cfg2 := testConfig() // Different function instances
-
-	if cfg1.Equal(cfg2) {
-		t.Error("Configs with different function instances should not be equal")
-	}
+	core.AssertFalse(t, testConfig().Equal(testConfig()), "different instances")
 }
 
 func TestConfigEqual(t *testing.T) {
-	tests := []testCase{
-		{"same functions", testConfigEqualSame},
-		{"different functions", testConfigEqualDifferent},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, tc.test)
-	}
+	t.Run("same functions", testConfigEqualSame)
+	t.Run("different functions", testConfigEqualDifferent)
 }
 
-func runConcurrentWriter(s *Set[int, int, testItem], done chan bool) {
+func runConcurrentWriter(s *set.Set[int, int, testItem], done chan bool) {
 	for i := range 100 {
 		_, _ = s.Push(testItem{ID: i, Name: "item", Value: "value"})
 	}
 	done <- true
 }
 
-func runConcurrentReader(s *Set[int, int, testItem], done chan bool) {
+func runConcurrentReader(s *set.Set[int, int, testItem], done chan bool) {
 	for i := range 100 {
 		s.Contains(i)
 		_, _ = s.Get(i)
@@ -693,180 +301,64 @@ func runConcurrentReader(s *Set[int, int, testItem], done chan bool) {
 	done <- true
 }
 
-func runConcurrentForEach(s *Set[int, int, testItem], done chan bool) {
+func runConcurrentForEach(s *set.Set[int, int, testItem], done chan bool) {
 	for range 10 {
 		s.ForEach(func(testItem) bool { return true })
 	}
 	done <- true
 }
 
-func doTestThreadSafety(t *testing.T) {
-	cfg := testConfig()
-	s, err := cfg.New()
-	if err != nil {
-		t.Fatalf("New failed: %v", err)
-	}
-
-	// Run concurrent operations
+func TestThreadSafety(t *testing.T) {
+	s := testConfig().Must()
 	done := make(chan bool)
 
 	go runConcurrentWriter(s, done)
 	go runConcurrentReader(s, done)
 	go runConcurrentForEach(s, done)
 
-	// Wait for all goroutines
 	for range 3 {
 		<-done
 	}
-}
-
-func TestThreadSafety(t *testing.T) {
-	tests := []testCase{
-		{"concurrent operations", doTestThreadSafety},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, tc.test)
-	}
+	core.AssertNoPanic(t, func() { _ = s.Values() }, "consistent after concurrency")
 }
 
 func testNilReceiverInit(t *testing.T) {
-	var s *Set[int, int, testItem]
-	cfg := testConfig()
-
-	if err := cfg.Init(s); err == nil {
-		t.Error("Init on nil receiver should return error")
-	}
+	var s *set.Set[int, int, testItem]
+	core.AssertErrorIs(t, testConfig().Init(s), core.ErrInvalid, "init on nil receiver")
 }
 
 func testNilReceiverMethods(t *testing.T) {
-	var s *Set[int, int, testItem]
+	var s *set.Set[int, int, testItem]
+	core.AssertFalse(t, s.Contains(1), "contains on nil")
 
-	if s.Contains(1) {
-		t.Error("nil set Contains should return false")
-	}
+	_, err := s.Get(1)
+	core.AssertErrorIs(t, err, core.ErrNilReceiver, "get on nil")
 
-	if _, err := s.Get(1); err == nil || !core.IsError(err, core.ErrNilReceiver) {
-		t.Errorf("nil set Get should return ErrNilReceiver, got: %v", err)
-	}
-
-	if _, err := s.Push(testItem{ID: 1}); err == nil || !core.IsError(err, core.ErrNilReceiver) {
-		t.Errorf("nil set Push should return ErrNilReceiver, got: %v", err)
-	}
+	_, err = s.Push(testItem{ID: 1})
+	core.AssertErrorIs(t, err, core.ErrNilReceiver, "push on nil")
 }
 
 func TestNilReceiver(t *testing.T) {
-	tests := []testCase{
-		{"init nil receiver", testNilReceiverInit},
-		{"methods on nil", testNilReceiverMethods},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, tc.test)
-	}
-}
-
-func doTestEmptySet(t *testing.T) {
-	cfg := testConfig()
-	s, err := cfg.New()
-	if err != nil {
-		t.Fatalf("New failed: %v", err)
-	}
-
-	// Test operations on empty set
-	values := s.Values()
-	if len(values) != 0 {
-		t.Errorf("Empty set Values() should return empty slice, got %d items", len(values))
-	}
-
-	count := 0
-	s.ForEach(func(testItem) bool {
-		count++
-		return true
-	})
-	if count != 0 {
-		t.Errorf("Empty set ForEach should not iterate, got %d iterations", count)
-	}
-
-	if s.Contains(1) {
-		t.Error("Empty set Contains should return false")
-	}
-
-	// Test Pop on empty set
-	if _, err := s.Pop(1); err == nil {
-		t.Error("Pop on empty set should return error")
-	}
-
-	// Test Get on empty set
-	if _, err := s.Get(1); err == nil {
-		t.Error("Get on empty set should return error")
-	}
+	t.Run("init", testNilReceiverInit)
+	t.Run("methods", testNilReceiverMethods)
 }
 
 func TestEmptySet(t *testing.T) {
-	tests := []testCase{
-		{"empty set operations", doTestEmptySet},
-	}
+	s := testConfig().Must()
 
-	for _, tc := range tests {
-		t.Run(tc.name, tc.test)
-	}
-}
+	core.AssertEqual(t, 0, len(s.Values()), "empty values")
+	core.AssertFalse(t, s.Contains(1), "empty contains")
 
-func makeHashCollisionItems() []testItem {
-	return []testItem{
-		{ID: 1, Name: "one"},
-		{ID: 11, Name: "eleven"},
-		{ID: 21, Name: "twenty-one"},
-		{ID: 31, Name: "thirty-one"},
-	}
-}
+	_, err := s.Pop(1)
+	core.AssertErrorIs(t, err, set.ErrNotExist, "pop on empty")
 
-func verifyPushItems(t *testing.T, s *Set[int, int, testItem], items []testItem) {
-	for _, item := range items {
-		if _, err := s.Push(item); err != nil {
-			t.Errorf("Push(%d) failed: %v", item.ID, err)
-		}
-	}
-}
-
-func verifyGetItems(t *testing.T, s *Set[int, int, testItem], items []testItem) {
-	for _, item := range items {
-		if v, err := s.Get(item.ID); err != nil {
-			t.Errorf("Get(%d) failed: %v", item.ID, err)
-		} else if v.ID != item.ID {
-			t.Errorf("Get(%d) returned wrong item: %+v", item.ID, v)
-		}
-	}
-}
-
-func verifyContainsItems(t *testing.T, s *Set[int, int, testItem], items []testItem) {
-	for _, item := range items {
-		if !s.Contains(item.ID) {
-			t.Errorf("Contains(%d) should return true", item.ID)
-		}
-	}
-}
-
-func doTestHashCollisions(t *testing.T) {
-	cfg := testConfig() // Uses hash function that returns k % 10
-	s, err := cfg.New()
-	if err != nil {
-		t.Fatalf("New failed: %v", err)
-	}
-
-	items := makeHashCollisionItems()
-	verifyPushItems(t, s, items)
-	verifyGetItems(t, s, items)
-	verifyContainsItems(t, s, items)
+	_, err = s.Get(1)
+	core.AssertErrorIs(t, err, set.ErrNotExist, "get on empty")
 }
 
 func TestHashCollisions(t *testing.T) {
-	tests := []testCase{
-		{"hash collisions", doTestHashCollisions},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, tc.test)
-	}
+	items := makeHashCollisionItems()
+	s := testConfig().Must(items...)
+	assertGetAll(t, s, items)
+	assertHasIDs(t, s, 1, 11, 21, 31)
 }

--- a/container/set/testutils_test.go
+++ b/container/set/testutils_test.go
@@ -1,0 +1,77 @@
+package set_test
+
+import (
+	"testing"
+
+	"darvaza.org/core"
+
+	"darvaza.org/x/container/set"
+)
+
+// testItem is the element type shared across the set tests.
+type testItem struct {
+	ID    int
+	Name  string
+	Value string
+}
+
+// testConfig returns a valid Config keyed by ID with a modulo-10 hash, so
+// IDs sharing a last digit collide into the same bucket.
+func testConfig() set.Config[int, int, testItem] {
+	return set.Config[int, int, testItem]{
+		ItemKey:   func(v testItem) (int, error) { return v.ID, nil },
+		Hash:      func(k int) (int, error) { return k % 10, nil },
+		ItemMatch: func(k int, v testItem) bool { return k == v.ID },
+	}
+}
+
+func makeTestItems() []testItem {
+	return core.S(
+		testItem{ID: 1, Name: "one", Value: "first"},
+		testItem{ID: 2, Name: "two", Value: "second"},
+	)
+}
+
+func makeTriple() []testItem {
+	return core.S(
+		testItem{ID: 1, Name: "one", Value: "first"},
+		testItem{ID: 2, Name: "two", Value: "second"},
+		testItem{ID: 3, Name: "three", Value: "third"},
+	)
+}
+
+func makeHashCollisionItems() []testItem {
+	// IDs 1, 11, 21 and 31 all hash to bucket 1.
+	return core.S(
+		testItem{ID: 1, Name: "one"},
+		testItem{ID: 11, Name: "eleven"},
+		testItem{ID: 21, Name: "twenty-one"},
+		testItem{ID: 31, Name: "thirty-one"},
+	)
+}
+
+// assertGetAll verifies every item can be fetched back by key.
+func assertGetAll(t *testing.T, s *set.Set[int, int, testItem], items []testItem) {
+	t.Helper()
+	for _, item := range items {
+		v, err := s.Get(item.ID)
+		core.AssertNoError(t, err, "get %d", item.ID)
+		core.AssertEqual(t, item.ID, v.ID, "id %d", item.ID)
+	}
+}
+
+// assertHasIDs verifies the set holds exactly the given IDs, checking the
+// count (so duplicates are caught) and membership of each.
+func assertHasIDs(t *testing.T, s *set.Set[int, int, testItem], ids ...int) {
+	t.Helper()
+	values := s.Values()
+	core.AssertEqual(t, len(ids), len(values), "count")
+
+	got := make([]int, 0, len(values))
+	for _, v := range values {
+		got = append(got, v.ID)
+	}
+	for _, id := range ids {
+		core.AssertTrue(t, core.SliceContains(got, id), "contains %d", id)
+	}
+}


### PR DESCRIPTION
## container/set: add Len, migrate tests to TESTING.md, close coverage gaps

Adds a `Set.Len()` accessor and brings the `container/set` test suite up to
the project's TESTING.md conventions, taking the package to 100% statement
coverage along the way. The only production change is `Set.Len`; everything
else is test code.

### New API

`Set.Len() int` reports how many values the set holds without materialising
them through `Values()`. It takes the read lock and sums each bucket's list
length, so entries that collide into a single bucket are all counted. A nil
receiver and an uninitialised set both return zero rather than panicking,
matching the existing nil-safety of `Values` and `ForEach`.

### Test suite migration

"test(container/set): migrate to TESTING.md conventions" moves the suite from
in-package `package set` to black-box `package set_test` — every test
exercises the public surface — and replaces the hand-rolled
`testCase{name, test func}` table and its for-range loops with
`t.Run("scenario", namedFunc)` for distinct-logic scenarios and `core.TestCase`
tables (factories, interface assertions, `RunTestCases`) for the genuinely
tabular cases. Bare `t.Errorf`/`t.Fatalf` give way to `darvaza.org/core`
assertions that pin the specific sentinel (`core.ErrInvalid` on the
double-init and nil-receiver-init paths) rather than merely a non-nil error.
Shared fixtures and the `assertGetAll`/`assertHasIDs` helpers move to
`testutils_test.go`.

### Coverage

"test(container/set): cover Copy, Config.Equal, and invalid-state paths" adds
permanent regression rows for the previously untested branches: every `Copy`
destination path (uninitialised, compatible-append, incompatible Push
fallback, with and without a condition) and its no-op guards; the `Config.Equal`
rows that differ in `ItemKey`/`ItemMatch` and the nil-callback arms of
`equalFuncPointer`; the `ItemKey`-error path through `Push` and bulk insert;
and the nil-receiver, uninitialised, and collision-miss arms of `Reset`, `Pop`,
`Get`, `Contains`, and `Push`. `init`'s nil-receiver guard is unreachable
through the public API — `Config.Init` rejects a nil set before delegating — so
`set_private_test.go` covers it white-box, the one case the black-box suite
cannot reach.

### Verification

- `make test-container` — pass
- `make race-container` — pass, no races
- `make tidy-container` — clean
- `make coverage-container` — `container/set` at 100.0%


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `Len()` method to the Set container, enabling thread-safe retrieval of the total element count.

* **Tests**
  * Expanded test coverage with additional test suites for set operations, including copy/clone behavior, iteration, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->