### PR TITLE
tls: Store contract, certpool subject-hash indexing, buffer store fixes

### DIFF
--- a/tls/README.md
+++ b/tls/README.md
@@ -17,9 +17,14 @@
 ## Overview
 
 The `tls` package provides advanced TLS/SSL certificate handling utilities
-that extend Go's standard crypto/tls package. It includes certificate stores,
-SNI inspection, certificate bundling, and enhanced x509 utilities with a focus
-on dynamic certificate management.
+that extend Go's standard crypto/tls package: the `Store` abstraction, SNI
+inspection, certificate bundling, and enhanced x509 utilities.
+
+Unlike the standard library's static configuration, a `Store` is a living
+source of certificates and trust — material is added, renewed and removed while
+in use. The `Store` interfaces are designed to be layered, so higher-level
+systems can compose behaviour (on-demand issuance, replication) over a simple
+local store while keeping it both flexible and consistent.
 
 ## Features
 
@@ -32,22 +37,20 @@ on dynamic certificate management.
 
 ### Certificate Store
 
-Dynamic certificate storage with multiple backend implementations.
+The `Store` interfaces describe a dynamic source of certificates and trust. A
+read/write store adds lookup, iteration and the building-block writers
+(`AddCACerts`, `AddPrivateKey`, `AddCert`, `AddCertPair`) on top of the base
+`Store`. Any implementation wires straight into a `tls.Config`:
 
 ```go
-// Create a store
-store := &basic.Store{}
-ctx := context.Background()
+// store is any tls.Store implementation.
+config, err := tls.NewConfig(store)
 
-// Add certificates
-err := store.AddCertPair(ctx, privateKey, cert, intermediates)
-
-// Configure TLS
-config := &tls.Config{
-    GetCertificate: store.GetCertificate,
-    RootCAs: store.GetCAPool(),
-}
+// or bind one to an existing config:
+err = tls.WithStore(config, store)
 ```
+
+`WithStore` sets `GetCertificate`, `RootCAs` and `ClientCAs` from the store.
 
 ### Certificate Bundling
 
@@ -78,10 +81,19 @@ if info != nil {
     fmt.Printf("SNI: %s\n", info.ServerName)
 }
 
-// SNI-based routing
-dispatcher := sni.NewDispatcher()
-dispatcher.Add("example.com", exampleHandler)
-dispatcher.Add("*.api.com", apiHandler)
+// SNI-based routing: GetHandler claims a connection for a dedicated
+// Handler, or returns nil to let it fall through to the TLS listener.
+dispatcher := &sni.Dispatcher{
+    GetHandler: func(chi *tls.ClientHelloInfo) sni.Handler {
+        if chi.ServerName == "example.com" {
+            return exampleHandler
+        }
+        return nil
+    },
+}
+
+go dispatcher.Serve(rawListener)  // feed it the raw net.Listener
+tlsListener := tls.NewListener(dispatcher, cfg)  // unclaimed ones land here
 ```
 
 ## Packages
@@ -96,11 +108,10 @@ Server Name Indication parsing and routing.
 
 ### `store`
 
-Certificate storage implementations.
+Loading and population for a `Store`.
 
-* `basic`: Simple in-memory store.
-* `buffer`: Buffered certificate operations.
-* `config`: Configuration-based loading.
+* `buffer`: collect certificates and keys, then flush them into a `Store`.
+* `config`: load certificates and keys from configuration and PEM sources.
 
 ### `x509utils`
 
@@ -129,23 +140,24 @@ customPool.AddCert(internalCA)
 ### PEM Operations
 
 ```go
-// Read PEM files
-certs, err := x509utils.ReadCertificates(pemData)
-key, err := x509utils.ReadPrivateKey(keyData)
+// Decode certificates from PEM via a per-block callback
+err := x509utils.ReadPEM(pemData, func(_ fs.FS, _ string, block *pem.Block) bool {
+    if cert, err := x509utils.BlockToCertificate(block); err == nil {
+        certs = append(certs, cert)
+    }
+    return true // keep reading
+})
 
-// Write PEM
-pemData := x509utils.EncodeCertificates(certs...)
-keyData := x509utils.EncodePrivateKey(key)
+// Encode a certificate (DER) back to PEM
+pemBytes := x509utils.EncodeCertificate(cert.Raw)
 ```
 
-### Custom Verification
+### Certificate Verification
 
 ```go
-err := tls.Verify(cert, &tls.VerifyOptions{
-    DNSName: "example.com",
-    Roots: customRoots,
-    Intermediates: customInter,
-})
+// Verify a tls.Certificate. Pass a roots pool to also verify the chain;
+// nil checks only the certificate's own validity.
+err := tls.Verify(cert, customRoots)
 ```
 
 ## Installation

--- a/tls/bundler.go
+++ b/tls/bundler.go
@@ -19,8 +19,8 @@ type Bundler struct {
 	// Quality comparison function. Defaults to shorter-chain.
 	Less func(a, b []*x509.Certificate) bool
 
-	mu   sync.Mutex
 	opts x509.VerifyOptions
+	mu   sync.Mutex
 }
 
 // Bundle bundles a key and a certificate into a [tls.Certificate] using the

--- a/tls/doc.go
+++ b/tls/doc.go
@@ -1,0 +1,27 @@
+// Package tls provides utilities for working with TLS certificates: aliases for
+// the standard library's certificate types, certificate verification ([Verify]),
+// chain assembly ([Bundler], [Bundle]), configuration helpers ([WithStore],
+// [NewConfig]) and the [Store] abstraction.
+//
+// Store is the central facility. Unlike the standard library's static
+// configuration, a Store is a living entity: certificates are added, minted on
+// demand, renewed, replicated and removed throughout its lifetime. The Store
+// interfaces are built to be layered, so higher-level systems — distributed
+// certificate serving, ACME issuance, auto-renewal, key replication — can
+// compose behaviour over a simple local store while keeping it both flexible and
+// consistent:
+//
+//   - Flexibility: the error sentinels and the callback hooks on
+//     implementations are seams a decorator store builds on — a miss becomes
+//     on-demand minting, a write becomes replication, a renewal becomes a swap
+//     — rather than mere status reporting.
+//   - Consistency: deduplicating implementations (see the certpool subpackage)
+//     collapse identical certificates to a single reference and report a re-add
+//     with an "already exists" sentinel, so layers compare by identity and stay
+//     idempotent and convergent across nodes.
+//
+// These facilities build on the x509utils subpackage, which supplies the
+// underlying x509 certificate and key primitives. Companion subpackages cover
+// neighbouring concerns: sni screens incoming connections by server name, and
+// store loads certificates into a Store from configuration and PEM sources.
+package tls

--- a/tls/sni/common.go
+++ b/tls/sni/common.go
@@ -196,7 +196,7 @@ const (
 // http://www.iana.org/assignments/tls-parameters/tls-parameters.xml#tls-parameters-8
 type CurveID uint16
 
-type keyShare struct {
+type keyShare struct { //nolint:govet // fieldalignment: TLS protocol struct; field order follows the wire format
 	group CurveID
 	data  []byte
 }

--- a/tls/sni/dispatcher.go
+++ b/tls/sni/dispatcher.go
@@ -31,16 +31,13 @@ type Handler func(context.Context, net.Conn) error
 // conf := &tls.Config{...}
 // lsn, err := tls.NewListener(dispatcher, config)
 type Dispatcher struct {
-	mu sync.Mutex
-	wg core.WaitGroup
 	ch chan accept
 
-	ctx       context.Context
-	cancel    context.CancelFunc
-	cancelled atomic.Bool
-	ln        net.Listener
-	log       slog.Logger
-	err       error
+	ctx    context.Context
+	cancel context.CancelFunc
+	ln     net.Listener
+	log    slog.Logger
+	err    error
 
 	// Logger to report errors
 	Logger slog.Logger
@@ -58,6 +55,11 @@ type Dispatcher struct {
 	// OnError let's the use decide if we shut down on critical errors or not
 	// it also allows the user to act accordingly
 	OnError func(err error) bool
+
+	wg core.WaitGroup
+
+	mu        sync.Mutex
+	cancelled atomic.Bool
 }
 
 type accept struct {

--- a/tls/sni/sni.go
+++ b/tls/sni/sni.go
@@ -62,7 +62,7 @@ license that can be found in the LICENSE file.*/
 
 // ClientHelloInfo contains information from a ClientHello message in order to
 // guide application logic in the GetCertificate and GetConfigForClient callbacks.
-type ClientHelloInfo struct {
+type ClientHelloInfo struct { //nolint:govet // fieldalignment: TLS protocol struct; field order follows the wire format
 	raw                              []byte
 	Vers                             uint16
 	random                           []byte

--- a/tls/std.go
+++ b/tls/std.go
@@ -1,4 +1,3 @@
-// Package tls aids working with TLS Certificates
 package tls
 
 import "crypto/tls"
@@ -13,3 +12,8 @@ type (
 	// Config is an alias of the standard [tls.Config]
 	Config = tls.Config
 )
+
+// NewListener is an alias of the standard [tls.NewListener]. It wraps a
+// net.Listener so accepted connections negotiate TLS using the given [Config] —
+// pair it with an sni.Dispatcher to serve unclaimed connections.
+var NewListener = tls.NewListener

--- a/tls/store.go
+++ b/tls/store.go
@@ -5,6 +5,7 @@ import (
 	"crypto"
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"fmt"
 
 	"darvaza.org/core"
@@ -13,44 +14,149 @@ import (
 // ErrNoStore is an error indicating the [Store] wasn't provided.
 var ErrNoStore = core.Wrap(core.ErrInvalid, "store not provided")
 
-// A Store is used to set up a [tls.Config].
+// IsExists reports whether err is the no-op an add returns when the subject was
+// already present, leaving the store unchanged. Use it to tell a redundant
+// write from a real failure.
+func IsExists(err error) bool {
+	return errors.Is(err, core.ErrExists)
+}
+
+// IsNotExists reports whether err is the miss [StoreReader.Get] returns, or the
+// no-op a delete returns, when the subject is not held. Use it to tell an
+// absent subject from a real failure.
+func IsNotExists(err error) bool {
+	return errors.Is(err, core.ErrNotExists)
+}
+
+// IsInvalid reports whether err is the rejection a method returns for a missing
+// or malformed argument: a nil or corrupt certificate or key, or a missing
+// [Store]. Use it to tell bad input from a real failure.
+func IsInvalid(err error) bool {
+	return errors.Is(err, core.ErrInvalid)
+}
+
+// A Store is the source of certificates and trust a [tls.Config] consults during
+// the handshake: it presents a certificate for an incoming connection and offers
+// the pool of roots to verify peers against. Implementations are living entities,
+// designed to be layered — see the package overview. Bind one to a [tls.Config]
+// with [WithStore].
+//
+// Across these interfaces, any method returning an error reports a nil receiver
+// with [core.ErrNilReceiver] and a missing or malformed certificate or key with
+// [core.ErrInvalid], before making any change.
 type Store interface {
+	// GetCertificate selects the certificate to present in response to a
+	// ClientHello, keyed on its ServerName (SNI). Both its signature and its
+	// return semantics are those of [tls.Config.GetCertificate], so a Store
+	// wires straight in.
 	GetCertificate(*tls.ClientHelloInfo) (*tls.Certificate, error)
+
+	// GetCAPool returns the trust anchors used to verify peer certificates,
+	// consumed as a [tls.Config]'s RootCAs and ClientCAs under its semantics.
 	GetCAPool() *x509.CertPool
 }
 
-// StoreReader adds read methods to the [Store].
+// The Store methods are guarded here against the [tls.Config] fields they feed —
+// GetCertificate to GetCertificate, GetCAPool to RootCAs and ClientCAs — so the
+// correspondence is explicit and checked at build time. [WithStore] performs the
+// actual wiring.
+var _ = func(s Store) {
+	_ = tls.Config{
+		GetCertificate: s.GetCertificate,
+		RootCAs:        s.GetCAPool(),
+		ClientCAs:      s.GetCAPool(),
+	}
+}
+
+// StoreReader adds lookup and iteration over the held certificates to the
+// [Store].
 type StoreReader interface {
 	Store
 
+	// Get returns the certificate matching name (a server name, exact or
+	// wildcard). Implementations may serve it from an on-demand source when
+	// nothing is held; a miss they cannot resolve is reported with
+	// [core.ErrNotExists], which [IsNotExists] tests.
 	Get(ctx context.Context, name string) (*tls.Certificate, error)
 
+	// ForEach calls fn for every stored certificate, stopping early if fn
+	// returns false or ctx is cancelled.
 	ForEach(ctx context.Context, fn func(context.Context, *tls.Certificate) bool)
+
+	// ForEachMatch is ForEach restricted to certificates that match name (a
+	// server name, exact or wildcard).
 	ForEachMatch(ctx context.Context, name string, fn func(context.Context, *tls.Certificate) bool)
 }
 
-// StoreWriter adds [tls.Certificate] write methods to the [Store].
+// StoreWriter adds [tls.Certificate] write methods to the [Store]. Where
+// [StoreX509Writer] takes raw building blocks (keys, certificates, chains),
+// StoreWriter works in finished units: a [tls.Certificate] already carrying its
+// leaf, private key and chain.
 type StoreWriter interface {
 	Store
 
+	// Put stores a complete certificate, first filling any gaps it can from
+	// material already held and verifying the result. A leaf missing its key or
+	// intermediates is completed when the store holds them; one that cannot be
+	// verified is rejected. Storing a certificate already held is the
+	// [core.ErrExists] no-op ([IsExists]); new or renewed material is an
+	// effective change.
 	Put(ctx context.Context, cert *tls.Certificate) error
+
+	// Delete removes a previously stored certificate; removing one not held is
+	// the no-op reported with [core.ErrNotExists] ([IsNotExists]).
 	Delete(ctx context.Context, cert *tls.Certificate) error
 }
 
-// StoreX509Writer adds [x509.Certificate] write methods to the [Store].
+// StoreX509Writer adds [x509.Certificate] write methods to the [Store]. The
+// methods form a toolkit in which trust anchors, private keys, certificates and
+// complete bundles each have their own entry point.
+//
+// Writes report whether they had effect, so layers can react to real changes. A
+// write that changes nothing is a no-op rather than a failure, reported with a
+// sentinel: a duplicate add with [core.ErrExists], tested with [IsExists]; a
+// delete of something absent with [core.ErrNotExists], tested with
+// [IsNotExists]; a nil return marks an effective change.
 type StoreX509Writer interface {
 	Store
 
+	// AddCACerts adds the given certificates as trusted roots. They populate the
+	// pool returned by [Store.GetCAPool] and are the anchors verification
+	// ultimately chains to. Only certificates marked as a CA are accepted; a
+	// non-CA is rejected. Passing none is a no-op; roots already trusted count as
+	// no change under the convention above.
 	AddCACerts(ctx context.Context, roots ...*x509.Certificate) error
 
+	// AddPrivateKey adds a private key on its own, ahead of the certificate it
+	// belongs to. It is the companion of [StoreX509Writer.AddCert]: a key added
+	// here is matched by public key when its leaf is added afterwards.
 	AddPrivateKey(ctx context.Context, key crypto.Signer) error
+
+	// AddCert adds a single certificate, classifying it by what it is:
+	//   - self-signed: trusted as a root, as if passed to AddCACerts;
+	//   - CA (not self-signed): held as an intermediate, used to complete
+	//     chains when a leaf is later verified;
+	//   - leaf (non-CA): its private key must already have been added with
+	//     AddPrivateKey, otherwise the certificate is rejected.
+	// To add a leaf together with its key and chain in one step, use
+	// [StoreX509Writer.AddCertPair].
 	AddCert(ctx context.Context, cert *x509.Certificate) error
+
+	// AddCertPair adds a leaf certificate together with its private key and any
+	// intermediates in a single call, without a prior AddPrivateKey. It is the
+	// bundle counterpart of the piecemeal AddPrivateKey + AddCert path. key may
+	// be nil, in which case the store resolves it from keys already held, as
+	// AddCert does, and rejects the certificate when none matches; intermediates
+	// may be empty.
 	AddCertPair(ctx context.Context, key crypto.Signer, cert *x509.Certificate, intermediates []*x509.Certificate) error
 
+	// DeleteCert removes a certificate from the store, identified by its DER
+	// contents. It is the inverse of AddCert and AddCertPair; removing one not
+	// held is the no-op reported with [core.ErrNotExists] ([IsNotExists]).
 	DeleteCert(ctx context.Context, cert *x509.Certificate) error
 }
 
-// StoreReadWriter includes read and write methods for the [Store]
+// StoreReadWriter includes read and write methods for the [Store].
 type StoreReadWriter interface {
 	StoreReader
 	StoreWriter

--- a/tls/store/buffer/buffer.go
+++ b/tls/store/buffer/buffer.go
@@ -13,13 +13,14 @@ import (
 
 // Buffer is a PEM decoding buffer to populate a [tls.StoreWriter].
 type Buffer struct {
-	mu     sync.Mutex
 	ctx    context.Context
 	logger slog.Logger // TODO: use
 
 	keySet  *KeySet
 	certSet *certpool.CertSet
 	sources map[SourceName]*Source
+
+	mu sync.Mutex
 }
 
 // New creates a PEM decoding Buffer to populate a [tls.StoreWriter].

--- a/tls/store/buffer/buffer_add.go
+++ b/tls/store/buffer/buffer_add.go
@@ -7,13 +7,19 @@ import (
 	"darvaza.org/x/tls"
 )
 
+// hasCerts selects sources carrying at least one certificate.
+func hasCerts(e *Source) bool { return len(e.Certs) > 0 }
+
+// hasKeys selects sources carrying at least one private key.
+func hasKeys(e *Source) bool { return len(e.Keys) > 0 }
+
 // AddCACerts adds all certificates in the [Buffer] to the [tls.Store] as trusted CAs.
 func (buf *Buffer) AddCACerts(ctx context.Context, out tls.StoreX509Writer) (int, error) {
 	fn := func(ctx context.Context, src *Source, out tls.StoreX509Writer) (int, error) {
 		return src.AddCACerts(ctx, out)
 	}
 
-	return buf.doAddFn(ctx, out, "AddCACerts", fn)
+	return buf.doAddFn(ctx, out, "AddCACerts", hasCerts, fn)
 }
 
 // AddPrivateKey adds all private keys in the [Buffer] to the [tls.Store].
@@ -22,7 +28,7 @@ func (buf *Buffer) AddPrivateKey(ctx context.Context, out tls.StoreX509Writer) (
 		return src.AddPrivateKeys(ctx, out)
 	}
 
-	return buf.doAddFn(ctx, out, "AddPrivateKeys", fn)
+	return buf.doAddFn(ctx, out, "AddPrivateKeys", hasKeys, fn)
 }
 
 // AddCert adds all certificates in the [Buffer] to the [tls.Store].
@@ -31,7 +37,7 @@ func (buf *Buffer) AddCert(ctx context.Context, out tls.StoreX509Writer) (int, e
 		return src.AddCert(ctx, out)
 	}
 
-	return buf.doAddFn(ctx, out, "AddCert", fn)
+	return buf.doAddFn(ctx, out, "AddCert", hasCerts, fn)
 }
 
 // AddCertPair adds all certificates in the [Buffer] to the [tls.Store] considering intermediate
@@ -41,19 +47,15 @@ func (buf *Buffer) AddCertPair(ctx context.Context, out tls.StoreX509Writer) (in
 		return src.AddCertPair(ctx, out, buf.keySet)
 	}
 
-	return buf.doAddFn(ctx, out, "AddCertPair", fn)
+	return buf.doAddFn(ctx, out, "AddCertPair", hasCerts, fn)
 }
 
 func (buf *Buffer) doAddFn(ctx context.Context, out tls.StoreX509Writer, op string,
+	cond func(*Source) bool,
 	fn func(context.Context, *Source, tls.StoreX509Writer) (int, error)) (int, error) {
 	// validate
 	if err := buf.canAdd(ctx, out); err != nil {
 		return 0, err
-	}
-
-	// only sources with certificates
-	cond := func(e *Source) bool {
-		return len(e.Certs) > 0
 	}
 
 	ctx2, cancel := context.WithCancel(ctx)
@@ -68,13 +70,12 @@ func (buf *Buffer) doAddFnFromChannel(ctx context.Context, out tls.StoreX509Writ
 	sources <-chan *Source) (int, error) {
 	//
 	var errs core.CompoundError
-	var count int
+	var count, seen int
 
 	for src := range sources {
+		seen++
 		n, cont, err := buf.doAddFnFromSource(ctx, out, op, fn, src)
-		if n > 0 {
-			count += n
-		}
+		count += n
 		if err != nil {
 			_ = errs.AppendError(err)
 		}
@@ -83,7 +84,7 @@ func (buf *Buffer) doAddFnFromChannel(ctx context.Context, out tls.StoreX509Writ
 		}
 	}
 
-	return returnAdd2(count, errs.AsError())
+	return returnAdd2(seen, count, errs.AsError())
 }
 
 func (buf *Buffer) doAddFnFromSource(ctx context.Context, out tls.StoreX509Writer, op string,

--- a/tls/store/buffer/buffer_test.go
+++ b/tls/store/buffer/buffer_test.go
@@ -1,0 +1,375 @@
+package buffer_test
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/pem"
+	"io/fs"
+	"testing"
+
+	"darvaza.org/core"
+
+	"darvaza.org/x/tls"
+	"darvaza.org/x/tls/store/buffer"
+	"darvaza.org/x/tls/x509utils"
+)
+
+// feed pushes the given PEM blocks into buf as a single named source via the
+// general add callback (certs and keys both routed by block type).
+func feed(t *testing.T, buf *buffer.Buffer, file string, blocks ...*pem.Block) {
+	t.Helper()
+	cb := buf.NewAddCallback()
+	core.AssertMustNotNil(t, cb, "callback")
+	for _, b := range blocks {
+		cb(nil, file, b)
+	}
+}
+
+// TestNew confirms a fresh buffer is usable and empty.
+func TestNew(t *testing.T) {
+	buf := buffer.New(context.Background(), nil)
+	core.AssertMustNotNil(t, buf, "buffer")
+
+	core.AssertMustNotNil(t, buf.Certs(), "certs")
+	core.AssertMustNotNil(t, buf.Keys(), "keys")
+
+	pairs, err := buf.Pairs()
+	core.AssertMustNoError(t, err, "pairs")
+	core.AssertEqual(t, 0, len(pairs), "pair count")
+}
+
+// TestNilReceiver confirms every accessor is nil-receiver safe.
+func TestNilReceiver(t *testing.T) {
+	var buf *buffer.Buffer
+
+	core.AssertNil(t, buf.Certs(), "certs")
+	core.AssertNil(t, buf.Keys(), "keys")
+	core.AssertNil(t, buf.Clone(), "clone")
+	core.AssertNil(t, buf.NewAddCallback(), "callback")
+
+	_, err := buf.Pairs()
+	core.AssertErrorIs(t, err, core.ErrNilReceiver, "pairs err")
+
+	// ForEach on a nil receiver is a silent no-op.
+	buf.ForEach(func(fs.FS, string, []x509utils.PrivateKey,
+		[]*x509.Certificate, []error) bool {
+		t.Fatal("nil receiver must not iterate")
+		return false
+	})
+}
+
+// bufferGuardOp names a Buffer flush method for the shared argument-guard
+// checks in TestAddGuards.
+type bufferGuardOp struct {
+	fn   func(*buffer.Buffer, context.Context, tls.StoreX509Writer) (int, error)
+	name string
+}
+
+// addOps lists the four flush methods as method expressions so the guards are
+// exercised uniformly across all of them.
+var addOps = []bufferGuardOp{
+	{name: "AddCACerts", fn: (*buffer.Buffer).AddCACerts},
+	{name: "AddPrivateKey", fn: (*buffer.Buffer).AddPrivateKey},
+	{name: "AddCert", fn: (*buffer.Buffer).AddCert},
+	{name: "AddCertPair", fn: (*buffer.Buffer).AddCertPair},
+}
+
+// runAddGuardCancelled confirms a flush method aborts on a cancelled context.
+func runAddGuardCancelled(t *testing.T, op bufferGuardOp) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	buf := buffer.New(context.Background(), nil)
+	_, err := op.fn(buf, ctx, newFakeStore())
+	core.AssertErrorIs(t, err, context.Canceled, "err")
+}
+
+// TestAddGuards confirms the argument guards on every flush method.
+func TestAddGuards(t *testing.T) {
+	for _, op := range addOps {
+		t.Run(op.name+"/nil receiver", func(t *testing.T) {
+			_, err := op.fn(nil, context.Background(), newFakeStore())
+			core.AssertErrorIs(t, err, core.ErrNilReceiver, "err")
+		})
+		t.Run(op.name+"/nil store", func(t *testing.T) {
+			buf := buffer.New(context.Background(), nil)
+			_, err := op.fn(buf, context.Background(), nil)
+			core.AssertErrorIs(t, err, tls.ErrNoStore, "err")
+		})
+		t.Run(op.name+"/cancelled", func(t *testing.T) {
+			runAddGuardCancelled(t, op)
+		})
+	}
+}
+
+// TestPopulateAndRead feeds a leaf and its key as one source and confirms the
+// buffer exposes both and pairs them.
+func TestPopulateAndRead(t *testing.T) {
+	ca := mkCA(t, "Read CA")
+	leaf := mkLeaf(t, ca, "read.example.com", "read.example.com")
+
+	buf := buffer.New(context.Background(), nil)
+	feed(t, buf, "leaf.pem", certBlock(leaf), keyBlock(t, leaf))
+
+	core.AssertEqual(t, 1, buf.Certs().Len(), "cert count")
+	core.AssertEqual(t, 1, buf.Keys().Len(), "key count")
+
+	pairs, err := buf.Pairs()
+	core.AssertMustNoError(t, err, "pairs")
+	core.AssertMustEqual(t, 1, len(pairs), "pair count")
+	core.AssertEqual(t, 1, len(pairs[0].Certs), "paired certs")
+	core.AssertTrue(t, x509utils.ValidCertKeyPair(leaf.Leaf, pairs[0].Key),
+		"pair matches")
+
+	var sources int
+	buf.ForEach(func(_ fs.FS, name string, keys []x509utils.PrivateKey,
+		certs []*x509.Certificate, _ []error) bool {
+		sources++
+		core.AssertEqual(t, "leaf.pem", name, "source name")
+		core.AssertEqual(t, 1, len(keys), "source keys")
+		core.AssertEqual(t, 1, len(certs), "source certs")
+		return true
+	})
+	core.AssertEqual(t, 1, sources, "source count")
+}
+
+// TestAddCACerts confirms trusted roots flush to the store.
+func TestAddCACerts(t *testing.T) {
+	ca := mkCA(t, "Trust CA")
+
+	buf := buffer.New(context.Background(), nil)
+	feed(t, buf, "ca.pem", certBlock(ca))
+
+	store := newFakeStore()
+	n, err := buf.AddCACerts(context.Background(), store)
+	core.AssertMustNoError(t, err, "add")
+	core.AssertEqual(t, 1, n, "count")
+	core.AssertEqual(t, 1, len(store.caCerts), "stored roots")
+}
+
+// TestAddCert confirms plain certificates flush to the store.
+func TestAddCert(t *testing.T) {
+	ca := mkCA(t, "Cert CA")
+	leaf := mkLeaf(t, ca, "cert.example.com", "cert.example.com")
+
+	buf := buffer.New(context.Background(), nil)
+	feed(t, buf, "leaf.pem", certBlock(leaf))
+
+	store := newFakeStore()
+	n, err := buf.AddCert(context.Background(), store)
+	core.AssertMustNoError(t, err, "add")
+	core.AssertEqual(t, 1, n, "count")
+	core.AssertEqual(t, 1, len(store.certs), "stored certs")
+}
+
+// TestAddPrivateKeyKeyOnly is the regression guard for F51: a key-only source
+// (no certificate) must still flush its key. The old cond filtered on
+// len(Certs)>0, so AddPrivateKey silently added nothing.
+func TestAddPrivateKeyKeyOnly(t *testing.T) {
+	leaf := mkSelfSignedLeaf(t, "key.example.org")
+
+	buf := buffer.New(context.Background(), nil)
+	feed(t, buf, "key.pem", keyBlock(t, leaf))
+
+	store := newFakeStore()
+	n, err := buf.AddPrivateKey(context.Background(), store)
+	core.AssertMustNoError(t, err, "add")
+	core.AssertEqual(t, 1, n, "count")
+	core.AssertMustEqual(t, 1, len(store.keys), "stored keys")
+	core.AssertTrue(t, x509utils.ValidCertKeyPair(leaf.Leaf, store.keys[0]),
+		"stored key matches")
+}
+
+// feedFn stages a leaf and its key into a buffer in a particular order.
+type feedFn func(t *testing.T, buf *buffer.Buffer, leaf *tls.Certificate)
+
+// addCertPairCase confirms AddCertPair pairs a leaf with its key regardless of
+// the injection order staged by feed; the assertion path is shared.
+type addCertPairCase struct {
+	feed feedFn
+	name string
+}
+
+var _ core.TestCase = addCertPairCase{}
+
+func newAddCertPairCase(name string, feed feedFn) addCertPairCase {
+	return addCertPairCase{name: name, feed: feed}
+}
+
+// Name returns the test case name.
+func (tc addCertPairCase) Name() string { return tc.name }
+
+// Test stages the buffer via feed and confirms the leaf is paired with its key.
+func (tc addCertPairCase) Test(t *testing.T) {
+	t.Helper()
+
+	ca := mkCA(t, "Pair CA")
+	leaf := mkLeaf(t, ca, "pair.example.com", "pair.example.com")
+	buf := buffer.New(context.Background(), nil)
+	tc.feed(t, buf, leaf)
+
+	store := newFakeStore()
+	n, err := buf.AddCertPair(context.Background(), store)
+	core.AssertMustNoError(t, err, "add")
+	core.AssertEqual(t, 1, n, "count")
+	core.AssertMustEqual(t, 1, len(store.pairs), "stored pairs")
+	core.AssertMustNotNil(t, store.pairs[0].key, "paired key")
+	core.AssertTrue(t,
+		x509utils.ValidCertKeyPair(leaf.Leaf, store.pairs[0].key),
+		"pair key matches leaf")
+}
+
+// TestAddCertPairOrderIndependent is the core design guarantee: a leaf is
+// paired with its key regardless of injection order or source — key before
+// cert, cert before key, or each in its own source.
+func TestAddCertPairOrderIndependent(t *testing.T) {
+	core.RunTestCases(t, []addCertPairCase{
+		newAddCertPairCase("key then cert, one source",
+			func(t *testing.T, buf *buffer.Buffer, leaf *tls.Certificate) {
+				feed(t, buf, "pair.pem", keyBlock(t, leaf), certBlock(leaf))
+			}),
+		newAddCertPairCase("cert then key, one source",
+			func(t *testing.T, buf *buffer.Buffer, leaf *tls.Certificate) {
+				feed(t, buf, "pair.pem", certBlock(leaf), keyBlock(t, leaf))
+			}),
+		newAddCertPairCase("separate sources",
+			func(t *testing.T, buf *buffer.Buffer, leaf *tls.Certificate) {
+				feed(t, buf, "cert.pem", certBlock(leaf))
+				feed(t, buf, "key.pem", keyBlock(t, leaf))
+			}),
+	})
+}
+
+// TestAddCertPairIntermediates confirms the leaf is paired and the rest of the
+// source travels as intermediates.
+func TestAddCertPairIntermediates(t *testing.T) {
+	root := mkCA(t, "Root CA")
+	sub := mkSubCA(t, root, "Sub CA")
+	leaf := mkLeaf(t, sub, "chain.example.com", "chain.example.com")
+
+	buf := buffer.New(context.Background(), nil)
+	// leaf first (it is the pair leaf), then the intermediate, plus the key.
+	feed(t, buf, "bundle.pem", certBlock(leaf), certBlock(sub), keyBlock(t, leaf))
+
+	store := newFakeStore()
+	n, err := buf.AddCertPair(context.Background(), store)
+	core.AssertMustNoError(t, err, "add")
+	core.AssertEqual(t, 1, n, "count")
+	core.AssertMustEqual(t, 1, len(store.pairs), "stored pairs")
+	core.AssertEqual(t, 1, len(store.pairs[0].inter), "intermediates")
+}
+
+// TestAddPrivateKeyIdempotent is the regression guard for F49: re-applying keys
+// already present is a successful no-op (count 0, nil), not ErrEmpty.
+func TestAddPrivateKeyIdempotent(t *testing.T) {
+	leaf := mkSelfSignedLeaf(t, "key.example.org")
+
+	buf := buffer.New(context.Background(), nil)
+	feed(t, buf, "key.pem", keyBlock(t, leaf))
+
+	store := newFakeStore()
+	n, err := buf.AddPrivateKey(context.Background(), store)
+	core.AssertMustNoError(t, err, "first add")
+	core.AssertEqual(t, 1, n, "first count")
+
+	// second flush against the same store: all already present.
+	n, err = buf.AddPrivateKey(context.Background(), store)
+	core.AssertNoError(t, err, "re-apply err")
+	core.AssertEqual(t, 0, n, "re-apply count")
+}
+
+// TestAddEmptyBuffer confirms a genuinely empty buffer still reports ErrEmpty —
+// the distinction F49 preserves.
+func TestAddEmptyBuffer(t *testing.T) {
+	buf := buffer.New(context.Background(), nil)
+	store := newFakeStore()
+
+	_, err := buf.AddPrivateKey(context.Background(), store)
+	core.AssertErrorIs(t, err, x509utils.ErrEmpty, "empty buffer")
+}
+
+// runFlushErrAddCACerts confirms a store error from AddCACerts surfaces.
+func runFlushErrAddCACerts(t *testing.T) {
+	t.Helper()
+	ctx := context.Background()
+	buf := buffer.New(ctx, nil)
+	feed(t, buf, "ca.pem", certBlock(mkCA(t, "Err CA")))
+	store := newFakeStore()
+	store.errAddCACerts = core.ErrInvalid
+	n, err := buf.AddCACerts(ctx, store)
+	core.AssertErrorIs(t, err, core.ErrInvalid, "err")
+	core.AssertEqual(t, 0, n, "count")
+}
+
+// runFlushErrAddCert confirms a store error from AddCert surfaces.
+func runFlushErrAddCert(t *testing.T) {
+	t.Helper()
+	ctx := context.Background()
+	leaf := mkLeaf(t, mkCA(t, "Err CA"), "err.example.com", "err.example.com")
+	buf := buffer.New(ctx, nil)
+	feed(t, buf, "leaf.pem", certBlock(leaf))
+	store := newFakeStore()
+	store.errAddCert = core.ErrInvalid
+	n, err := buf.AddCert(ctx, store)
+	core.AssertErrorIs(t, err, core.ErrInvalid, "err")
+	core.AssertEqual(t, 0, n, "count")
+}
+
+// runFlushErrAddPrivateKey confirms a store error from AddPrivateKey surfaces.
+func runFlushErrAddPrivateKey(t *testing.T) {
+	t.Helper()
+	ctx := context.Background()
+	leaf := mkSelfSignedLeaf(t, "err.example.org")
+	buf := buffer.New(ctx, nil)
+	feed(t, buf, "key.pem", keyBlock(t, leaf))
+	store := newFakeStore()
+	store.errAddPrivateKey = core.ErrInvalid
+	n, err := buf.AddPrivateKey(ctx, store)
+	core.AssertErrorIs(t, err, core.ErrInvalid, "err")
+	core.AssertEqual(t, 0, n, "count")
+}
+
+// runFlushErrAddCertPair confirms a store error from AddCertPair surfaces.
+func runFlushErrAddCertPair(t *testing.T) {
+	t.Helper()
+	ctx := context.Background()
+	leaf := mkLeaf(t, mkCA(t, "Err CA"), "err.example.com", "err.example.com")
+	buf := buffer.New(ctx, nil)
+	feed(t, buf, "pair.pem", certBlock(leaf), keyBlock(t, leaf))
+	store := newFakeStore()
+	store.errAddCertPair = core.ErrInvalid
+	n, err := buf.AddCertPair(ctx, store)
+	core.AssertErrorIs(t, err, core.ErrInvalid, "err")
+	core.AssertEqual(t, 0, n, "count")
+}
+
+// TestFlushPropagatesError confirms a real add error (not a duplicate) from
+// the store surfaces through the compound error rather than being swallowed,
+// across every flush method.
+func TestFlushPropagatesError(t *testing.T) {
+	t.Run("AddCACerts", runFlushErrAddCACerts)
+	t.Run("AddCert", runFlushErrAddCert)
+	t.Run("AddPrivateKey", runFlushErrAddPrivateKey)
+	t.Run("AddCertPair", runFlushErrAddCertPair)
+}
+
+// TestClone confirms a clone carries the content and is independent of the
+// source.
+func TestClone(t *testing.T) {
+	ca := mkCA(t, "Clone CA")
+	leaf := mkLeaf(t, ca, "clone.example.com", "clone.example.com")
+
+	buf := buffer.New(context.Background(), nil)
+	feed(t, buf, "leaf.pem", certBlock(leaf), keyBlock(t, leaf))
+
+	clone := buf.Clone()
+	core.AssertMustNotNil(t, clone, "clone")
+	core.AssertEqual(t, 1, clone.Certs().Len(), "clone certs")
+	core.AssertEqual(t, 1, clone.Keys().Len(), "clone keys")
+
+	// adding to the clone must not affect the original.
+	extra := mkLeaf(t, ca, "extra.example.com", "extra.example.com")
+	feed(t, clone, "extra.pem", certBlock(extra))
+	core.AssertEqual(t, 2, clone.Certs().Len(), "clone after add")
+	core.AssertEqual(t, 1, buf.Certs().Len(), "source unchanged")
+}

--- a/tls/store/buffer/error_test.go
+++ b/tls/store/buffer/error_test.go
@@ -1,0 +1,92 @@
+package buffer_test
+
+import (
+	"errors"
+	"testing"
+
+	"darvaza.org/core"
+
+	"darvaza.org/x/tls/store/buffer"
+)
+
+// errBoom is a sentinel base error for the anonymous-source wrap cases.
+var errBoom = errors.New("boom")
+
+// newErrorTestCase exercises SourceName.NewError for anonymous sources
+// (FileName == ""); named sources route through NewPathError, covered in
+// source_test.go. Every row expects a non-nil error whose text carries the
+// annotation token; the nil result is checked in TestSourceNameNewErrorNil.
+type newErrorTestCase struct {
+	base     error
+	name     string
+	op       string
+	note     string
+	wantText string
+}
+
+var _ core.TestCase = newErrorTestCase{}
+
+func newNewErrorTestCase(name string, base error, op, note,
+	wantText string) newErrorTestCase {
+	return newErrorTestCase{
+		base:     base,
+		name:     name,
+		op:       op,
+		note:     note,
+		wantText: wantText,
+	}
+}
+
+func (tc newErrorTestCase) Name() string { return tc.name }
+
+func (tc newErrorTestCase) Test(t *testing.T) {
+	t.Helper()
+
+	sn := buffer.NewSourceName(nil, "")
+	err := sn.NewError(tc.base, tc.op, tc.note)
+
+	core.AssertMustNotNil(t, err, "err")
+	core.AssertContains(t, err.Error(), tc.wantText, "annotation")
+	if tc.base != nil {
+		core.AssertErrorIs(t, err, tc.base, "wraps base")
+	}
+}
+
+func newErrorTestCases() []newErrorTestCase {
+	return []newErrorTestCase{
+		// err == nil: doNewError2 synthesises a fresh error.
+		newNewErrorTestCase("op and note", nil, "read", "bad", "read: bad"),
+		newNewErrorTestCase("note only", nil, "", "bad", "bad"),
+		newNewErrorTestCase("op only", nil, "read", "", "read"),
+		// err != nil: the annotation must wrap the base. F52 regression: the
+		// single-annotation arms wrapped with the empty variable, so
+		// core.Wrap returned the bare base and the annotation was lost.
+		newNewErrorTestCase("wrap pass-through", errBoom, "", "", "boom"),
+		newNewErrorTestCase("wrap note only", errBoom, "", "label", "label"),
+		newNewErrorTestCase("wrap op only", errBoom, "verb", "", "verb"),
+		newNewErrorTestCase("wrap op and note", errBoom, "verb", "label",
+			"verb: label"),
+	}
+}
+
+func TestSourceNameNewError(t *testing.T) {
+	core.RunTestCases(t, newErrorTestCases())
+}
+
+// TestSourceNameNewErrorNil confirms an anonymous source with neither error
+// nor annotation yields nil.
+func TestSourceNameNewErrorNil(t *testing.T) {
+	sn := buffer.NewSourceName(nil, "")
+	core.AssertNil(t, sn.NewError(nil, "", ""), "nil")
+}
+
+// TestSourceNameNewErrorf confirms the formatted annotation reaches the
+// wrapped error.
+func TestSourceNameNewErrorf(t *testing.T) {
+	sn := buffer.NewSourceName(nil, "")
+	err := sn.NewErrorf(errBoom, "op", "count=%d", 3)
+
+	core.AssertMustNotNil(t, err, "err")
+	core.AssertContains(t, err.Error(), "count=3", "formatted note")
+	core.AssertErrorIs(t, err, errBoom, "wraps base")
+}

--- a/tls/store/buffer/reader_test.go
+++ b/tls/store/buffer/reader_test.go
@@ -1,0 +1,86 @@
+package buffer_test
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/pem"
+	"io/fs"
+	"testing"
+
+	"darvaza.org/core"
+
+	"darvaza.org/x/tls/store/buffer"
+	"darvaza.org/x/tls/x509utils"
+)
+
+// feedCerts pushes blocks through the certificates-only callback.
+func feedCerts(t *testing.T, buf *buffer.Buffer, file string,
+	blocks ...*pem.Block) {
+	t.Helper()
+	cb := buf.NewAddCertsCallback()
+	core.AssertMustNotNil(t, cb, "callback")
+	for _, b := range blocks {
+		cb(nil, file, b)
+	}
+}
+
+// feedKeys pushes blocks through the private-keys-only callback.
+func feedKeys(t *testing.T, buf *buffer.Buffer, file string,
+	blocks ...*pem.Block) {
+	t.Helper()
+	cb := buf.NewAddPrivateKeysCallback()
+	core.AssertMustNotNil(t, cb, "callback")
+	for _, b := range blocks {
+		cb(nil, file, b)
+	}
+}
+
+// TestNewAddCertsCallback confirms the certificates-only callback records the
+// certificate and nothing else.
+func TestNewAddCertsCallback(t *testing.T) {
+	leaf := mkSelfSignedLeaf(t, "certs.example.org")
+
+	buf := buffer.New(context.Background(), nil)
+	feedCerts(t, buf, "cert.pem", certBlock(leaf))
+
+	core.AssertEqual(t, 1, buf.Certs().Len(), "certs")
+	core.AssertEqual(t, 0, buf.Keys().Len(), "keys")
+}
+
+// TestNewAddPrivateKeysCallback confirms the keys-only callback records the key
+// and no certificate.
+func TestNewAddPrivateKeysCallback(t *testing.T) {
+	leaf := mkSelfSignedLeaf(t, "keys.example.org")
+
+	buf := buffer.New(context.Background(), nil)
+	feedKeys(t, buf, "key.pem", keyBlock(t, leaf))
+
+	core.AssertEqual(t, 1, buf.Keys().Len(), "keys")
+	core.AssertEqual(t, 0, buf.Certs().Len(), "certs")
+}
+
+// TestCallbacksNilReceiver confirms the typed callbacks are nil-receiver safe.
+func TestCallbacksNilReceiver(t *testing.T) {
+	var buf *buffer.Buffer
+	core.AssertNil(t, buf.NewAddCertsCallback(), "certs cb")
+	core.AssertNil(t, buf.NewAddPrivateKeysCallback(), "keys cb")
+}
+
+// TestPushErr confirms a malformed block records an error against its source,
+// surfaced through ForEach.
+func TestPushErr(t *testing.T) {
+	buf := buffer.New(context.Background(), nil)
+	bad := &pem.Block{Type: "CERTIFICATE", Bytes: []byte("not a certificate")}
+	feedCerts(t, buf, "bad.pem", bad)
+
+	core.AssertEqual(t, 0, buf.Certs().Len(), "no certs")
+
+	var errs int
+	buf.ForEach(func(_ fs.FS, name string, _ []x509utils.PrivateKey,
+		_ []*x509.Certificate, e []error) bool {
+		core.AssertEqual(t, "bad.pem", name, "source")
+		errs += len(e)
+		return true
+	})
+	core.AssertEqual(t, 1, errs, "recorded error")
+}

--- a/tls/store/buffer/set_test.go
+++ b/tls/store/buffer/set_test.go
@@ -1,0 +1,191 @@
+package buffer_test
+
+// cspell:words csclone cscopy csinit
+
+import (
+	"crypto/x509"
+	"testing"
+
+	"darvaza.org/core"
+
+	"darvaza.org/x/tls"
+	"darvaza.org/x/tls/store/buffer"
+	"darvaza.org/x/tls/x509utils"
+)
+
+// TestNewKeySet confirms construction and deduplication by public key.
+func TestNewKeySet(t *testing.T) {
+	a := keyOf(t, mkSelfSignedLeaf(t, "a.example.org"))
+	b := keyOf(t, mkSelfSignedLeaf(t, "b.example.org"))
+
+	ks, err := buffer.NewKeySet(a, b)
+	core.AssertMustNoError(t, err, "new")
+	core.AssertEqual(t, 2, ks.Len(), "len")
+
+	dup, err := buffer.NewKeySet(a, a)
+	core.AssertMustNoError(t, err, "new dup")
+	core.AssertEqual(t, 1, dup.Len(), "unique len")
+}
+
+// TestNewKeySetInvalid confirms a nil key is rejected and MustKeySet panics.
+func TestNewKeySetInvalid(t *testing.T) {
+	_, err := buffer.NewKeySet(nil)
+	core.AssertErrorIs(t, err, core.ErrInvalid, "nil key")
+
+	core.AssertPanic(t, func() { buffer.MustKeySet(nil) }, nil, "must panics")
+}
+
+// TestKeySetPublic confirms the public-key type-cast helper.
+func TestKeySetPublic(t *testing.T) {
+	ks := buffer.MustKeySet()
+	key := keyOf(t, mkSelfSignedLeaf(t, "pub.example.org"))
+
+	core.AssertNotNil(t, ks.Public(key), "public")
+	core.AssertNil(t, ks.Public(nil), "nil key")
+}
+
+// TestKeySetGetFromCertificate confirms lookup by a certificate's public key,
+// covering the found, not-present and invalid-certificate paths plus the nil
+// receiver.
+func TestKeySetGetFromCertificate(t *testing.T) {
+	leaf := mkSelfSignedLeaf(t, "get.example.org")
+	other := mkSelfSignedLeaf(t, "other.example.org")
+	ks := buffer.MustKeySet(keyOf(t, leaf))
+
+	got, err := ks.GetFromCertificate(leaf.Leaf)
+	core.AssertMustNoError(t, err, "found")
+	core.AssertTrue(t, x509utils.ValidCertKeyPair(leaf.Leaf, got), "match")
+
+	_, err = ks.GetFromCertificate(other.Leaf)
+	core.AssertErrorIs(t, err, core.ErrNotExists, "absent")
+
+	_, err = ks.GetFromCertificate(new(x509.Certificate))
+	core.AssertErrorIs(t, err, core.ErrInvalid, "no public key")
+
+	var nilKS *buffer.KeySet
+	_, err = nilKS.GetFromCertificate(leaf.Leaf)
+	core.AssertErrorIs(t, err, core.ErrNilReceiver, "nil receiver")
+}
+
+// TestKeySetClone confirms Clone is independent and nil-receiver safe.
+func TestKeySetClone(t *testing.T) {
+	a := keyOf(t, mkSelfSignedLeaf(t, "clone-a.example.org"))
+	b := keyOf(t, mkSelfSignedLeaf(t, "clone-b.example.org"))
+	ks := buffer.MustKeySet(a)
+
+	clone := ks.Clone()
+	core.AssertMustNotNil(t, clone, "clone")
+	core.AssertEqual(t, 1, clone.Len(), "clone len")
+
+	_, err := clone.Push(b)
+	core.AssertMustNoError(t, err, "push")
+	core.AssertEqual(t, 2, clone.Len(), "clone grew")
+	core.AssertEqual(t, 1, ks.Len(), "source unchanged")
+
+	var nilKS *buffer.KeySet
+	core.AssertNil(t, nilKS.Clone(), "nil clone")
+}
+
+// TestKeySetCopyCond confirms Copy honours the filter condition.
+func TestKeySetCopyCond(t *testing.T) {
+	a := keyOf(t, mkSelfSignedLeaf(t, "copy-a.example.org"))
+	b := keyOf(t, mkSelfSignedLeaf(t, "copy-b.example.org"))
+	ks := buffer.MustKeySet(a, b)
+
+	dst := ks.Copy(nil, func(k x509utils.PrivateKey) bool {
+		return x509utils.PublicKeyEqual(k.Public(), a.Public())
+	})
+	core.AssertMustNotNil(t, dst, "dst")
+	core.AssertEqual(t, 1, dst.Len(), "filtered copy")
+}
+
+// TestInitKeySet confirms in-place initialisation and its guards.
+func TestInitKeySet(t *testing.T) {
+	a := keyOf(t, mkSelfSignedLeaf(t, "init.example.org"))
+
+	var ks buffer.KeySet
+	core.AssertMustNoError(t, buffer.InitKeySet(&ks, a), "init")
+	core.AssertEqual(t, 1, ks.Len(), "init len")
+
+	core.AssertErrorIs(t, buffer.InitKeySet(nil, a), core.ErrInvalid, "nil out")
+
+	var must buffer.KeySet
+	buffer.MustInitKeySet(&must, a)
+	core.AssertEqual(t, 1, must.Len(), "must init len")
+
+	core.AssertPanic(t, func() { buffer.MustInitKeySet(nil, a) }, nil,
+		"must init panics")
+}
+
+// TestNewCertSet confirms construction and deduplication by leaf.
+func TestNewCertSet(t *testing.T) {
+	a := mkSelfSignedLeaf(t, "cs-a.example.org")
+	b := mkSelfSignedLeaf(t, "cs-b.example.org")
+
+	cs, err := buffer.NewCertSet(a, b)
+	core.AssertMustNoError(t, err, "new")
+	core.AssertEqual(t, 2, cs.Len(), "len")
+
+	dup, err := buffer.NewCertSet(a, a)
+	core.AssertMustNoError(t, err, "new dup")
+	core.AssertEqual(t, 1, dup.Len(), "unique len")
+}
+
+// TestNewCertSetInvalid confirms a nil certificate is rejected and MustCertSet
+// panics.
+func TestNewCertSetInvalid(t *testing.T) {
+	_, err := buffer.NewCertSet(nil)
+	core.AssertErrorIs(t, err, core.ErrInvalid, "nil cert")
+
+	core.AssertPanic(t, func() { buffer.MustCertSet(nil) }, nil, "must panics")
+}
+
+// TestCertSetClone confirms Clone is independent and nil-receiver safe.
+func TestCertSetClone(t *testing.T) {
+	a := mkSelfSignedLeaf(t, "csclone-a.example.org")
+	b := mkSelfSignedLeaf(t, "csclone-b.example.org")
+	cs := buffer.MustCertSet(a)
+
+	clone := cs.Clone()
+	core.AssertMustNotNil(t, clone, "clone")
+	core.AssertEqual(t, 1, clone.Len(), "clone len")
+
+	_, err := clone.Push(b)
+	core.AssertMustNoError(t, err, "push")
+	core.AssertEqual(t, 2, clone.Len(), "clone grew")
+	core.AssertEqual(t, 1, cs.Len(), "source unchanged")
+
+	var nilCS *buffer.CertSet
+	core.AssertNil(t, nilCS.Clone(), "nil clone")
+}
+
+// TestCertSetCopyCond confirms Copy honours the filter condition.
+func TestCertSetCopyCond(t *testing.T) {
+	a := mkSelfSignedLeaf(t, "cscopy-a.example.org")
+	b := mkSelfSignedLeaf(t, "cscopy-b.example.org")
+	cs := buffer.MustCertSet(a, b)
+
+	dst := cs.Copy(nil, func(c *tls.Certificate) bool {
+		return c.Leaf.Equal(a.Leaf)
+	})
+	core.AssertMustNotNil(t, dst, "dst")
+	core.AssertEqual(t, 1, dst.Len(), "filtered copy")
+}
+
+// TestInitCertSet confirms in-place initialisation and its guards.
+func TestInitCertSet(t *testing.T) {
+	a := mkSelfSignedLeaf(t, "csinit.example.org")
+
+	var cs buffer.CertSet
+	core.AssertMustNoError(t, buffer.InitCertSet(&cs, a), "init")
+	core.AssertEqual(t, 1, cs.Len(), "init len")
+
+	core.AssertErrorIs(t, buffer.InitCertSet(nil, a), core.ErrInvalid, "nil out")
+
+	var must buffer.CertSet
+	buffer.MustInitCertSet(&must, a)
+	core.AssertEqual(t, 1, must.Len(), "must init len")
+
+	core.AssertPanic(t, func() { buffer.MustInitCertSet(nil, a) }, nil,
+		"must init panics")
+}

--- a/tls/store/buffer/source.go
+++ b/tls/store/buffer/source.go
@@ -37,31 +37,31 @@ func (sn SourceName) NewError(err error, op, note string) error {
 	case sn.IsFile():
 		return sn.NewPathError(err, op, note)
 	case err == nil:
-		// no wrapping
+		// synthesise from the annotation alone
 		return sn.doNewError2(op, note)
-	case op == "" && note == "":
-		// pass through
-		return err
-	case op == "":
-		return core.Wrap(err, op)
-	case note == "":
-		return core.Wrap(err, note)
 	default:
-		return core.Wrapf(err, "%s: %s", op, note)
+		// core.Wrap returns err unchanged when the annotation is empty
+		return core.Wrap(err, annotation(op, note))
 	}
 }
 
 func (SourceName) doNewError2(op, note string) error {
+	if s := annotation(op, note); s != "" {
+		return errors.New(s)
+	}
+	return nil
+}
+
+// annotation joins op and note into a single "op: note" annotation, omitting
+// whichever side is empty. It returns "" when both are empty.
+func annotation(op, note string) string {
 	switch {
-	case op == "" && note == "":
-		// no error
-		return nil
 	case op != "" && note != "":
-		return fmt.Errorf("%s: %s", op, note)
-	case op == "":
-		return errors.New(note)
+		return op + ": " + note
+	case op != "":
+		return op
 	default:
-		return errors.New(op)
+		return note
 	}
 }
 
@@ -211,7 +211,7 @@ func (src *Source) doAddCertPair(ctx context.Context, out tls.StoreX509Writer, l
 func (src *Source) findKeyForCert(cert *x509.Certificate, keys *KeySet) x509utils.PrivateKey {
 	// same source first
 	for _, key := range src.Keys {
-		if x509utils.PublicKeyEqual(cert.PublicKey, key.Public) {
+		if x509utils.PublicKeyEqual(cert.PublicKey, key.Public()) {
 			return key
 		}
 	}
@@ -276,7 +276,7 @@ func addSourceFn[T any](ctx context.Context, out tls.StoreX509Writer, src *Sourc
 		_ = errs.AppendError(err)
 	}
 
-	return returnAdd2(count, errs.AsError())
+	return returnAdd2(len(data), count, errs.AsError())
 }
 
 func doAddSourceFn[T any](ctx context.Context, out tls.StoreX509Writer, data []T,

--- a/tls/store/buffer/source_test.go
+++ b/tls/store/buffer/source_test.go
@@ -1,0 +1,168 @@
+package buffer_test
+
+import (
+	"context"
+	"crypto/x509"
+	"io/fs"
+	"testing"
+
+	"darvaza.org/core"
+
+	"darvaza.org/x/tls"
+	"darvaza.org/x/tls/store/buffer"
+	"darvaza.org/x/tls/x509utils"
+)
+
+// mkSource builds a Source from a leaf and its key in one place.
+func mkSource(name string, certs []*x509.Certificate,
+	keys []x509utils.PrivateKey) *buffer.Source {
+	return &buffer.Source{
+		SourceName: buffer.NewSourceName(nil, name),
+		Certs:      certs,
+		Keys:       keys,
+	}
+}
+
+// TestSourceAddCertPairSameSourceKey is the F34 regression: with a nil KeySet
+// the same-source loop in findKeyForCert is the ONLY way to pair the leaf with
+// its key. The bug (key.Public method value vs key.Public()) made the loop
+// never match, so the pair went out with a nil key.
+func TestSourceAddCertPairSameSourceKey(t *testing.T) {
+	leaf := mkSelfSignedLeaf(t, "same-source.example.org")
+	src := mkSource("pair.pem",
+		core.S(leaf.Leaf),
+		core.S(keyOf(t, leaf)))
+
+	store := newFakeStore()
+	// nil KeySet on purpose: no buffer-wide fallback is available.
+	n, err := src.AddCertPair(context.Background(), store, nil)
+	core.AssertMustNoError(t, err, "add")
+	core.AssertEqual(t, 1, n, "count")
+	core.AssertMustEqual(t, 1, len(store.pairs), "pairs")
+	core.AssertMustNotNil(t, store.pairs[0].key, "paired key (F34)")
+	core.AssertTrue(t,
+		x509utils.ValidCertKeyPair(leaf.Leaf, store.pairs[0].key),
+		"paired key matches leaf")
+}
+
+// TestSourceAddCertPairBufferWideKey confirms the fallback: an empty source
+// KeySet but the key present in the buffer-wide KeySet still pairs.
+func TestSourceAddCertPairBufferWideKey(t *testing.T) {
+	leaf := mkSelfSignedLeaf(t, "wide.example.org")
+	keys := buffer.MustKeySet(keyOf(t, leaf))
+
+	// the source carries the leaf but NOT its key.
+	src := mkSource("cert.pem", core.S(leaf.Leaf), nil)
+
+	store := newFakeStore()
+	n, err := src.AddCertPair(context.Background(), store, keys)
+	core.AssertMustNoError(t, err, "add")
+	core.AssertEqual(t, 1, n, "count")
+	core.AssertMustEqual(t, 1, len(store.pairs), "pairs")
+	core.AssertTrue(t,
+		x509utils.ValidCertKeyPair(leaf.Leaf, store.pairs[0].key),
+		"paired key matches leaf")
+}
+
+// sourceGuardOp names a Source flush method for the shared argument-guard
+// checks in TestSourceGuards.
+type sourceGuardOp struct {
+	fn   func(*buffer.Source, context.Context, tls.StoreX509Writer) (int, error)
+	name string
+}
+
+// sourceOps lists the Source flush methods that share the argument guards.
+// AddCertPair takes an extra KeySet, so it is wrapped to the common signature
+// with a nil set.
+var sourceOps = []sourceGuardOp{
+	{name: "AddCACerts", fn: (*buffer.Source).AddCACerts},
+	{name: "AddCert", fn: (*buffer.Source).AddCert},
+	{name: "AddPrivateKeys", fn: (*buffer.Source).AddPrivateKeys},
+	{name: "AddCertPair", fn: func(src *buffer.Source, ctx context.Context,
+		out tls.StoreX509Writer) (int, error) {
+		return src.AddCertPair(ctx, out, nil)
+	}},
+}
+
+// runSourceGuardCancelled confirms a Source flush method aborts on a cancelled
+// context.
+func runSourceGuardCancelled(t *testing.T, op sourceGuardOp) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	src := mkSource("x.pem", nil, nil)
+	_, err := op.fn(src, ctx, newFakeStore())
+	core.AssertErrorIs(t, err, context.Canceled, "err")
+}
+
+// TestSourceGuards confirms the argument guards on every Source flush method.
+func TestSourceGuards(t *testing.T) {
+	for _, op := range sourceOps {
+		t.Run(op.name+"/nil receiver", func(t *testing.T) {
+			_, err := op.fn(nil, context.Background(), newFakeStore())
+			core.AssertErrorIs(t, err, core.ErrNilReceiver, "err")
+		})
+		t.Run(op.name+"/nil store", func(t *testing.T) {
+			src := mkSource("x.pem", nil, nil)
+			_, err := op.fn(src, context.Background(), nil)
+			core.AssertErrorIs(t, err, tls.ErrNoStore, "err")
+		})
+		t.Run(op.name+"/cancelled", func(t *testing.T) {
+			runSourceGuardCancelled(t, op)
+		})
+	}
+}
+
+// TestSourceClone confirms Clone produces an independent copy.
+func TestSourceClone(t *testing.T) {
+	leaf := mkSelfSignedLeaf(t, "clone.example.org")
+	src := mkSource("s.pem",
+		core.S(leaf.Leaf),
+		core.S(keyOf(t, leaf)))
+
+	clone := src.Clone()
+	core.AssertMustNotNil(t, clone, "clone")
+	core.AssertEqual(t, 1, len(clone.Certs), "clone certs")
+	core.AssertEqual(t, 1, len(clone.Keys), "clone keys")
+
+	// mutating the clone's slices must not touch the source.
+	clone.Certs = append(clone.Certs, leaf.Leaf)
+	core.AssertEqual(t, 1, len(src.Certs), "source unchanged")
+}
+
+// TestSourceCloneNil confirms Clone is nil-receiver safe.
+func TestSourceCloneNil(t *testing.T) {
+	var src *buffer.Source
+	core.AssertNil(t, src.Clone(), "clone")
+}
+
+func TestSourceNameIsFile(t *testing.T) {
+	core.AssertTrue(t, buffer.NewSourceName(nil, "f.pem").IsFile(), "named")
+	core.AssertFalse(t, buffer.NewSourceName(nil, "").IsFile(), "anonymous")
+}
+
+// TestSourceNameNewErrorPathError confirms a named source yields an
+// [fs.PathError] carrying the file name and op.
+func TestSourceNameNewErrorPathError(t *testing.T) {
+	sn := buffer.NewSourceName(nil, "bad.pem")
+	err := sn.NewError(core.ErrInvalid, "AddCert", "boom")
+
+	pe := core.AssertMustTypeIs[*fs.PathError](t, err, "PathError")
+	core.AssertEqual(t, "bad.pem", pe.Path, "path")
+	core.AssertEqual(t, "AddCert", pe.Op, "op")
+	core.AssertErrorIs(t, pe, core.ErrInvalid, "wrapped")
+}
+
+// TestSourceNameAppendErrorFlattens confirms a compound error is appended
+// element by element rather than nested.
+func TestSourceNameAppendErrorFlattens(t *testing.T) {
+	inner := new(core.CompoundError)
+	_ = inner.AppendError(core.ErrInvalid)
+	_ = inner.AppendError(core.ErrExists)
+
+	sn := buffer.NewSourceName(nil, "")
+	out := new(core.CompoundError)
+	sn.AppendError(out, inner, "op", "")
+
+	core.AssertEqual(t, 2, len(out.Errs), "flattened count")
+}

--- a/tls/store/buffer/testutils_test.go
+++ b/tls/store/buffer/testutils_test.go
@@ -1,0 +1,257 @@
+package buffer_test
+
+import (
+	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"testing"
+	"time"
+
+	"darvaza.org/core"
+
+	"darvaza.org/x/tls"
+	"darvaza.org/x/tls/x509utils"
+)
+
+// certSpec describes a certificate to generate for tests. A nil parent
+// produces a self-signed certificate; otherwise the parent signs the leaf.
+type certSpec struct {
+	parent *tls.Certificate
+	cn     string
+	dns    []string
+	isCA   bool
+}
+
+// build generates the certificate described by the spec, returning a
+// [tls.Certificate] with Leaf, Certificate chain and PrivateKey populated.
+func (spec certSpec) build(t *testing.T) *tls.Certificate {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	core.AssertMustNoError(t, err, "generate key")
+
+	tmpl := spec.template(t)
+	parentLeaf, parentKey := spec.parentFor(t, tmpl, key)
+
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, parentLeaf,
+		key.Public(), parentKey)
+	core.AssertMustNoError(t, err, "create certificate")
+
+	leaf, err := x509.ParseCertificate(der)
+	core.AssertMustNoError(t, err, "parse certificate")
+
+	chain := [][]byte{der}
+	if spec.parent != nil {
+		chain = append(chain, spec.parent.Certificate...)
+	}
+
+	return &tls.Certificate{
+		Certificate: chain,
+		PrivateKey:  key,
+		Leaf:        leaf,
+	}
+}
+
+// template builds the x509 template, filling sensible validity defaults.
+func (spec certSpec) template(t *testing.T) *x509.Certificate {
+	t.Helper()
+
+	notBefore := time.Now().Add(-time.Hour)
+	notAfter := time.Now().Add(time.Hour)
+
+	tmpl := &x509.Certificate{
+		SerialNumber: mkSerial(t),
+		Subject:      pkix.Name{CommonName: spec.cn},
+		NotBefore:    notBefore,
+		NotAfter:     notAfter,
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSNames:     spec.dns,
+	}
+
+	if spec.isCA {
+		tmpl.IsCA = true
+		tmpl.BasicConstraintsValid = true
+		tmpl.KeyUsage |= x509.KeyUsageCertSign
+	}
+
+	return tmpl
+}
+
+// parentFor resolves the signing certificate and key: the leaf itself for a
+// self-signed spec, or the configured parent otherwise.
+func (spec certSpec) parentFor(t *testing.T, leafTmpl *x509.Certificate,
+	leafKey crypto.Signer) (*x509.Certificate, crypto.Signer) {
+	t.Helper()
+	if spec.parent == nil {
+		return leafTmpl, leafKey
+	}
+	signer := core.AssertMustTypeIs[crypto.Signer](t,
+		spec.parent.PrivateKey, "parent signer")
+	return spec.parent.Leaf, signer
+}
+
+func mkSerial(t *testing.T) *big.Int {
+	t.Helper()
+	n, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	core.AssertMustNoError(t, err, "serial")
+	return n
+}
+
+// mkCA returns a self-signed CA certificate.
+func mkCA(t *testing.T, cn string) *tls.Certificate {
+	t.Helper()
+	return certSpec{cn: cn, isCA: true}.build(t)
+}
+
+// mkSubCA returns an intermediate CA certificate signed by parent.
+func mkSubCA(t *testing.T, parent *tls.Certificate, cn string) *tls.Certificate {
+	t.Helper()
+	return certSpec{parent: parent, cn: cn, isCA: true}.build(t)
+}
+
+// mkLeaf returns a non-CA leaf certificate signed by parent, with the given
+// DNS SANs.
+func mkLeaf(t *testing.T, parent *tls.Certificate, cn string,
+	dns ...string) *tls.Certificate {
+	t.Helper()
+	return certSpec{parent: parent, cn: cn, dns: dns}.build(t)
+}
+
+// mkSelfSignedLeaf returns a self-signed non-CA leaf certificate.
+func mkSelfSignedLeaf(t *testing.T, cn string) *tls.Certificate {
+	t.Helper()
+	return certSpec{cn: cn}.build(t)
+}
+
+// keyOf returns the private key as an [x509utils.PrivateKey].
+func keyOf(t *testing.T, c *tls.Certificate) x509utils.PrivateKey {
+	t.Helper()
+	return core.AssertMustTypeIs[x509utils.PrivateKey](t, c.PrivateKey, "key")
+}
+
+// certBlock returns the leaf as a PEM CERTIFICATE block.
+func certBlock(c *tls.Certificate) *pem.Block {
+	return &pem.Block{Type: "CERTIFICATE", Bytes: c.Certificate[0]}
+}
+
+// keyBlock returns the private key as a PEM PRIVATE KEY (PKCS#8) block.
+func keyBlock(t *testing.T, c *tls.Certificate) *pem.Block {
+	t.Helper()
+	body, err := x509.MarshalPKCS8PrivateKey(c.PrivateKey)
+	core.AssertMustNoError(t, err, "marshal key")
+	return &pem.Block{Type: "PRIVATE KEY", Bytes: body}
+}
+
+// pairRec records one AddCertPair call.
+type pairRec struct {
+	key   crypto.Signer
+	cert  *x509.Certificate
+	inter []*x509.Certificate
+}
+
+// fakeStore is a recording [tls.StoreX509Writer]. Each add is appended to the
+// matching slice; a repeated add of the same subject is the [core.ErrExists]
+// no-op real stores return, so duplicate handling and idempotence are
+// exercised. A non-nil err* field forces that method to fail.
+type fakeStore struct {
+	seen map[string]bool
+
+	errAddCACerts    error
+	errAddPrivateKey error
+	errAddCert       error
+	errAddCertPair   error
+
+	caCerts []*x509.Certificate
+	keys    []crypto.Signer
+	certs   []*x509.Certificate
+	pairs   []pairRec
+}
+
+func newFakeStore() *fakeStore {
+	return &fakeStore{seen: make(map[string]bool)}
+}
+
+// once reports the first sighting of key, recording it; later sightings yield
+// false so the caller can return the ErrExists no-op.
+func (s *fakeStore) once(key string) bool {
+	if s.seen[key] {
+		return false
+	}
+	s.seen[key] = true
+	return true
+}
+
+func (*fakeStore) GetCertificate(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+	return nil, nil
+}
+
+func (*fakeStore) GetCAPool() *x509.CertPool { return x509.NewCertPool() }
+
+func (s *fakeStore) AddCACerts(_ context.Context, roots ...*x509.Certificate) error {
+	if s.errAddCACerts != nil {
+		return s.errAddCACerts
+	}
+	for _, root := range roots {
+		if !s.once("ca:" + string(root.Raw)) {
+			return core.ErrExists
+		}
+		s.caCerts = append(s.caCerts, root)
+	}
+	return nil
+}
+
+func (s *fakeStore) AddPrivateKey(_ context.Context, key crypto.Signer) error {
+	if s.errAddPrivateKey != nil {
+		return s.errAddPrivateKey
+	}
+	der, err := x509.MarshalPKIXPublicKey(key.Public())
+	if err != nil {
+		return err
+	}
+	if !s.once("k:" + string(der)) {
+		return core.ErrExists
+	}
+	s.keys = append(s.keys, key)
+	return nil
+}
+
+func (s *fakeStore) AddCert(_ context.Context, cert *x509.Certificate) error {
+	if s.errAddCert != nil {
+		return s.errAddCert
+	}
+	if !s.once("c:" + string(cert.Raw)) {
+		return core.ErrExists
+	}
+	s.certs = append(s.certs, cert)
+	return nil
+}
+
+func (s *fakeStore) AddCertPair(_ context.Context, key crypto.Signer,
+	cert *x509.Certificate, intermediates []*x509.Certificate) error {
+	if s.errAddCertPair != nil {
+		return s.errAddCertPair
+	}
+	if !s.once("p:" + string(cert.Raw)) {
+		return core.ErrExists
+	}
+	s.pairs = append(s.pairs, pairRec{key: key, cert: cert, inter: intermediates})
+	return nil
+}
+
+func (s *fakeStore) DeleteCert(_ context.Context, cert *x509.Certificate) error {
+	if !s.seen["c:"+string(cert.Raw)] {
+		return core.ErrNotExists
+	}
+	delete(s.seen, "c:"+string(cert.Raw))
+	return nil
+}
+
+// compile-time guard: fakeStore satisfies the interface the buffer writes to.
+var _ tls.StoreX509Writer = (*fakeStore)(nil)

--- a/tls/store/buffer/utils.go
+++ b/tls/store/buffer/utils.go
@@ -18,9 +18,13 @@ func IsExists(err error) bool {
 	return core.IsError(err, core.ErrExists, fs.ErrExist)
 }
 
-// returnAdd2 induces an [x509utils.ErrEmpty] error when nothing was found.
-func returnAdd2(count int, err error) (int, error) {
-	if count == 0 && err == nil {
+// returnAdd2 induces an [x509utils.ErrEmpty] error only when there was
+// genuinely nothing to operate on (inputs == 0). It must NOT fire when inputs
+// were present but all already existed: an all-duplicate apply added nothing
+// (count == 0) yet is a successful idempotent no-op, not a failure. count is
+// the number of items actually added.
+func returnAdd2(inputs, count int, err error) (int, error) {
+	if inputs == 0 && err == nil {
 		err = x509utils.ErrEmpty
 	}
 	return count, err

--- a/tls/x509utils/certpool/certpool.go
+++ b/tls/x509utils/certpool/certpool.go
@@ -17,8 +17,6 @@ var (
 
 // CertPool is a collection of x.509 Certificates.
 type CertPool struct {
-	mu sync.RWMutex
-
 	cache    *x509.CertPool
 	certs    *CertSet
 	entries  map[*x509.Certificate]*certPoolEntry
@@ -29,6 +27,8 @@ type CertPool struct {
 	// so a child's candidate issuers can be found natively from its
 	// RawIssuer without exporting to a [x509.CertPool]. See GetBySubjectHash.
 	bySubject map[Hash]*list.List[*certPoolEntry]
+
+	mu sync.RWMutex
 }
 
 // IsZero tells if the non-nil store is empty.

--- a/tls/x509utils/certpool/certpool.go
+++ b/tls/x509utils/certpool/certpool.go
@@ -24,6 +24,11 @@ type CertPool struct {
 	entries  map[*x509.Certificate]*certPoolEntry
 	names    map[string]*list.List[*certPoolEntry]
 	patterns map[string]*list.List[*certPoolEntry]
+
+	// bySubject indexes entries by the blake3 hash of their RawSubject,
+	// so a child's candidate issuers can be found natively from its
+	// RawIssuer without exporting to a [x509.CertPool]. See GetBySubjectHash.
+	bySubject map[Hash]*list.List[*certPoolEntry]
 }
 
 // IsZero tells if the non-nil store is empty.
@@ -108,15 +113,17 @@ func (s *CertPool) unsafeReset() error {
 	s.entries = make(map[*x509.Certificate]*certPoolEntry)
 	s.names = make(map[string]*list.List[*certPoolEntry])
 	s.patterns = make(map[string]*list.List[*certPoolEntry])
+	s.bySubject = make(map[Hash]*list.List[*certPoolEntry])
 	return nil
 }
 
 // New creates a blank [CertPool] store.
 func New() *CertPool {
 	return &CertPool{
-		certs:    MustCertSet(),
-		entries:  make(map[*x509.Certificate]*certPoolEntry),
-		names:    make(map[string]*list.List[*certPoolEntry]),
-		patterns: make(map[string]*list.List[*certPoolEntry]),
+		certs:     MustCertSet(),
+		entries:   make(map[*x509.Certificate]*certPoolEntry),
+		names:     make(map[string]*list.List[*certPoolEntry]),
+		patterns:  make(map[string]*list.List[*certPoolEntry]),
+		bySubject: make(map[Hash]*list.List[*certPoolEntry]),
 	}
 }

--- a/tls/x509utils/certpool/certpool_copy.go
+++ b/tls/x509utils/certpool/certpool_copy.go
@@ -3,6 +3,7 @@ package certpool
 import (
 	"crypto/x509"
 
+	"darvaza.org/x/container/list"
 	"darvaza.org/x/tls/x509utils"
 )
 
@@ -118,14 +119,18 @@ func (s *CertPool) doClone(cond func(*certPoolEntry) bool) *CertPool {
 	defer s.mu.RUnlock()
 
 	out := &CertPool{
-		certs:    MustCertSet(),
-		entries:  copyMap(s.entries, fn),
-		names:    copyMapList(s.names, fn),
-		patterns: copyMapList(s.patterns, fn),
+		certs:     MustCertSet(),
+		entries:   copyMap(s.entries, fn),
+		names:     copyMapList(s.names, fn),
+		patterns:  copyMapList(s.patterns, fn),
+		bySubject: make(map[Hash]*list.List[*certPoolEntry]),
 	}
 
-	for k := range out.entries {
+	// bySubject is keyed by a hash derived from each entry, so it can't be
+	// cloned by copyMapList; rebuild it from the cloned entries.
+	for k, ce := range out.entries {
 		_, _ = out.certs.Push(k)
+		out.unsafeIndexSubject(ce)
 	}
 
 	return out

--- a/tls/x509utils/certpool/certpool_issuer.go
+++ b/tls/x509utils/certpool/certpool_issuer.go
@@ -1,0 +1,63 @@
+package certpool
+
+import (
+	"crypto/x509"
+)
+
+// GetBySubjectHash returns every certificate held by the pool whose RawSubject
+// hashes to h. It is a pure index lookup over the pool's own certificates — no
+// [x509.CertPool] export and no signature check. Callers resolving an issuer
+// must verify each candidate themselves with
+// [x509.Certificate.CheckSignatureFrom]; pair it with [HashIssuer] to find a
+// child's candidate issuers natively.
+func (s *CertPool) GetBySubjectHash(h Hash) []*x509.Certificate {
+	if s == nil {
+		return nil
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	l, ok := s.bySubject[h]
+	if !ok || l.Len() == 0 {
+		return nil
+	}
+
+	out := make([]*x509.Certificate, 0, l.Len())
+	l.ForEach(func(ce *certPoolEntry) bool {
+		if ce.Valid() {
+			out = append(out, ce.cert)
+		}
+		return true
+	})
+	return out
+}
+
+// GetBySubject returns every certificate held by the pool that shares cert's
+// Subject (cert itself included when held). Shortcut for
+// GetBySubjectHash(HashSubject(cert)).
+func (s *CertPool) GetBySubject(cert *x509.Certificate) []*x509.Certificate {
+	if h, ok := HashSubject(cert); ok {
+		return s.GetBySubjectHash(h)
+	}
+	return nil
+}
+
+// GetByIssuer returns cert's candidate issuers held by the pool: every
+// certificate whose Subject matches cert's Issuer. The match is by name only —
+// verifying which candidate actually signed cert (via CheckSignatureFrom) is
+// the caller's job. Shortcut for GetBySubjectHash(HashIssuer(cert)).
+func (s *CertPool) GetByIssuer(cert *x509.Certificate) []*x509.Certificate {
+	if h, ok := HashIssuer(cert); ok {
+		return s.GetBySubjectHash(h)
+	}
+	return nil
+}
+
+// unsafeIndexSubject adds ce to the bySubject index under the hash of its
+// RawSubject. The caller must hold the write lock.
+func (s *CertPool) unsafeIndexSubject(ce *certPoolEntry) {
+	if h, ok := HashSubject(ce.cert); ok {
+		appendMapList(s.bySubject, h, ce)
+	}
+}

--- a/tls/x509utils/certpool/certpool_issuer_test.go
+++ b/tls/x509utils/certpool/certpool_issuer_test.go
@@ -1,0 +1,178 @@
+package certpool_test
+
+import (
+	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"testing"
+	"time"
+
+	"darvaza.org/core"
+
+	"darvaza.org/x/tls/x509utils/certpool"
+)
+
+// testCert bundles a parsed certificate with the key that owns it, so it can
+// sign children.
+type testCert struct {
+	cert *x509.Certificate
+	key  *ecdsa.PrivateKey
+}
+
+func baseTemplate(t *testing.T, cn string, dns []string) *x509.Certificate {
+	t.Helper()
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	core.AssertMustNoError(t, err, "serial")
+
+	return &x509.Certificate{
+		SerialNumber: serial,
+		Subject:      pkix.Name{CommonName: cn},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		DNSNames:     dns,
+	}
+}
+
+// signAndParse generates a key for tmpl and signs it with parent (self-signed
+// when parent is nil), returning the parsed certificate and its key.
+func signAndParse(t *testing.T, tmpl *x509.Certificate, parent *testCert) testCert {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	core.AssertMustNoError(t, err, "generate key")
+
+	signerCert, signerKey := tmpl, crypto.Signer(key)
+	if parent != nil {
+		signerCert, signerKey = parent.cert, parent.key
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, signerCert,
+		key.Public(), signerKey)
+	core.AssertMustNoError(t, err, "create certificate")
+
+	cert, err := x509.ParseCertificate(der)
+	core.AssertMustNoError(t, err, "parse certificate")
+	return testCert{cert: cert, key: key}
+}
+
+// mkTestCA builds a CA certificate signed by parent, or self-signed when parent
+// is nil.
+func mkTestCA(t *testing.T, cn string, parent *testCert) testCert {
+	t.Helper()
+	tmpl := baseTemplate(t, cn, nil)
+	tmpl.IsCA = true
+	tmpl.BasicConstraintsValid = true
+	tmpl.KeyUsage |= x509.KeyUsageCertSign
+	return signAndParse(t, tmpl, parent)
+}
+
+// mkTestLeaf builds a non-CA leaf certificate signed by parent.
+func mkTestLeaf(t *testing.T, cn string, parent *testCert) testCert {
+	t.Helper()
+	return signAndParse(t, baseTemplate(t, cn, []string{cn}), parent)
+}
+
+// mustHashIssuer returns the subject-hash to look up a child's candidate
+// issuers.
+func mustHashIssuer(t *testing.T, child *x509.Certificate) certpool.Hash {
+	t.Helper()
+	h, ok := certpool.HashIssuer(child)
+	core.AssertMustTrue(t, ok, "hash issuer")
+	return h
+}
+
+// TestGetBySubjectHash confirms a candidate issuer is found by the child's
+// issuer hash (and a cert by its own subject hash), and that the lookup is
+// nil-safe and reports a miss for an empty pool.
+func TestGetBySubjectHash(t *testing.T) {
+	root := mkTestCA(t, "Lookup Root", nil)
+	sub := mkTestCA(t, "Lookup Sub", &root)
+	leaf := mkTestLeaf(t, "leaf.example.com", &sub)
+
+	pool := certpool.New()
+	core.AssertMustTrue(t, pool.AddCert(sub.cert), "add sub")
+
+	// base primitive: by the child's issuer hash → its candidate issuer
+	got := pool.GetBySubjectHash(mustHashIssuer(t, leaf.cert))
+	core.AssertMustEqual(t, 1, len(got), "one candidate")
+	core.AssertTrue(t, got[0].Equal(sub.cert), "candidate is sub")
+
+	// GetByIssuer shortcut resolves to the same candidate
+	core.AssertMustEqual(t, 1, len(pool.GetByIssuer(leaf.cert)), "by issuer")
+
+	// GetBySubject shortcut finds the cert by its own Subject
+	bySub := pool.GetBySubject(sub.cert)
+	core.AssertMustEqual(t, 1, len(bySub), "by subject")
+	core.AssertTrue(t, bySub[0].Equal(sub.cert), "subject match is sub")
+
+	// misses / nil-safety
+	core.AssertNil(t, certpool.New().GetByIssuer(leaf.cert), "empty pool")
+	core.AssertNil(t, (*certpool.CertPool)(nil).GetByIssuer(leaf.cert), "nil pool")
+	core.AssertNil(t, pool.GetBySubject(nil), "nil cert by subject")
+	core.AssertNil(t, pool.GetByIssuer(nil), "nil cert by issuer")
+}
+
+// TestGetBySubjectHashReturnsTwins confirms the lookup is signature-agnostic:
+// two certs sharing a Subject but holding different keys both land in the
+// bucket and are both returned. Selecting the genuine signer via
+// CheckSignatureFrom is the caller's job, not the index's.
+func TestGetBySubjectHashReturnsTwins(t *testing.T) {
+	root := mkTestCA(t, "Twin Root", nil)
+	sub := mkTestCA(t, "Twin Sub", &root)
+	twin := mkTestCA(t, "Twin Sub", &root) // same Subject, different key
+	leaf := mkTestLeaf(t, "twin.example.com", &sub)
+
+	pool := certpool.New()
+	core.AssertMustTrue(t, pool.AddCert(sub.cert), "add sub")
+	core.AssertMustTrue(t, pool.AddCert(twin.cert), "add twin")
+
+	got := pool.GetByIssuer(leaf.cert)
+	core.AssertMustEqual(t, 2, len(got), "both twins returned")
+
+	var verified int
+	for _, c := range got {
+		if leaf.cert.CheckSignatureFrom(c) == nil {
+			verified++
+		}
+	}
+	core.AssertEqual(t, 1, verified, "exactly one genuine signer")
+}
+
+// TestGetBySubjectHashSurvivesClone confirms Clone rebuilds the subject index:
+// the lookup works on the cloned pool even though bySubject is keyed by a
+// derived hash and so is rebuilt from the cloned entries rather than copied.
+func TestGetBySubjectHashSurvivesClone(t *testing.T) {
+	root := mkTestCA(t, "Clone Root", nil)
+	sub := mkTestCA(t, "Clone Sub", &root)
+	leaf := mkTestLeaf(t, "clone.example.com", &sub)
+
+	pool := certpool.New()
+	core.AssertMustTrue(t, pool.AddCert(sub.cert), "add sub")
+
+	clone, ok := pool.Clone().(*certpool.CertPool)
+	core.AssertMustTrue(t, ok, "clone is *CertPool")
+
+	got := clone.GetByIssuer(leaf.cert)
+	core.AssertMustEqual(t, 1, len(got), "candidate found in clone")
+	core.AssertTrue(t, got[0].Equal(sub.cert), "candidate is sub")
+}
+
+// TestGetBySubjectHashAfterDelete confirms the subject index is maintained on
+// delete: once the cert is removed, the lookup misses.
+func TestGetBySubjectHashAfterDelete(t *testing.T) {
+	root := mkTestCA(t, "Delete Root", nil)
+	sub := mkTestCA(t, "Delete Sub", &root)
+	leaf := mkTestLeaf(t, "del.example.com", &sub)
+
+	pool := certpool.New()
+	core.AssertMustTrue(t, pool.AddCert(sub.cert), "add sub")
+	core.AssertMustEqual(t, 1, len(pool.GetByIssuer(leaf.cert)), "present")
+
+	core.AssertMustNoError(t, pool.DeleteCert(context.Background(), sub.cert), "delete")
+	core.AssertNil(t, pool.GetByIssuer(leaf.cert), "gone")
+}

--- a/tls/x509utils/certpool/certpool_writer.go
+++ b/tls/x509utils/certpool/certpool_writer.go
@@ -126,6 +126,9 @@ func (s *CertPool) unsafeDeleteCertEntry(ce *certPoolEntry) {
 
 	deleteMapListMatchFn(s.names, ce.names, eq)
 	deleteMapListMatchFn(s.patterns, ce.patterns, eq)
+	if h, ok := HashSubject(ce.cert); ok {
+		deleteMapListMatchFn(s.bySubject, []Hash{h}, eq)
+	}
 }
 
 // Import certificates from another CertPool.
@@ -272,4 +275,5 @@ func (s *CertPool) unsafeAddCertEntry(ce *certPoolEntry) {
 	for _, pattern := range ce.patterns {
 		appendMapList(s.patterns, pattern, ce)
 	}
+	s.unsafeIndexSubject(ce)
 }

--- a/tls/x509utils/certpool/hash.go
+++ b/tls/x509utils/certpool/hash.go
@@ -52,6 +52,14 @@ func HashSubject(cert *x509.Certificate) (Hash, bool) {
 	return Hash{}, false
 }
 
+// HashIssuer produces a blake3 digest of the raw issuer of the Certificate
+func HashIssuer(cert *x509.Certificate) (Hash, bool) {
+	if validCert(cert) {
+		return Sum(cert.RawIssuer), true
+	}
+	return Hash{}, false
+}
+
 // HashSubjectPublicKey produces a blake3 digest of the PublicKey of the Certificate
 func HashSubjectPublicKey(cert *x509.Certificate) (Hash, bool) {
 	if validCert(cert) {

--- a/tls/x509utils/certpool/system_test.go
+++ b/tls/x509utils/certpool/system_test.go
@@ -1,4 +1,4 @@
-package certpool
+package certpool_test
 
 import (
 	"bytes"
@@ -7,10 +7,12 @@ import (
 	"encoding/base64"
 	"fmt"
 	"testing"
+
+	"darvaza.org/x/tls/x509utils/certpool"
 )
 
 func TestSystemCertPool(t *testing.T) {
-	pool, err := SystemCertPool()
+	pool, err := certpool.SystemCertPool()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tls/x509utils/certpool/utils.go
+++ b/tls/x509utils/certpool/utils.go
@@ -15,7 +15,7 @@ func validCert(cert *x509.Certificate) bool {
 	switch {
 	case cert == nil, cert.PublicKey == nil:
 		return false
-	case len(cert.Raw) == 0, len(cert.RawSubject) == 0:
+	case len(cert.Raw) == 0, len(cert.RawSubject) == 0, len(cert.RawIssuer) == 0:
 		return false
 	default:
 		return true

--- a/tls/x509utils/certpool/utils_internal_test.go
+++ b/tls/x509utils/certpool/utils_internal_test.go
@@ -1,0 +1,87 @@
+package certpool
+
+import (
+	"crypto/x509"
+	"testing"
+
+	"darvaza.org/core"
+)
+
+// validCertTestCase exercises validCert: a certificate is valid only when it
+// carries DER bytes, a public key, and both a non-empty subject and issuer
+// (RFC 5280 makes issuer a mandatory field).
+type validCertTestCase struct {
+	cert *x509.Certificate
+	name string
+	want bool
+}
+
+// Name returns the test case name for identification.
+func (tc validCertTestCase) Name() string { return tc.name }
+
+// Test asserts validCert's verdict for the case's certificate.
+func (tc validCertTestCase) Test(t *testing.T) {
+	t.Helper()
+	core.AssertEqual(t, tc.want, validCert(tc.cert), "validCert")
+}
+
+var _ core.TestCase = validCertTestCase{}
+
+func newValidCertTestCase(name string, cert *x509.Certificate,
+	want bool) validCertTestCase {
+	return validCertTestCase{
+		cert: cert,
+		name: name,
+		want: want,
+	}
+}
+
+// fullCert returns a certificate satisfying every validCert requirement; each
+// negative case blanks exactly one field.
+func fullCert() *x509.Certificate {
+	return &x509.Certificate{
+		Raw:        []byte{0x01},
+		RawSubject: []byte{0x02},
+		RawIssuer:  []byte{0x03},
+		PublicKey:  struct{}{},
+	}
+}
+
+func withoutPublicKey() *x509.Certificate {
+	c := fullCert()
+	c.PublicKey = nil
+	return c
+}
+
+func withoutRaw() *x509.Certificate {
+	c := fullCert()
+	c.Raw = nil
+	return c
+}
+
+func withoutSubject() *x509.Certificate {
+	c := fullCert()
+	c.RawSubject = nil
+	return c
+}
+
+func withoutIssuer() *x509.Certificate {
+	c := fullCert()
+	c.RawIssuer = nil
+	return c
+}
+
+func validCertTestCases() []validCertTestCase {
+	return []validCertTestCase{
+		newValidCertTestCase("nil cert", nil, false),
+		newValidCertTestCase("no public key", withoutPublicKey(), false),
+		newValidCertTestCase("no DER bytes", withoutRaw(), false),
+		newValidCertTestCase("no subject", withoutSubject(), false),
+		newValidCertTestCase("no issuer", withoutIssuer(), false),
+		newValidCertTestCase("complete", fullCert(), true),
+	}
+}
+
+func TestValidCert(t *testing.T) {
+	core.RunTestCases(t, validCertTestCases())
+}


### PR DESCRIPTION
Hardens the `tls` Store ecosystem on three fronts: the Store interfaces
become a written, build-checked contract; the certpool resolves issuer
chains from its own data instead of round-tripping through the standard
library; and the buffer staging store has its flush-path defects fixed and
a full black-box test suite added.

## Store contract and error classifiers

*feat(tls): document the Store contract and add error checkers*

- Pins the `Store` / `StoreReader` / `StoreWriter` / `StoreX509Writer`
  interface family as a binding specification, so in-tree and external
  implementations have one contract to conform to: the effective-change vs
  no-op convention (duplicate add → already-exists, absent delete →
  does-not-exist) and the nil-receiver / invalid-argument preconditions.
- Adds `IsExists`, `IsNotExists` and `IsInvalid` so callers can classify
  Store errors without importing `darvaza.org/core`.
- Re-exports `NewListener` for the SNI listener path.
- A build-time guard ties `GetCertificate` and `GetCAPool` to the
  `tls.Config` fields they feed; package doc and README lead with the Store
  as a layered, living source of certificates and trust, and the stale SNI,
  PEM and Verify examples are corrected.

## certpool: native chain resolution

*feat(tls/x509utils/certpool): index certificates by subject hash*
*test(tls/x509utils/certpool): make system test black-box*

- Adds a `bySubject` index keyed on the blake3 hash of each `RawSubject`,
  so a child's candidate issuers are found from its `RawIssuer` natively —
  no `x509.CertPool` export and no `Certificate.Verify` round-trip.
  Resolving chains over the store's own data is why this package exists.
- `GetBySubjectHash(h)` is the lookup primitive; `GetBySubject(cert)` and
  `GetByIssuer(cert)` are cert-level shortcuts, with `HashIssuer` mirroring
  `HashSubject`. Lookup is signature-agnostic (returns same-subject twins);
  confirming which candidate actually signed a child stays the caller's job.
- `HashIssuer` now rejects an empty `RawIssuer` (mandatory under RFC 5280)
  rather than hashing to empty bytes. The index is maintained on add and
  delete, and rebuilt on clone.
- The system test moves to `package certpool_test`, adopting the convention
  that `_internal_test.go` is reserved for tests needing unexported access.

## buffer store: fixes and tests

*fix(tls/store/buffer): predicate, pairing, empty-detection, annotation*
*test(tls/store/buffer): cover add flows, sets, sources and callbacks*

Four defects in the Buffer flush path:

- A key-only source was skipped because `AddPrivateKey` filtered sources by
  certificate presence; the predicate is now chosen per operation.
- `findKeyForCert` compared against the `key.Public` method value rather
  than its result, so same-source pairing never matched and the pair went
  out with a nil key.
- `ErrEmpty` was raised whenever nothing was added, mistaking an
  all-duplicate idempotent apply for a failure; it is now gated on the
  input count, so only genuinely empty inputs report "nothing to do".
- `NewError` dropped single annotations through its empty-variable branches;
  a shared annotation helper restores them.

A black-box suite (`package buffer_test`, ~1169 lines) pins all four,
plus the per-method argument guards (nil receiver, nil store, cancelled
context), store-error propagation, Clone independence, the KeySet/CertSet
constructors, and the typed add callbacks including malformed-block error
recording.

## Supporting changes

- *refactor(tls): order struct fields for alignment* and
  *refactor(tls/sni): field-align Dispatcher, exempt protocol structs* —
  cluster pointer-bearing fields first so the GC pointer scan stops early;
  the `keyShare` and `ClientHelloInfo` wire-format structs are exempted with
  a localised `//nolint:govet`. Field order only; behaviour untouched.

## Testing

`make tls race-tls coverage-tls` is green (build, tidy/lint, race). Buffer
store coverage is 90.9%. CI on the branch tip passes Test, Race Detection,
Codecov and Build.

## Follow-ups

The `config` package tests are deferred until the general-purpose
`basic.Store` lands, so they can target a real Store destination end to end
rather than a recording double.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `NewListener` convenience variable for creating TLS listeners with custom configurations.
  * Added error classification helpers: `IsExists`, `IsNotExists`, and `IsInvalid` for simplified error handling.
  * Enhanced `CertPool` with subject/issuer-based certificate lookup methods for efficient certificate resolution.

* **Documentation**
  * Expanded package documentation with clearer guidance on `Store` composition and runtime certificate management.
  * Updated TLS configuration examples showing `tls.NewConfig` and `sni.Dispatcher` usage patterns.

* **Improvements**
  * Enhanced certificate buffer functionality with improved source filtering and metrics tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->