### PR TITLE
test(container): modernise suite, fix Purge, align structs

### DIFF
--- a/container/list/list.go
+++ b/container/list/list.go
@@ -185,7 +185,7 @@ func (l *List[T]) Purge() int {
 			if _, ok := el.Value.(T); !ok {
 				remove = append(remove, el)
 			}
-			return true
+			return false // continue: inspect every element
 		}
 
 		core.ListForEachElement(ll, cb)

--- a/container/list/list_more_test.go
+++ b/container/list/list_more_test.go
@@ -14,38 +14,55 @@ func TestNewWithValues(t *testing.T) {
 	core.AssertSliceEqual(t, values, l.Values(), "values")
 }
 
-func testFrontBackEmpty(t *testing.T) {
-	l := list.New[string]()
-	_, frontOK := l.Front()
-	core.AssertFalse(t, frontOK, "front present")
-	_, backOK := l.Back()
-	core.AssertFalse(t, backOK, "back present")
+var _ core.TestCase = frontBackTestCase{}
+
+// frontBackTestCase verifies Front and Back against a list built from input.
+type frontBackTestCase struct {
+	name      string
+	wantFront string
+	wantBack  string
+	input     []string
+	wantOK    bool
 }
 
-func testFrontBackSingle(t *testing.T) {
-	l := list.New("only")
-	front, ok := l.Front()
-	core.AssertTrue(t, ok, "front present")
-	core.AssertEqual(t, "only", front, "front")
-	back, ok := l.Back()
-	core.AssertTrue(t, ok, "back present")
-	core.AssertEqual(t, "only", back, "back")
+func newFrontBackTestCase(name string, input []string,
+	wantFront, wantBack string, wantOK bool) frontBackTestCase {
+	return frontBackTestCase{
+		name:      name,
+		wantFront: wantFront,
+		wantBack:  wantBack,
+		input:     input,
+		wantOK:    wantOK,
+	}
 }
 
-func testFrontBackMultiple(t *testing.T) {
-	l := list.New("first", "middle", "last")
-	front, ok := l.Front()
-	core.AssertTrue(t, ok, "front present")
-	core.AssertEqual(t, "first", front, "front")
-	back, ok := l.Back()
-	core.AssertTrue(t, ok, "back present")
-	core.AssertEqual(t, "last", back, "back")
+func (tc frontBackTestCase) Name() string { return tc.name }
+
+func (tc frontBackTestCase) Test(t *testing.T) {
+	t.Helper()
+
+	l := list.New(tc.input...)
+	front, frontOK := l.Front()
+	back, backOK := l.Back()
+
+	core.AssertEqual(t, tc.wantOK, frontOK, "front present")
+	core.AssertEqual(t, tc.wantOK, backOK, "back present")
+	core.AssertEqual(t, tc.wantFront, front, "front")
+	core.AssertEqual(t, tc.wantBack, back, "back")
+}
+
+func frontBackTestCases() []frontBackTestCase {
+	return []frontBackTestCase{
+		newFrontBackTestCase("empty list", core.S[string](), "", "", false),
+		newFrontBackTestCase("single element", core.S("only"), "only", "only",
+			true),
+		newFrontBackTestCase("multiple elements",
+			core.S("first", "middle", "last"), "first", "last", true),
+	}
 }
 
 func TestFrontBack(t *testing.T) {
-	t.Run("empty list", testFrontBackEmpty)
-	t.Run("single element", testFrontBackSingle)
-	t.Run("multiple elements", testFrontBackMultiple)
+	core.RunTestCases(t, frontBackTestCases())
 }
 
 func TestPushFrontBack(t *testing.T) {
@@ -60,65 +77,95 @@ func TestPushFrontBack(t *testing.T) {
 	core.AssertSliceEqual(t, core.S(3, 1, 2, 4), l.Values(), "values")
 }
 
-func testDeleteMatchFnNone(t *testing.T) {
-	l := list.New(1, 3, 5, 7)
-	// Try to delete even numbers (none exist)
-	l.DeleteMatchFn(func(v int) bool {
-		return v%2 == 0
-	})
-	core.AssertEqual(t, 4, l.Len(), "length")
+var _ core.TestCase = deleteMatchFnTestCase{}
+
+// deleteMatchFnTestCase deletes even numbers from input and checks the remainder.
+type deleteMatchFnTestCase struct {
+	name  string
+	input []int
+	want  []int
 }
 
-func testDeleteMatchFnSome(t *testing.T) {
-	l := list.New(1, 2, 3, 4, 5)
-	// Delete even numbers
-	l.DeleteMatchFn(func(v int) bool {
-		return v%2 == 0
-	})
-	core.AssertSliceEqual(t, core.S(1, 3, 5), l.Values(), "values")
+func newDeleteMatchFnTestCase(name string, input,
+	want []int) deleteMatchFnTestCase {
+	return deleteMatchFnTestCase{
+		name:  name,
+		input: input,
+		want:  want,
+	}
 }
 
-func testDeleteMatchFnAll(t *testing.T) {
-	l := list.New(2, 4, 6, 8)
-	// Delete all even numbers
-	l.DeleteMatchFn(func(v int) bool {
-		return v%2 == 0
-	})
-	core.AssertEqual(t, 0, l.Len(), "length")
+func (tc deleteMatchFnTestCase) Name() string { return tc.name }
+
+func (tc deleteMatchFnTestCase) Test(t *testing.T) {
+	t.Helper()
+
+	l := list.New(tc.input...)
+	l.DeleteMatchFn(func(v int) bool { return v%2 == 0 })
+	core.AssertSliceEqual(t, tc.want, l.Values(), "values")
+}
+
+func deleteMatchFnTestCases() []deleteMatchFnTestCase {
+	return []deleteMatchFnTestCase{
+		newDeleteMatchFnTestCase("delete none", core.S(1, 3, 5, 7),
+			core.S(1, 3, 5, 7)),
+		newDeleteMatchFnTestCase("delete some", core.S(1, 2, 3, 4, 5),
+			core.S(1, 3, 5)),
+		newDeleteMatchFnTestCase("delete all", core.S(2, 4, 6, 8),
+			core.S[int]()),
+	}
 }
 
 func TestDeleteMatchFn(t *testing.T) {
-	t.Run("delete none", testDeleteMatchFnNone)
-	t.Run("delete some", testDeleteMatchFnSome)
-	t.Run("delete all", testDeleteMatchFnAll)
+	core.RunTestCases(t, deleteMatchFnTestCases())
 }
 
-func testPopFirstMatchFnFound(t *testing.T) {
-	l := list.New(1, 2, 3, 4, 5)
-	// Pop first even number
-	v, ok := l.PopFirstMatchFn(func(n int) bool {
-		return n%2 == 0
-	})
-	core.AssertTrue(t, ok, "popped")
-	core.AssertEqual(t, 2, v, "popped value")
-	// Verify it was removed
-	core.AssertSliceEqual(t, core.S(1, 3, 4, 5), l.Values(), "remaining")
+var _ core.TestCase = popFirstMatchFnTestCase{}
+
+// popFirstMatchFnTestCase pops the first even number, checking value and remainder.
+type popFirstMatchFnTestCase struct {
+	name      string
+	input     []int
+	want      []int
+	wantValue int
+	wantOK    bool
 }
 
-func testPopFirstMatchFnNotFound(t *testing.T) {
-	l := list.New(1, 3, 5)
-	// Try to pop even number (none exist)
-	_, ok := l.PopFirstMatchFn(func(n int) bool {
-		return n%2 == 0
-	})
-	core.AssertFalse(t, ok, "not found")
-	// List should be unchanged
-	core.AssertEqual(t, 3, l.Len(), "length")
+func newPopFirstMatchFnTestCase(name string, input []int, wantValue int,
+	wantOK bool, want []int) popFirstMatchFnTestCase {
+	return popFirstMatchFnTestCase{
+		name:      name,
+		input:     input,
+		want:      want,
+		wantValue: wantValue,
+		wantOK:    wantOK,
+	}
+}
+
+func (tc popFirstMatchFnTestCase) Name() string { return tc.name }
+
+func (tc popFirstMatchFnTestCase) Test(t *testing.T) {
+	t.Helper()
+
+	l := list.New(tc.input...)
+	v, ok := l.PopFirstMatchFn(func(n int) bool { return n%2 == 0 })
+
+	core.AssertEqual(t, tc.wantOK, ok, "popped")
+	core.AssertEqual(t, tc.wantValue, v, "value")
+	core.AssertSliceEqual(t, tc.want, l.Values(), "remaining")
+}
+
+func popFirstMatchFnTestCases() []popFirstMatchFnTestCase {
+	return []popFirstMatchFnTestCase{
+		newPopFirstMatchFnTestCase("found", core.S(1, 2, 3, 4, 5), 2, true,
+			core.S(1, 3, 4, 5)),
+		newPopFirstMatchFnTestCase("not found", core.S(1, 3, 5), 0, false,
+			core.S(1, 3, 5)),
+	}
 }
 
 func TestPopFirstMatchFn(t *testing.T) {
-	t.Run("found", testPopFirstMatchFnFound)
-	t.Run("not found", testPopFirstMatchFnNotFound)
+	core.RunTestCases(t, popFirstMatchFnTestCases())
 }
 
 func TestMoveToBackFirstMatchFn(t *testing.T) {
@@ -141,28 +188,48 @@ func TestMoveToFrontFirstMatchFn(t *testing.T) {
 	core.AssertSliceEqual(t, core.S(4, 1, 2, 3, 5), l.Values(), "values")
 }
 
-func testFirstMatchFnFound(t *testing.T) {
-	l := list.New("apple", "banana", "cherry", "date")
-	// Find first string with length > 5
-	v, ok := l.FirstMatchFn(func(s string) bool {
-		return len(s) > 5
-	})
-	core.AssertTrue(t, ok, "found")
-	core.AssertEqual(t, "banana", v, "match")
+var _ core.TestCase = firstMatchFnTestCase{}
+
+// firstMatchFnTestCase finds the first string longer than five characters.
+type firstMatchFnTestCase struct {
+	name      string
+	wantValue string
+	input     []string
+	wantOK    bool
 }
 
-func testFirstMatchFnNotFound(t *testing.T) {
-	l := list.New("a", "b", "c")
-	// Find string with length > 5
-	_, ok := l.FirstMatchFn(func(s string) bool {
-		return len(s) > 5
-	})
-	core.AssertFalse(t, ok, "not found")
+func newFirstMatchFnTestCase(name string, input []string, wantValue string,
+	wantOK bool) firstMatchFnTestCase {
+	return firstMatchFnTestCase{
+		name:      name,
+		wantValue: wantValue,
+		input:     input,
+		wantOK:    wantOK,
+	}
+}
+
+func (tc firstMatchFnTestCase) Name() string { return tc.name }
+
+func (tc firstMatchFnTestCase) Test(t *testing.T) {
+	t.Helper()
+
+	l := list.New(tc.input...)
+	v, ok := l.FirstMatchFn(func(s string) bool { return len(s) > 5 })
+
+	core.AssertEqual(t, tc.wantOK, ok, "found")
+	core.AssertEqual(t, tc.wantValue, v, "match")
+}
+
+func firstMatchFnTestCases() []firstMatchFnTestCase {
+	return []firstMatchFnTestCase{
+		newFirstMatchFnTestCase("found",
+			core.S("apple", "banana", "cherry", "date"), "banana", true),
+		newFirstMatchFnTestCase("not found", core.S("a", "b", "c"), "", false),
+	}
 }
 
 func TestFirstMatchFn(t *testing.T) {
-	t.Run("found", testFirstMatchFnFound)
-	t.Run("not found", testFirstMatchFnNotFound)
+	core.RunTestCases(t, firstMatchFnTestCases())
 }
 
 func TestZero(t *testing.T) {

--- a/container/list/list_more_test.go
+++ b/container/list/list_more_test.go
@@ -288,20 +288,46 @@ func TestCopy(t *testing.T) {
 	t.Run("copy all", testCopyAll)
 }
 
-func TestPurge(t *testing.T) {
-	// Purge is specifically for removing elements that don't match the type
-	// This is more relevant when dealing with interface{} conversions
-	// For a generic List[T], all elements should already be of type T
-	l := list.New[int]()
-
-	// Add some values
-	l.PushBack(1)
-	l.PushBack(2)
-	l.PushBack(3)
-
-	// Since all elements are already int, purge should remove nothing
+func testPurgeNoMismatch(t *testing.T) {
+	// Every element is already an int, so Purge removes nothing.
+	l := list.New(1, 2, 3)
 	core.AssertEqual(t, 0, l.Purge(), "removed")
 	core.AssertEqual(t, 3, l.Len(), "length")
+}
+
+func testPurgeTypeMismatch(t *testing.T) {
+	// Inject a wrongly-typed value through the underlying list; only direct
+	// access to list.List can break the List[T] type invariant.
+	l := list.New(1, 2, 3)
+	l.Sys().PushBack("not an int")
+	core.AssertMustEqual(t, 4, l.Sys().Len(), "raw length")
+
+	// Iteration skips the wrongly-typed element...
+	core.AssertSliceEqual(t, core.S(1, 2, 3), l.Values(), "values before purge")
+
+	// ...and Purge removes it, reporting the count.
+	core.AssertEqual(t, 1, l.Purge(), "removed")
+	core.AssertEqual(t, 3, l.Sys().Len(), "raw length after purge")
+	core.AssertSliceEqual(t, core.S(1, 2, 3), l.Values(), "values after purge")
+}
+
+func testPurgeMultipleMismatches(t *testing.T) {
+	// Scatter wrongly-typed values at the head, middle and tail to confirm
+	// Purge scans the whole list rather than stopping at the first one.
+	l := list.New[int]()
+	for _, v := range []any{"a", 1, "b", 2, 3, "c"} {
+		l.Sys().PushBack(v)
+	}
+	core.AssertMustEqual(t, 6, l.Sys().Len(), "raw length")
+
+	core.AssertEqual(t, 3, l.Purge(), "removed")
+	core.AssertSliceEqual(t, core.S(1, 2, 3), l.Values(), "values")
+}
+
+func TestPurge(t *testing.T) {
+	t.Run("no mismatch", testPurgeNoMismatch)
+	t.Run("type mismatch", testPurgeTypeMismatch)
+	t.Run("multiple mismatches", testPurgeMultipleMismatches)
 }
 
 func TestNilList(t *testing.T) {
@@ -318,6 +344,7 @@ func TestNilList(t *testing.T) {
 	core.AssertFalse(t, backOK, "nil Back")
 
 	core.AssertEqual(t, 0, len(l.Values()), "nil Values")
+	core.AssertEqual(t, 0, l.Purge(), "nil Purge")
 
 	// These should not panic
 	core.AssertNoPanic(t, func() {

--- a/container/list/list_more_test.go
+++ b/container/list/list_more_test.go
@@ -1,57 +1,45 @@
-package list
+package list_test
 
 import (
 	"testing"
+
+	"darvaza.org/core"
+	"darvaza.org/x/container/list"
 )
 
 func TestNewWithValues(t *testing.T) {
-	values := []int{1, 2, 3, 4, 5}
-	l := New(values...)
+	values := core.S(1, 2, 3, 4, 5)
+	l := list.New(values...)
 
-	if l.Len() != len(values) {
-		t.Errorf("Expected length %d, got %d", len(values), l.Len())
-	}
-
-	result := l.Values()
-	for i, v := range result {
-		if v != values[i] {
-			t.Errorf("Value at index %d: got %d, expected %d", i, v, values[i])
-		}
-	}
+	core.AssertSliceEqual(t, values, l.Values(), "values")
 }
 
 func testFrontBackEmpty(t *testing.T) {
-	l := New[string]()
-	if v, ok := l.Front(); ok {
-		t.Errorf("Expected no front value, got %v", v)
-	}
-	if v, ok := l.Back(); ok {
-		t.Errorf("Expected no back value, got %v", v)
-	}
+	l := list.New[string]()
+	_, frontOK := l.Front()
+	core.AssertFalse(t, frontOK, "front present")
+	_, backOK := l.Back()
+	core.AssertFalse(t, backOK, "back present")
 }
 
 func testFrontBackSingle(t *testing.T) {
-	l := New("only")
+	l := list.New("only")
 	front, ok := l.Front()
-	if !ok || front != "only" {
-		t.Errorf("Front: got (%v, %v), expected (only, true)", front, ok)
-	}
+	core.AssertTrue(t, ok, "front present")
+	core.AssertEqual(t, "only", front, "front")
 	back, ok := l.Back()
-	if !ok || back != "only" {
-		t.Errorf("Back: got (%v, %v), expected (only, true)", back, ok)
-	}
+	core.AssertTrue(t, ok, "back present")
+	core.AssertEqual(t, "only", back, "back")
 }
 
 func testFrontBackMultiple(t *testing.T) {
-	l := New("first", "middle", "last")
+	l := list.New("first", "middle", "last")
 	front, ok := l.Front()
-	if !ok || front != "first" {
-		t.Errorf("Front: got (%v, %v), expected (first, true)", front, ok)
-	}
+	core.AssertTrue(t, ok, "front present")
+	core.AssertEqual(t, "first", front, "front")
 	back, ok := l.Back()
-	if !ok || back != "last" {
-		t.Errorf("Back: got (%v, %v), expected (last, true)", back, ok)
-	}
+	core.AssertTrue(t, ok, "back present")
+	core.AssertEqual(t, "last", back, "back")
 }
 
 func TestFrontBack(t *testing.T) {
@@ -61,7 +49,7 @@ func TestFrontBack(t *testing.T) {
 }
 
 func TestPushFrontBack(t *testing.T) {
-	l := New[int]()
+	l := list.New[int]()
 
 	// Build: [3, 1, 2, 4]
 	l.PushBack(1)
@@ -69,58 +57,34 @@ func TestPushFrontBack(t *testing.T) {
 	l.PushFront(3)
 	l.PushBack(4)
 
-	expected := []int{3, 1, 2, 4}
-	values := l.Values()
-
-	if len(values) != len(expected) {
-		t.Fatalf("Expected %d values, got %d", len(expected), len(values))
-	}
-
-	for i, v := range values {
-		if v != expected[i] {
-			t.Errorf("Value at index %d: got %d, expected %d", i, v, expected[i])
-		}
-	}
+	core.AssertSliceEqual(t, core.S(3, 1, 2, 4), l.Values(), "values")
 }
 
 func testDeleteMatchFnNone(t *testing.T) {
-	l := New(1, 3, 5, 7)
+	l := list.New(1, 3, 5, 7)
 	// Try to delete even numbers (none exist)
 	l.DeleteMatchFn(func(v int) bool {
 		return v%2 == 0
 	})
-	if l.Len() != 4 {
-		t.Errorf("Expected length 4, got %d", l.Len())
-	}
+	core.AssertEqual(t, 4, l.Len(), "length")
 }
 
 func testDeleteMatchFnSome(t *testing.T) {
-	l := New(1, 2, 3, 4, 5)
+	l := list.New(1, 2, 3, 4, 5)
 	// Delete even numbers
 	l.DeleteMatchFn(func(v int) bool {
 		return v%2 == 0
 	})
-	expected := []int{1, 3, 5}
-	values := l.Values()
-	if len(values) != len(expected) {
-		t.Fatalf("Expected %d values, got %d", len(expected), len(values))
-	}
-	for i, v := range values {
-		if v != expected[i] {
-			t.Errorf("Value at index %d: got %d, expected %d", i, v, expected[i])
-		}
-	}
+	core.AssertSliceEqual(t, core.S(1, 3, 5), l.Values(), "values")
 }
 
 func testDeleteMatchFnAll(t *testing.T) {
-	l := New(2, 4, 6, 8)
+	l := list.New(2, 4, 6, 8)
 	// Delete all even numbers
 	l.DeleteMatchFn(func(v int) bool {
 		return v%2 == 0
 	})
-	if l.Len() != 0 {
-		t.Errorf("Expected empty list, got length %d", l.Len())
-	}
+	core.AssertEqual(t, 0, l.Len(), "length")
 }
 
 func TestDeleteMatchFn(t *testing.T) {
@@ -130,40 +94,26 @@ func TestDeleteMatchFn(t *testing.T) {
 }
 
 func testPopFirstMatchFnFound(t *testing.T) {
-	l := New(1, 2, 3, 4, 5)
+	l := list.New(1, 2, 3, 4, 5)
 	// Pop first even number
 	v, ok := l.PopFirstMatchFn(func(n int) bool {
 		return n%2 == 0
 	})
-	if !ok || v != 2 {
-		t.Errorf("Expected (2, true), got (%d, %v)", v, ok)
-	}
+	core.AssertTrue(t, ok, "popped")
+	core.AssertEqual(t, 2, v, "popped value")
 	// Verify it was removed
-	values := l.Values()
-	expected := []int{1, 3, 4, 5}
-	if len(values) != len(expected) {
-		t.Fatalf("Expected %d values, got %d", len(expected), len(values))
-	}
-	for i, val := range values {
-		if val != expected[i] {
-			t.Errorf("Value at index %d: got %d, expected %d", i, val, expected[i])
-		}
-	}
+	core.AssertSliceEqual(t, core.S(1, 3, 4, 5), l.Values(), "remaining")
 }
 
 func testPopFirstMatchFnNotFound(t *testing.T) {
-	l := New(1, 3, 5)
+	l := list.New(1, 3, 5)
 	// Try to pop even number (none exist)
-	v, ok := l.PopFirstMatchFn(func(n int) bool {
+	_, ok := l.PopFirstMatchFn(func(n int) bool {
 		return n%2 == 0
 	})
-	if ok {
-		t.Errorf("Expected not found, got (%d, true)", v)
-	}
+	core.AssertFalse(t, ok, "not found")
 	// List should be unchanged
-	if l.Len() != 3 {
-		t.Errorf("Expected length 3, got %d", l.Len())
-	}
+	core.AssertEqual(t, 3, l.Len(), "length")
 }
 
 func TestPopFirstMatchFn(t *testing.T) {
@@ -172,67 +122,42 @@ func TestPopFirstMatchFn(t *testing.T) {
 }
 
 func TestMoveToBackFirstMatchFn(t *testing.T) {
-	l := New(1, 2, 3, 4, 5)
+	l := list.New(1, 2, 3, 4, 5)
 	// Move first even number to back
 	l.MoveToBackFirstMatchFn(func(n int) bool {
 		return n%2 == 0
 	})
 
-	values := l.Values()
-	expected := []int{1, 3, 4, 5, 2}
-
-	if len(values) != len(expected) {
-		t.Fatalf("Expected %d values, got %d", len(expected), len(values))
-	}
-
-	for i, v := range values {
-		if v != expected[i] {
-			t.Errorf("Value at index %d: got %d, expected %d", i, v, expected[i])
-		}
-	}
+	core.AssertSliceEqual(t, core.S(1, 3, 4, 5, 2), l.Values(), "values")
 }
 
 func TestMoveToFrontFirstMatchFn(t *testing.T) {
-	l := New(1, 2, 3, 4, 5)
+	l := list.New(1, 2, 3, 4, 5)
 	// Move first number > 3 to front
 	l.MoveToFrontFirstMatchFn(func(n int) bool {
 		return n > 3
 	})
 
-	values := l.Values()
-	expected := []int{4, 1, 2, 3, 5}
-
-	if len(values) != len(expected) {
-		t.Fatalf("Expected %d values, got %d", len(expected), len(values))
-	}
-
-	for i, v := range values {
-		if v != expected[i] {
-			t.Errorf("Value at index %d: got %d, expected %d", i, v, expected[i])
-		}
-	}
+	core.AssertSliceEqual(t, core.S(4, 1, 2, 3, 5), l.Values(), "values")
 }
 
 func testFirstMatchFnFound(t *testing.T) {
-	l := New("apple", "banana", "cherry", "date")
+	l := list.New("apple", "banana", "cherry", "date")
 	// Find first string with length > 5
 	v, ok := l.FirstMatchFn(func(s string) bool {
 		return len(s) > 5
 	})
-	if !ok || v != "banana" {
-		t.Errorf("Expected (banana, true), got (%s, %v)", v, ok)
-	}
+	core.AssertTrue(t, ok, "found")
+	core.AssertEqual(t, "banana", v, "match")
 }
 
 func testFirstMatchFnNotFound(t *testing.T) {
-	l := New("a", "b", "c")
+	l := list.New("a", "b", "c")
 	// Find string with length > 5
-	v, ok := l.FirstMatchFn(func(s string) bool {
+	_, ok := l.FirstMatchFn(func(s string) bool {
 		return len(s) > 5
 	})
-	if ok {
-		t.Errorf("Expected not found, got (%s, true)", v)
-	}
+	core.AssertFalse(t, ok, "not found")
 }
 
 func TestFirstMatchFn(t *testing.T) {
@@ -241,53 +166,36 @@ func TestFirstMatchFn(t *testing.T) {
 }
 
 func TestZero(t *testing.T) {
-	l := New[int]()
-	if z := l.Zero(); z != 0 {
-		t.Errorf("Expected zero value 0, got %d", z)
-	}
+	l := list.New[int]()
+	core.AssertEqual(t, 0, l.Zero(), "int zero")
 
-	ls := New[string]()
-	if z := ls.Zero(); z != "" {
-		t.Errorf("Expected zero value empty string, got %q", z)
-	}
+	ls := list.New[string]()
+	core.AssertEqual(t, "", ls.Zero(), "string zero")
 
 	type custom struct {
 		b string
 		a int
 	}
-	lc := New[custom]()
+	lc := list.New[custom]()
 	z := lc.Zero()
-	if z.a != 0 || z.b != "" {
-		t.Errorf("Expected zero value {0, \"\"}, got %+v", z)
-	}
+	core.AssertEqual(t, 0, z.a, "custom zero a")
+	core.AssertEqual(t, "", z.b, "custom zero b")
 }
 
 func TestClone(t *testing.T) {
-	original := New(1, 2, 3)
+	original := list.New(1, 2, 3)
 	cloned := original.Clone()
 
 	// Verify they have same values
-	if original.Len() != cloned.Len() {
-		t.Errorf("Clone has different length: %d vs %d", cloned.Len(), original.Len())
-	}
-
-	origValues := original.Values()
-	cloneValues := cloned.Values()
-	for i := range origValues {
-		if origValues[i] != cloneValues[i] {
-			t.Errorf("Value mismatch at index %d: %v vs %v", i, origValues[i], cloneValues[i])
-		}
-	}
+	core.AssertSliceEqual(t, original.Values(), cloned.Values(), "clone values")
 
 	// Verify they are independent
 	cloned.PushBack(4)
-	if original.Len() == cloned.Len() {
-		t.Error("Clone modification affected original")
-	}
+	core.AssertNotEqual(t, original.Len(), cloned.Len(), "independent length")
 }
 
 func testCopyFilterTransform(t *testing.T) {
-	l := New(1, 2, 3, 4, 5, 6)
+	l := list.New(1, 2, 3, 4, 5, 6)
 	// Copy only even numbers, tripled
 	copied := l.Copy(func(v int) (int, bool) {
 		if v%2 == 0 {
@@ -296,38 +204,16 @@ func testCopyFilterTransform(t *testing.T) {
 		return 0, false
 	})
 
-	expected := []int{6, 12, 18}
-	values := copied.Values()
-
-	if len(values) != len(expected) {
-		t.Fatalf("Expected %d values, got %d", len(expected), len(values))
-	}
-
-	for i, v := range values {
-		if v != expected[i] {
-			t.Errorf("Value at index %d: got %d, expected %d", i, v, expected[i])
-		}
-	}
+	core.AssertSliceEqual(t, core.S(6, 12, 18), copied.Values(), "values")
 }
 
 func testCopyAll(t *testing.T) {
-	l := New("a", "b", "c")
+	l := list.New("a", "b", "c")
 	copied := l.Copy(func(v string) (string, bool) {
 		return v + v, true // double each string
 	})
 
-	expected := []string{"aa", "bb", "cc"}
-	values := copied.Values()
-
-	if len(values) != len(expected) {
-		t.Fatalf("Expected %d values, got %d", len(expected), len(values))
-	}
-
-	for i, v := range values {
-		if v != expected[i] {
-			t.Errorf("Value at index %d: got %s, expected %s", i, v, expected[i])
-		}
-	}
+	core.AssertSliceEqual(t, core.S("aa", "bb", "cc"), copied.Values(), "values")
 }
 
 func TestCopy(t *testing.T) {
@@ -339,7 +225,7 @@ func TestPurge(t *testing.T) {
 	// Purge is specifically for removing elements that don't match the type
 	// This is more relevant when dealing with interface{} conversions
 	// For a generic List[T], all elements should already be of type T
-	l := New[int]()
+	l := list.New[int]()
 
 	// Add some values
 	l.PushBack(1)
@@ -347,44 +233,30 @@ func TestPurge(t *testing.T) {
 	l.PushBack(3)
 
 	// Since all elements are already int, purge should remove nothing
-	removed := l.Purge()
-	if removed != 0 {
-		t.Errorf("Expected 0 elements removed, got %d", removed)
-	}
-
-	if l.Len() != 3 {
-		t.Errorf("Expected length 3 after purge, got %d", l.Len())
-	}
+	core.AssertEqual(t, 0, l.Purge(), "removed")
+	core.AssertEqual(t, 3, l.Len(), "length")
 }
 
 func TestNilList(t *testing.T) {
-	var l *List[int]
+	var l *list.List[int]
 
 	// Test nil-safe methods
-	if l.Len() != 0 {
-		t.Errorf("Nil list length should be 0, got %d", l.Len())
-	}
+	core.AssertEqual(t, 0, l.Len(), "nil length")
+	core.AssertNil(t, l.Sys(), "nil Sys")
 
-	if l.Sys() != nil {
-		t.Error("Nil list Sys() should return nil")
-	}
+	_, frontOK := l.Front()
+	core.AssertFalse(t, frontOK, "nil Front")
 
-	if v, ok := l.Front(); ok {
-		t.Errorf("Nil list Front() should return (zero, false), got (%v, %v)", v, ok)
-	}
+	_, backOK := l.Back()
+	core.AssertFalse(t, backOK, "nil Back")
 
-	if v, ok := l.Back(); ok {
-		t.Errorf("Nil list Back() should return (zero, false), got (%v, %v)", v, ok)
-	}
-
-	values := l.Values()
-	if len(values) != 0 {
-		t.Errorf("Nil list Values() should return empty slice, got %v", values)
-	}
+	core.AssertEqual(t, 0, len(l.Values()), "nil Values")
 
 	// These should not panic
-	l.PushFront(1)
-	l.PushBack(2)
-	l.ForEach(func(int) bool { return true })
-	l.DeleteMatchFn(func(int) bool { return true })
+	core.AssertNoPanic(t, func() {
+		l.PushFront(1)
+		l.PushBack(2)
+		l.ForEach(func(int) bool { return true })
+		l.DeleteMatchFn(func(int) bool { return true })
+	}, "nil mutators")
 }

--- a/container/list/list_more_test.go
+++ b/container/list/list_more_test.go
@@ -252,8 +252,8 @@ func TestZero(t *testing.T) {
 	}
 
 	type custom struct {
-		a int
 		b string
+		a int
 	}
 	lc := New[custom]()
 	z := lc.Zero()

--- a/container/list/list_test.go
+++ b/container/list/list_test.go
@@ -115,8 +115,8 @@ func TestEmptyList(t *testing.T) {
 }
 
 type TestStruct struct {
-	ID   int
 	Name string
+	ID   int
 }
 
 func makeTestList() (list *List[*TestStruct], first, second *TestStruct) {

--- a/container/list/list_test.go
+++ b/container/list/list_test.go
@@ -1,28 +1,25 @@
-package list
+package list_test
 
 import (
 	"testing"
+
+	"darvaza.org/core"
+	"darvaza.org/x/container/list"
 )
 
 func TestForEachBug(t *testing.T) {
 	// Create a new list
-	l := New[int]()
+	l := list.New[int]()
 
 	// Add two items
 	l.PushBack(1)
 	l.PushBack(2)
 
 	// Verify length is correct
-	if l.Len() != 2 {
-		t.Fatalf("Expected length 2, got %d", l.Len())
-	}
+	core.AssertMustEqual(t, 2, l.Len(), "length")
 
 	// Test Values() method (which uses ForEach internally)
-	values := l.Values()
-	if len(values) != 2 {
-		t.Errorf("Values() returned %d items, expected 2", len(values))
-		t.Logf("Values: %v", values)
-	}
+	core.AssertEqual(t, 2, len(l.Values()), "Values count")
 
 	// Test ForEach directly
 	var items []int
@@ -30,30 +27,19 @@ func TestForEachBug(t *testing.T) {
 		items = append(items, v)
 		return true // Continue iteration
 	})
-
-	if len(items) != 2 {
-		t.Errorf("ForEach collected %d items, expected 2", len(items))
-		t.Logf("ForEach items: %v", items)
-	}
+	core.AssertEqual(t, 2, len(items), "ForEach count")
 
 	// Manual verification using underlying list
 	count := 0
-	sysList := l.Sys()
-	for e := sysList.Front(); e != nil; e = e.Next() {
+	for e := l.Sys().Front(); e != nil; e = e.Next() {
 		count++
-		if v, ok := e.Value.(int); ok {
-			t.Logf("Manual iteration [%d]: %d", count-1, v)
-		}
 	}
-
-	if count != 2 {
-		t.Errorf("Manual iteration found %d items, expected 2", count)
-	}
+	core.AssertEqual(t, 2, count, "manual count")
 }
 
 func TestForEachEarlyTermination(t *testing.T) {
 	// Test that ForEach can be terminated early by returning false
-	l := New[int]()
+	l := list.New[int]()
 	for i := 1; i <= 5; i++ {
 		l.PushBack(i)
 	}
@@ -64,39 +50,25 @@ func TestForEachEarlyTermination(t *testing.T) {
 		return v < 3 // Stop after 3
 	})
 
-	if len(collected) != 3 {
-		t.Errorf("Expected to collect 3 items before stopping, got %d", len(collected))
-	}
-
-	if collected[len(collected)-1] != 3 {
-		t.Errorf("Expected last item to be 3, got %d", collected[len(collected)-1])
-	}
+	core.AssertMustEqual(t, 3, len(collected), "collected count")
+	core.AssertEqual(t, 3, collected[len(collected)-1], "last item")
 }
 
 func TestValuesMethod(t *testing.T) {
 	// Test that Values() returns all elements
-	l := New[string]()
-	expected := []string{"first", "second", "third"}
+	l := list.New[string]()
+	expected := core.S("first", "second", "third")
 
 	for _, v := range expected {
 		l.PushBack(v)
 	}
 
-	values := l.Values()
-	if len(values) != len(expected) {
-		t.Errorf("Values() returned %d items, expected %d", len(values), len(expected))
-	}
-
-	for i, v := range values {
-		if v != expected[i] {
-			t.Errorf("Values()[%d] = %q, expected %q", i, v, expected[i])
-		}
-	}
+	core.AssertSliceEqual(t, expected, l.Values(), "values")
 }
 
 func TestEmptyList(t *testing.T) {
 	// Test ForEach on empty list
-	l := New[int]()
+	l := list.New[int]()
 
 	count := 0
 	l.ForEach(func(_ int) bool {
@@ -104,14 +76,8 @@ func TestEmptyList(t *testing.T) {
 		return true
 	})
 
-	if count != 0 {
-		t.Errorf("ForEach on empty list called callback %d times, expected 0", count)
-	}
-
-	values := l.Values()
-	if len(values) != 0 {
-		t.Errorf("Values() on empty list returned %d items, expected 0", len(values))
-	}
+	core.AssertEqual(t, 0, count, "callback count")
+	core.AssertEqual(t, 0, len(l.Values()), "Values count")
 }
 
 type TestStruct struct {
@@ -119,34 +85,23 @@ type TestStruct struct {
 	ID   int
 }
 
-func makeTestList() (list *List[*TestStruct], first, second *TestStruct) {
-	list = New[*TestStruct]()
+func makeTestList() (out *list.List[*TestStruct], first, second *TestStruct) {
+	out = list.New[*TestStruct]()
 	first = &TestStruct{ID: 1, Name: "first"}
 	second = &TestStruct{ID: 2, Name: "second"}
-	list.PushBack(first)
-	list.PushBack(second)
-	return list, first, second
+	out.PushBack(first)
+	out.PushBack(second)
+	return out, first, second
 }
 
 func testPointerListLength(t *testing.T) {
 	l, _, _ := makeTestList()
-	if l.Len() != 2 {
-		t.Fatalf("Expected length 2, got %d", l.Len())
-	}
+	core.AssertMustEqual(t, 2, l.Len(), "length")
 }
 
 func testPointerListValues(t *testing.T) {
 	l, item1, item2 := makeTestList()
-	values := l.Values()
-	if len(values) != 2 {
-		t.Errorf("Values() returned %d items, expected 2", len(values))
-	}
-	if len(values) >= 1 && values[0] != item1 {
-		t.Errorf("First value mismatch: got %+v, expected %+v", values[0], item1)
-	}
-	if len(values) >= 2 && values[1] != item2 {
-		t.Errorf("Second value mismatch: got %+v, expected %+v", values[1], item2)
-	}
+	core.AssertSliceEqual(t, core.S(item1, item2), l.Values(), "values")
 }
 
 func testPointerListForEach(t *testing.T) {
@@ -154,19 +109,10 @@ func testPointerListForEach(t *testing.T) {
 	var items []*TestStruct
 	l.ForEach(func(v *TestStruct) bool {
 		items = append(items, v)
-		t.Logf("ForEach item: %+v", v)
 		return true
 	})
 
-	if len(items) != 2 {
-		t.Errorf("ForEach collected %d items, expected 2", len(items))
-	}
-	if len(items) >= 1 && items[0] != item1 {
-		t.Errorf("First item mismatch: got %+v, expected %+v", items[0], item1)
-	}
-	if len(items) >= 2 && items[1] != item2 {
-		t.Errorf("Second item mismatch: got %+v, expected %+v", items[1], item2)
-	}
+	core.AssertSliceEqual(t, core.S(item1, item2), items, "items")
 }
 
 func TestForEachWithPointers(t *testing.T) {

--- a/container/set/example_test.go
+++ b/container/set/example_test.go
@@ -17,8 +17,8 @@ func printS(s string)                   { _, _ = fmt.Print(s) }
 
 // User represents a user with ID and name
 type User struct {
-	ID   int
 	Name string
+	ID   int
 }
 
 func ExampleConfig_New() {

--- a/container/set/set.go
+++ b/container/set/set.go
@@ -21,8 +21,8 @@ var (
 // Set implements a simple set using generics.
 type Set[K, H comparable, T any] struct {
 	cfg     Config[K, H, T]
-	mu      sync.RWMutex
 	buckets map[H]*list.List[T]
+	mu      sync.RWMutex
 }
 
 func (set *Set[K, H, T]) init(cfg Config[K, H, T], items ...T) error {

--- a/container/set/set_foreach_test.go
+++ b/container/set/set_foreach_test.go
@@ -52,8 +52,8 @@ var _ core.TestCase = lenTestCase{}
 
 // lenTestCase verifies Set.Len across receiver states and bucket layouts.
 type lenTestCase struct {
-	name string
 	set  *set.Set[int, int, testItem]
+	name string
 	want int
 }
 

--- a/container/set/set_test.go
+++ b/container/set/set_test.go
@@ -92,8 +92,8 @@ var _ core.TestCase = containsTestCase{}
 
 // containsTestCase checks Set.Contains against a shared populated set.
 type containsTestCase struct {
-	name string
 	set  *set.Set[int, int, testItem]
+	name string
 	key  int
 	want bool
 }

--- a/container/set/testutils_test.go
+++ b/container/set/testutils_test.go
@@ -10,9 +10,9 @@ import (
 
 // testItem is the element type shared across the set tests.
 type testItem struct {
-	ID    int
 	Name  string
 	Value string
+	ID    int
 }
 
 // testConfig returns a valid Config keyed by ID with a modulo-10 hash, so

--- a/container/slices/example_test.go
+++ b/container/slices/example_test.go
@@ -110,8 +110,8 @@ func ExampleCustomSet_ForEach() {
 func ExampleNewCustomSet() {
 	// Custom type with comparison function
 	type Person struct {
-		ID   int
 		Name string
+		ID   int
 	}
 
 	// Compare by ID

--- a/container/slices/set_fn.go
+++ b/container/slices/set_fn.go
@@ -15,9 +15,9 @@ var _ Set[struct{}] = (*CustomSet[struct{}])(nil)
 // CustomSet is a generic thread-safe set implementation with custom element comparison.
 // It maintains a sorted slice of unique elements using a provided comparison function.
 type CustomSet[T any] struct {
-	mu  sync.RWMutex
-	s   []T
 	cmp func(T, T) int // comparison function: negative if a<b, zero if a==b, positive if a>b
+	s   []T
+	mu  sync.RWMutex
 }
 
 // New creates a new empty CustomSet with the same comparison function as the current set.

--- a/container/slices/set_fn.go
+++ b/container/slices/set_fn.go
@@ -55,8 +55,8 @@ func NewCustomSet[T any](cmp func(T, T) int, initial ...T) (*CustomSet[T], error
 
 // MustCustomSet creates a new CustomSet, panicking if initialization fails.
 // This is a convenience function for when error handling is not needed.
-func MustCustomSet[T any](cmd func(T, T) int, initial ...T) *CustomSet[T] {
-	return core.Must(NewCustomSet(cmd, initial...))
+func MustCustomSet[T any](cmp func(T, T) int, initial ...T) *CustomSet[T] {
+	return core.Must(NewCustomSet(cmp, initial...))
 }
 
 // InitCustomSet initializes a pre-allocated CustomSet with thread-safe semantics.

--- a/container/slices/set_fn_test.go
+++ b/container/slices/set_fn_test.go
@@ -148,6 +148,9 @@ func TestCustomSet_ForEach(t *testing.T) {
 		return count < 3
 	})
 	core.AssertEqual(t, 3, count, "early termination count")
+
+	// A nil callback is a no-op.
+	core.AssertNoPanic(t, func() { set.ForEach(nil) }, "nil callback")
 }
 
 func TestCustomSet_Reserve(t *testing.T) {
@@ -231,12 +234,86 @@ func TestCustomSet_Nil(t *testing.T) {
 	core.AssertEqual(t, 0, set.Add(1), "nil Add")
 	core.AssertEqual(t, 0, set.Remove(1), "nil Remove")
 	core.AssertEqual(t, 0, len(set.Export()), "nil Export")
+
+	core.AssertNil(t, set.New(), "nil New")
+	core.AssertNil(t, set.Clone(), "nil Clone")
+	core.AssertEqual(t, 0, len(set.Purge()), "nil Purge")
+	core.AssertFalse(t, set.Reserve(10), "nil Reserve")
+	core.AssertFalse(t, set.Grow(10), "nil Grow")
+	core.AssertFalse(t, set.Trim(), "nil Trim")
+
+	// Clear and ForEach are no-ops on a nil receiver.
+	core.AssertNoPanic(t, func() {
+		set.Clear()
+		set.ForEach(func(int) bool { return true })
+	}, "nil Clear/ForEach")
 }
 
 func TestMustCustomSet_Panic(t *testing.T) {
 	core.AssertPanic(t, func() {
 		_ = slices.MustCustomSet[int](nil)
 	}, core.ErrInvalid, "MustCustomSet(nil)")
+}
+
+func testInitNilReceiver(t *testing.T) {
+	var set *slices.CustomSet[int]
+	core.AssertErrorIs(t, slices.InitCustomSet(set, cmpInt), core.ErrNilReceiver, "nil receiver")
+}
+
+func testInitNilComparison(t *testing.T) {
+	var set slices.CustomSet[int]
+	core.AssertErrorIs(t, slices.InitCustomSet(&set, nil), core.ErrInvalid, "nil comparison")
+}
+
+func TestCustomSet_InitErrors(t *testing.T) {
+	t.Run("nil receiver", testInitNilReceiver)
+	t.Run("nil comparison", testInitNilComparison)
+}
+
+var _ core.TestCase = uninitialisedTestCase{}
+
+// uninitialisedTestCase checks that an operation on a zero-value CustomSet
+// (nil comparison, non-nil receiver) panics, covering the not-initialised
+// arms reached when NewCustomSet/InitCustomSet are bypassed.
+type uninitialisedTestCase struct {
+	op   func(*slices.CustomSet[int])
+	name string
+}
+
+func newUninitialisedTestCase(name string,
+	op func(*slices.CustomSet[int])) uninitialisedTestCase {
+	return uninitialisedTestCase{
+		op:   op,
+		name: name,
+	}
+}
+
+func (tc uninitialisedTestCase) Name() string {
+	return tc.name
+}
+
+func (tc uninitialisedTestCase) Test(t *testing.T) {
+	t.Helper()
+	var set slices.CustomSet[int]
+	core.AssertPanic(t, func() { tc.op(&set) }, nil, tc.name)
+}
+
+func uninitialisedTestCases() []uninitialisedTestCase {
+	return []uninitialisedTestCase{
+		newUninitialisedTestCase("New", func(s *slices.CustomSet[int]) { _ = s.New() }),
+		newUninitialisedTestCase("Clone", func(s *slices.CustomSet[int]) { _ = s.Clone() }),
+		newUninitialisedTestCase("Add", func(s *slices.CustomSet[int]) { s.Add(1) }),
+		newUninitialisedTestCase("Remove", func(s *slices.CustomSet[int]) { s.Remove(1) }),
+	}
+}
+
+func TestCustomSet_Uninitialised(t *testing.T) {
+	core.RunTestCases(t, uninitialisedTestCases())
+}
+
+func TestCustomSet_ContainsEmpty(t *testing.T) {
+	set := slices.MustCustomSet(cmpInt)
+	core.AssertFalse(t, set.Contains(1), "empty Contains")
 }
 
 func TestCustomSet_Complex(t *testing.T) {

--- a/container/slices/set_fn_test.go
+++ b/container/slices/set_fn_test.go
@@ -36,27 +36,51 @@ func TestCustomSet_InitCustomSet(t *testing.T) {
 	core.AssertError(t, slices.InitCustomSet(&set, cmpInt), "re-init")
 }
 
+var _ core.TestCase = customSetContainsTestCase{}
+
+// customSetContainsTestCase checks CustomSet.Contains against a shared set.
+type customSetContainsTestCase struct {
+	set   *slices.CustomSet[int]
+	name  string
+	value int
+	want  bool
+}
+
+func newCustomSetContainsTestCase(name string, s *slices.CustomSet[int],
+	value int, want bool) customSetContainsTestCase {
+	return customSetContainsTestCase{
+		set:   s,
+		name:  name,
+		value: value,
+		want:  want,
+	}
+}
+
+func (tc customSetContainsTestCase) Name() string {
+	return tc.name
+}
+
+func (tc customSetContainsTestCase) Test(t *testing.T) {
+	t.Helper()
+	core.AssertEqual(t, tc.want, tc.set.Contains(tc.value), "Contains(%d)", tc.value)
+}
+
+func customSetContainsTestCases() []customSetContainsTestCase {
+	s := slices.MustCustomSet(cmpInt, 1, 3, 5, 7, 9)
+	return []customSetContainsTestCase{
+		newCustomSetContainsTestCase("present 1", s, 1, true),
+		newCustomSetContainsTestCase("present 3", s, 3, true),
+		newCustomSetContainsTestCase("present 5", s, 5, true),
+		newCustomSetContainsTestCase("present 7", s, 7, true),
+		newCustomSetContainsTestCase("present 9", s, 9, true),
+		newCustomSetContainsTestCase("absent 2", s, 2, false),
+		newCustomSetContainsTestCase("absent 4", s, 4, false),
+		newCustomSetContainsTestCase("absent 10", s, 10, false),
+	}
+}
+
 func TestCustomSet_Contains(t *testing.T) {
-	set, err := slices.NewCustomSet(cmpInt, 1, 3, 5, 7, 9)
-	core.AssertMustNoError(t, err, "NewCustomSet")
-
-	tests := []struct {
-		value  int
-		expect bool
-	}{
-		{1, true},
-		{3, true},
-		{5, true},
-		{7, true},
-		{9, true},
-		{2, false},
-		{4, false},
-		{10, false},
-	}
-
-	for _, tc := range tests {
-		core.AssertEqual(t, tc.expect, set.Contains(tc.value), "Contains(%d)", tc.value)
-	}
+	core.RunTestCases(t, customSetContainsTestCases())
 }
 
 func TestCustomSet_Clone(t *testing.T) {

--- a/container/slices/set_fn_test.go
+++ b/container/slices/set_fn_test.go
@@ -1,7 +1,10 @@
-package slices
+package slices_test
 
 import (
 	"testing"
+
+	"darvaza.org/core"
+	"darvaza.org/x/container/slices"
 )
 
 func cmpInt(a, b int) int {
@@ -14,61 +17,28 @@ func cmpInt(a, b int) int {
 	return 0
 }
 
-// Assert helpers
-func assertNoError(t *testing.T, err error, msg string) {
-	t.Helper()
-	if err != nil {
-		t.Errorf("%s: unexpected error: %v", msg, err)
-	}
-}
-
-//revive:disable-next-line:flag-parameter
-func assertFalse(t *testing.T, v bool, msg string) {
-	t.Helper()
-	if v {
-		t.Errorf("%s: expected false, got true", msg)
-	}
-}
-
 func TestCustomSet_New(t *testing.T) {
-	set, err := NewCustomSet(cmpInt)
-	if err != nil {
-		t.Fatalf("NewCustomSet failed: %v", err)
-	}
+	set, err := slices.NewCustomSet(cmpInt)
+	core.AssertMustNoError(t, err, "NewCustomSet")
+
 	other := set.New()
-
-	if other == nil {
-		t.Fatal("New() returned nil")
-	}
-
-	// Verify it's empty
-	if other.Len() != 0 {
-		t.Errorf("New() created set with %d elements, expected 0", other.Len())
-	}
+	core.AssertMustNotNil(t, other, "New")
+	core.AssertEqual(t, 0, other.Len(), "len")
 }
 
 func TestCustomSet_InitCustomSet(t *testing.T) {
-	var set CustomSet[int]
+	var set slices.CustomSet[int]
 
-	if err := InitCustomSet(&set, cmpInt, 1, 2, 3); err != nil {
-		t.Fatalf("InitCustomSet failed: %v", err)
-	}
-
-	if set.Len() != 3 {
-		t.Errorf("InitCustomSet created set with %d elements, expected 3", set.Len())
-	}
+	core.AssertMustNoError(t, slices.InitCustomSet(&set, cmpInt, 1, 2, 3), "InitCustomSet")
+	core.AssertEqual(t, 3, set.Len(), "len")
 
 	// Test init on already initialized set
-	if err := InitCustomSet(&set, cmpInt); err == nil {
-		t.Error("InitCustomSet should fail on already initialized set")
-	}
+	core.AssertError(t, slices.InitCustomSet(&set, cmpInt), "re-init")
 }
 
 func TestCustomSet_Contains(t *testing.T) {
-	set, err := NewCustomSet(cmpInt, 1, 3, 5, 7, 9)
-	if err != nil {
-		t.Fatalf("NewCustomSet failed: %v", err)
-	}
+	set, err := slices.NewCustomSet(cmpInt, 1, 3, 5, 7, 9)
+	core.AssertMustNoError(t, err, "NewCustomSet")
 
 	tests := []struct {
 		value  int
@@ -85,104 +55,59 @@ func TestCustomSet_Contains(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		if got := set.Contains(tc.value); got != tc.expect {
-			t.Errorf("Contains(%d) = %v, expected %v", tc.value, got, tc.expect)
-		}
+		core.AssertEqual(t, tc.expect, set.Contains(tc.value), "Contains(%d)", tc.value)
 	}
 }
 
 func TestCustomSet_Clone(t *testing.T) {
-	original, err := NewCustomSet(cmpInt, 1, 2, 3)
-	if err != nil {
-		t.Fatalf("NewCustomSet failed: %v", err)
-	}
-	clone := original.Clone()
+	original, err := slices.NewCustomSet(cmpInt, 1, 2, 3)
+	core.AssertMustNoError(t, err, "NewCustomSet")
 
-	if clone == nil {
-		t.Fatal("Clone() returned nil")
-	}
+	clone := original.Clone()
+	core.AssertMustNotNil(t, clone, "Clone")
 
 	// Verify same elements
-	if clone.Len() != original.Len() {
-		t.Errorf("Clone has %d elements, original has %d", clone.Len(), original.Len())
-	}
-
+	core.AssertEqual(t, original.Len(), clone.Len(), "len")
 	for i := 0; i < original.Len(); i++ {
 		origVal, _ := original.GetByIndex(i)
-		cloneVal, _ := clone.(*CustomSet[int]).GetByIndex(i)
-		if origVal != cloneVal {
-			t.Errorf("Clone element %d: got %d, expected %d", i, cloneVal, origVal)
-		}
+		cloneVal, _ := clone.(*slices.CustomSet[int]).GetByIndex(i)
+		core.AssertEqual(t, origVal, cloneVal, "element %d", i)
 	}
 
 	// Verify independence
 	original.Add(4)
-	if clone.Contains(4) {
-		t.Error("Clone should not be affected by original modification")
-	}
+	core.AssertFalse(t, clone.Contains(4), "clone independence")
 }
 
 func TestCustomSet_Clear(t *testing.T) {
-	set, err := NewCustomSet(cmpInt, 1, 2, 3, 4, 5)
-	if err != nil {
-		t.Fatalf("NewCustomSet failed: %v", err)
-	}
-
-	if set.Len() != 5 {
-		t.Fatalf("Initial set has %d elements, expected 5", set.Len())
-	}
+	set, err := slices.NewCustomSet(cmpInt, 1, 2, 3, 4, 5)
+	core.AssertMustNoError(t, err, "NewCustomSet")
+	core.AssertMustEqual(t, 5, set.Len(), "initial len")
 
 	set.Clear()
-
-	if set.Len() != 0 {
-		t.Errorf("Clear() left %d elements, expected 0", set.Len())
-	}
+	core.AssertEqual(t, 0, set.Len(), "len after clear")
 
 	// Verify capacity remains
-	available, total := set.Cap()
-	if total == 0 {
-		t.Error("Clear() should preserve capacity")
-	}
-	_ = available // unused
+	_, total := set.Cap()
+	core.AssertNotEqual(t, 0, total, "capacity preserved")
 }
 
 func TestCustomSet_Purge(t *testing.T) {
-	set, err := NewCustomSet(cmpInt, 5, 3, 1, 4, 2)
-	if err != nil {
-		t.Fatalf("NewCustomSet failed: %v", err)
-	}
+	set, err := slices.NewCustomSet(cmpInt, 5, 3, 1, 4, 2)
+	core.AssertMustNoError(t, err, "NewCustomSet")
 
-	elements := set.Purge()
-
-	// Verify returned elements
-	if len(elements) != 5 {
-		t.Errorf("Purge() returned %d elements, expected 5", len(elements))
-	}
-
-	// Elements should be sorted
-	expected := []int{1, 2, 3, 4, 5}
-	for i, v := range elements {
-		if v != expected[i] {
-			t.Errorf("Purge() element %d: got %d, expected %d", i, v, expected[i])
-		}
-	}
+	// Returned elements should be sorted
+	core.AssertSliceEqual(t, core.S(1, 2, 3, 4, 5), set.Purge(), "purged")
 
 	// Verify set is empty with no capacity
-	if set.Len() != 0 {
-		t.Errorf("Purge() left %d elements, expected 0", set.Len())
-	}
-
+	core.AssertEqual(t, 0, set.Len(), "len after purge")
 	_, total := set.Cap()
-	if total != 0 {
-		t.Errorf("Purge() left capacity %d, expected 0", total)
-	}
+	core.AssertEqual(t, 0, total, "capacity after purge")
 }
 
 func TestCustomSet_ForEach(t *testing.T) {
-	set, err := NewCustomSet(cmpInt, 1, 2, 3, 4, 5)
-	if err != nil {
-		t.Fatalf("NewCustomSet failed: %v", err)
-	}
+	set, err := slices.NewCustomSet(cmpInt, 1, 2, 3, 4, 5)
+	core.AssertMustNoError(t, err, "NewCustomSet")
 
 	// Test full iteration
 	var sum int
@@ -190,10 +115,7 @@ func TestCustomSet_ForEach(t *testing.T) {
 		sum += v
 		return true
 	})
-
-	if sum != 15 {
-		t.Errorf("ForEach sum = %d, expected 15", sum)
-	}
+	core.AssertEqual(t, 15, sum, "sum")
 
 	// Test early termination
 	var count int
@@ -201,160 +123,96 @@ func TestCustomSet_ForEach(t *testing.T) {
 		count++
 		return count < 3
 	})
-
-	if count != 3 {
-		t.Errorf("ForEach early termination count = %d, expected 3", count)
-	}
+	core.AssertEqual(t, 3, count, "early termination count")
 }
 
 func TestCustomSet_Reserve(t *testing.T) {
-	set, err := NewCustomSet(cmpInt)
-	if err != nil {
-		t.Fatalf("NewCustomSet failed: %v", err)
-	}
+	set, err := slices.NewCustomSet(cmpInt)
+	core.AssertMustNoError(t, err, "NewCustomSet")
 
-	// Reserve capacity
-	if !set.Reserve(10) {
-		t.Error("Reserve(10) returned false")
-	}
+	core.AssertTrue(t, set.Reserve(10), "Reserve(10)")
 
 	available, _ := set.Cap()
-	if available < 10 {
-		t.Errorf("After Reserve(10), available capacity = %d, expected >= 10", available)
-	}
+	core.AssertTrue(t, available >= 10, "available capacity")
 
 	// Reserve less than current should return false
-	if set.Reserve(5) {
-		t.Error("Reserve(5) should return false when capacity is already >= 10")
-	}
+	core.AssertFalse(t, set.Reserve(5), "Reserve(5) when already >= 10")
 }
 
 func TestCustomSet_Grow(t *testing.T) {
-	set, err := NewCustomSet(cmpInt, 1, 2, 3)
-	if err != nil {
-		t.Fatalf("NewCustomSet failed: %v", err)
-	}
+	set, err := slices.NewCustomSet(cmpInt, 1, 2, 3)
+	core.AssertMustNoError(t, err, "NewCustomSet")
 
 	initialAvailable, _ := set.Cap()
 
-	// Grow capacity
-	if !set.Grow(5) {
-		t.Error("Grow(5) returned false")
-	}
+	core.AssertTrue(t, set.Grow(5), "Grow(5)")
 
 	newAvailable, _ := set.Cap()
-	if newAvailable < initialAvailable+5 {
-		t.Errorf("After Grow(5), available capacity increased by %d, expected >= 5",
-			newAvailable-initialAvailable)
-	}
+	core.AssertTrue(t, newAvailable >= initialAvailable+5, "available capacity")
 }
 
 func TestCustomSet_Trim(t *testing.T) {
-	set, err := NewCustomSet(cmpInt)
-	if err != nil {
-		t.Fatalf("NewCustomSet failed: %v", err)
-	}
+	set, err := slices.NewCustomSet(cmpInt)
+	core.AssertMustNoError(t, err, "NewCustomSet")
 
 	// Add elements and then grow capacity
 	set.Add(1, 2, 3)
 	set.Grow(20)
 
 	available, total := set.Cap()
-	if available <= 0 {
-		t.Fatalf("After Grow(20), available capacity = %d, expected > 0", available)
-	}
-	if total <= set.Len() {
-		t.Fatalf("After Grow(20), total capacity = %d, expected > %d", total, set.Len())
-	}
+	core.AssertMustTrue(t, available > 0, "available after grow")
+	core.AssertMustTrue(t, total > set.Len(), "total after grow")
 
 	// Trim excess capacity
-	if !set.Trim() {
-		t.Error("Trim() returned false")
-	}
+	core.AssertTrue(t, set.Trim(), "Trim()")
 
 	newAvailable, newTotal := set.Cap()
-	if newTotal != set.Len() {
-		t.Errorf("After Trim(), total capacity = %d, expected %d", newTotal, set.Len())
-	}
-	if newAvailable != 0 {
-		t.Errorf("After Trim(), available capacity = %d, expected 0", newAvailable)
-	}
+	core.AssertEqual(t, set.Len(), newTotal, "total after trim")
+	core.AssertEqual(t, 0, newAvailable, "available after trim")
 }
 
 func TestInitOrderedSet(t *testing.T) {
-	var set CustomSet[int]
+	var set slices.CustomSet[int]
 
-	if err := InitOrderedSet(&set, 3, 1, 4, 1, 5); err != nil {
-		t.Fatalf("InitOrderedSet failed: %v", err)
-	}
+	core.AssertMustNoError(t, slices.InitOrderedSet(&set, 3, 1, 4, 1, 5), "InitOrderedSet")
 
 	// Should have deduplicated and sorted
-	if set.Len() != 4 {
-		t.Errorf("InitOrderedSet created set with %d elements, expected 4", set.Len())
-	}
-
-	// Verify sorted order
-	expected := []int{1, 3, 4, 5}
-	for i, exp := range expected {
-		if v, _ := set.GetByIndex(i); v != exp {
-			t.Errorf("Element %d: got %d, expected %d", i, v, exp)
-		}
-	}
+	core.AssertSliceEqual(t, core.S(1, 3, 4, 5), set.Export(), "values")
 }
 
 func TestCustomSet_GetByIndex_Error(t *testing.T) {
-	set, err := NewCustomSet(cmpInt, 1, 2, 3)
-	assertNoError(t, err, "NewCustomSet")
+	set, err := slices.NewCustomSet(cmpInt, 1, 2, 3)
+	core.AssertMustNoError(t, err, "NewCustomSet")
 
 	// Test negative index
 	_, ok := set.GetByIndex(-1)
-	assertFalse(t, ok, "GetByIndex(-1) should return false")
+	core.AssertFalse(t, ok, "GetByIndex(-1)")
 
 	// Test out of bounds
 	_, ok = set.GetByIndex(3)
-	assertFalse(t, ok, "GetByIndex(3) with 3 elements should return false")
+	core.AssertFalse(t, ok, "GetByIndex(3) of 3 elements")
 }
 
 func TestCustomSet_Nil(t *testing.T) {
-	var set *CustomSet[int]
+	var set *slices.CustomSet[int]
 
 	// Test nil receiver methods
-	if set.Contains(1) {
-		t.Error("nil set Contains should return false")
-	}
-
-	if set.Len() != 0 {
-		t.Error("nil set Len should return 0")
-	}
+	core.AssertFalse(t, set.Contains(1), "nil Contains")
+	core.AssertEqual(t, 0, set.Len(), "nil Len")
 
 	available, total := set.Cap()
-	if available != 0 || total != 0 {
-		t.Error("nil set Cap should return 0, 0")
-	}
+	core.AssertEqual(t, 0, available, "nil Cap available")
+	core.AssertEqual(t, 0, total, "nil Cap total")
 
-	if set.Add(1) != 0 {
-		t.Error("nil set Add should return 0")
-	}
-
-	if set.Remove(1) != 0 {
-		t.Error("nil set Remove should return 0")
-	}
-
-	elements := set.Export()
-	if len(elements) != 0 {
-		t.Error("nil set Export should return empty slice")
-	}
+	core.AssertEqual(t, 0, set.Add(1), "nil Add")
+	core.AssertEqual(t, 0, set.Remove(1), "nil Remove")
+	core.AssertEqual(t, 0, len(set.Export()), "nil Export")
 }
 
 func TestMustCustomSet_Panic(t *testing.T) {
-	defer func() {
-		if r := recover(); r == nil {
-			t.Error("MustCustomSet should panic with nil comparison function")
-		}
-	}()
-
-	// This should panic
-	_ = MustCustomSet[int](nil)
+	core.AssertPanic(t, func() {
+		_ = slices.MustCustomSet[int](nil)
+	}, core.ErrInvalid, "MustCustomSet(nil)")
 }
 
 func TestCustomSet_Complex(t *testing.T) {
@@ -374,24 +232,18 @@ func TestCustomSet_Complex(t *testing.T) {
 		return 0
 	}
 
-	set, err := NewCustomSet(cmpPerson,
+	set, err := slices.NewCustomSet(cmpPerson,
 		Person{ID: 3, Name: "Charlie"},
 		Person{ID: 1, Name: "Alice"},
 		Person{ID: 2, Name: "Bob"},
 		Person{ID: 1, Name: "Alice Duplicate"},
 	)
-	if err != nil {
-		t.Fatalf("NewCustomSet failed: %v", err)
-	}
+	core.AssertMustNoError(t, err, "NewCustomSet")
 
 	// Should have 3 unique persons (by ID)
-	if set.Len() != 3 {
-		t.Errorf("Set has %d persons, expected 3", set.Len())
-	}
+	core.AssertEqual(t, 3, set.Len(), "len")
 
 	// Should be sorted by ID
 	first, _ := set.GetByIndex(0)
-	if first.ID != 1 {
-		t.Errorf("First person ID = %d, expected 1", first.ID)
-	}
+	core.AssertEqual(t, 1, first.ID, "first ID")
 }

--- a/container/slices/set_fn_test.go
+++ b/container/slices/set_fn_test.go
@@ -360,8 +360,8 @@ func TestMustCustomSet_Panic(t *testing.T) {
 func TestCustomSet_Complex(t *testing.T) {
 	// Test with a custom type
 	type Person struct {
-		ID   int
 		Name string
+		ID   int
 	}
 
 	cmpPerson := func(a, b Person) int {

--- a/container/slices/set_ordered_test.go
+++ b/container/slices/set_ordered_test.go
@@ -1,45 +1,30 @@
-package slices
+package slices_test
 
 import (
-	"slices"
 	"testing"
+
+	"darvaza.org/core"
+	"darvaza.org/x/container/slices"
 )
 
 //revive:disable-next-line:cognitive-complexity
 func TestSet(t *testing.T) {
 	t.Run("empty", func(t *testing.T) {
 		var s []string
-		if got := NewOrderedSet(s...); got.Len() != 0 {
-			t.Errorf("Set() = %v, want empty slice", got)
-		}
+		core.AssertEqual(t, 0, slices.NewOrderedSet(s...).Len(), "len")
 	})
 
 	t.Run("no duplicates", func(t *testing.T) {
 		s := []string{"a", "b", "c"}
-		got := NewOrderedSet(s...)
-		want := []string{"a", "b", "c"}
-		if got.Len() != len(want) {
-			t.Errorf("Set() = %v, want %v", got, want)
-		}
-		for i := range want {
-			if v, ok := got.GetByIndex(i); !ok || v != want[i] {
-				t.Errorf("Set()[%d] = %v, want %v", i, v, want[i])
-			}
-		}
+		got := slices.NewOrderedSet(s...)
+		core.AssertSliceEqual(t, s, got.Export(), "values")
 	})
 
 	t.Run("with duplicates", func(t *testing.T) {
 		s := []string{"a", "b", "a", "c", "b", "c"}
-		got := NewOrderedSet(s...)
+		got := slices.NewOrderedSet(s...)
 		want := []string{"a", "b", "c"}
-		if got.Len() != len(want) {
-			t.Errorf("Set() = %v, want %v", got, want)
-		}
-		for i := range want {
-			if v, ok := got.GetByIndex(i); !ok || v != want[i] {
-				t.Errorf("Set()[%d] = %v, want %v", i, v, want[i])
-			}
-		}
+		core.AssertSliceEqual(t, want, got.Export(), "values")
 	})
 }
 
@@ -91,19 +76,13 @@ func TestSortedSet_Add(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			set := NewOrderedSet[int]()
+			set := slices.NewOrderedSet[int]()
 			if tt.initial != nil {
 				set.Add(tt.initial...)
 			}
 
-			count := set.Add(tt.add...)
-			if count != tt.expected {
-				t.Errorf("Add() returned %v, want %v", count, tt.expected)
-			}
-
-			if got := set.Export(); !slices.Equal(got, tt.result) {
-				t.Errorf("After Add() got %v, want %v", got, tt.result)
-			}
+			core.AssertEqual(t, tt.expected, set.Add(tt.add...), "Add count")
+			core.AssertSliceEqual(t, tt.result, set.Export(), "result")
 		})
 	}
 }
@@ -156,18 +135,11 @@ func TestSortedSet_Remove(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			set := NewOrderedSet[int]()
+			set := slices.NewOrderedSet[int]()
 			set.Add(tt.initial...)
 
-			count := set.Remove(tt.remove...)
-
-			if count != tt.count {
-				t.Errorf("Remove() count = %v, want %v", count, tt.count)
-			}
-
-			if got := set.Export(); !slices.Equal(got, tt.expected) {
-				t.Errorf("After Remove() got = %v, want %v", got, tt.expected)
-			}
+			core.AssertEqual(t, tt.count, set.Remove(tt.remove...), "Remove count")
+			core.AssertSliceEqual(t, tt.expected, set.Export(), "result")
 		})
 	}
 }
@@ -175,7 +147,7 @@ func TestSortedSet_Remove(t *testing.T) {
 //revive:disable-next-line:cognitive-complexity
 func TestSortedSet_TrimN(t *testing.T) {
 	tests := []struct {
-		set         *CustomSet[int]
+		set         *slices.CustomSet[int]
 		name        string
 		minCapacity int
 		want        bool
@@ -188,25 +160,25 @@ func TestSortedSet_TrimN(t *testing.T) {
 		},
 		{
 			name:        "empty set",
-			set:         NewOrderedSet[int](),
+			set:         slices.NewOrderedSet[int](),
 			minCapacity: 0,
 			want:        false,
 		},
 		{
 			name:        "set with elements above min capacity",
-			set:         NewOrderedSet(1, 2, 3, 4, 5),
+			set:         slices.NewOrderedSet(1, 2, 3, 4, 5),
 			minCapacity: 3,
 			want:        false,
 		},
 		{
 			name:        "set with elements below min capacity",
-			set:         NewOrderedSet(1, 2),
+			set:         slices.NewOrderedSet(1, 2),
 			minCapacity: 5,
 			want:        true,
 		},
 		{
 			name:        "negative min capacity",
-			set:         NewOrderedSet(1, 2, 3),
+			set:         slices.NewOrderedSet(1, 2, 3),
 			minCapacity: -1,
 			want:        false,
 		},
@@ -214,13 +186,10 @@ func TestSortedSet_TrimN(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := tt.set.TrimN(tt.minCapacity); got != tt.want {
-				t.Errorf("SortedSet.TrimN() = %v, want %v", got, tt.want)
-			}
+			core.AssertEqual(t, tt.want, tt.set.TrimN(tt.minCapacity), "TrimN")
 			if tt.set != nil {
-				if _, c := tt.set.Cap(); c < tt.minCapacity {
-					t.Errorf("SortedSet.Cap() = %v, want >= %v", c, tt.minCapacity)
-				}
+				_, c := tt.set.Cap()
+				core.AssertTrue(t, c >= tt.minCapacity, "capacity")
 			}
 		})
 	}

--- a/container/slices/set_ordered_test.go
+++ b/container/slices/set_ordered_test.go
@@ -7,190 +7,199 @@ import (
 	"darvaza.org/x/container/slices"
 )
 
-//revive:disable-next-line:cognitive-complexity
+var _ core.TestCase = orderedSetTestCase{}
+
+// orderedSetTestCase checks NewOrderedSet deduplication and ordering.
+type orderedSetTestCase struct {
+	name  string
+	input []string
+	want  []string
+}
+
+func newOrderedSetTestCase(name string, input, want []string) orderedSetTestCase {
+	return orderedSetTestCase{
+		input: input,
+		want:  want,
+		name:  name,
+	}
+}
+
+func (tc orderedSetTestCase) Name() string {
+	return tc.name
+}
+
+func (tc orderedSetTestCase) Test(t *testing.T) {
+	t.Helper()
+	got := slices.NewOrderedSet(tc.input...)
+	core.AssertSliceEqual(t, tc.want, got.Export(), "values")
+}
+
+func orderedSetTestCases() []orderedSetTestCase {
+	return []orderedSetTestCase{
+		newOrderedSetTestCase("empty", nil, core.S[string]()),
+		newOrderedSetTestCase("no duplicates",
+			core.S("a", "b", "c"), core.S("a", "b", "c")),
+		newOrderedSetTestCase("with duplicates",
+			core.S("a", "b", "a", "c", "b", "c"), core.S("a", "b", "c")),
+	}
+}
+
 func TestSet(t *testing.T) {
-	t.Run("empty", func(t *testing.T) {
-		var s []string
-		core.AssertEqual(t, 0, slices.NewOrderedSet(s...).Len(), "len")
-	})
-
-	t.Run("no duplicates", func(t *testing.T) {
-		s := []string{"a", "b", "c"}
-		got := slices.NewOrderedSet(s...)
-		core.AssertSliceEqual(t, s, got.Export(), "values")
-	})
-
-	t.Run("with duplicates", func(t *testing.T) {
-		s := []string{"a", "b", "a", "c", "b", "c"}
-		got := slices.NewOrderedSet(s...)
-		want := []string{"a", "b", "c"}
-		core.AssertSliceEqual(t, want, got.Export(), "values")
-	})
+	core.RunTestCases(t, orderedSetTestCases())
 }
 
-//revive:disable-next-line:cognitive-complexity
+var _ core.TestCase = sortedSetAddTestCase{}
+
+// sortedSetAddTestCase checks OrderedSet.Add count and resulting order.
+type sortedSetAddTestCase struct {
+	name    string
+	initial []int
+	add     []int
+	result  []int
+	want    int
+}
+
+func newSortedSetAddTestCase(name string, initial, add []int, want int,
+	result []int) sortedSetAddTestCase {
+	return sortedSetAddTestCase{
+		initial: initial,
+		add:     add,
+		result:  result,
+		name:    name,
+		want:    want,
+	}
+}
+
+func (tc sortedSetAddTestCase) Name() string {
+	return tc.name
+}
+
+func (tc sortedSetAddTestCase) Test(t *testing.T) {
+	t.Helper()
+	set := slices.NewOrderedSet[int]()
+	set.Add(tc.initial...)
+	core.AssertEqual(t, tc.want, set.Add(tc.add...), "Add count")
+	core.AssertSliceEqual(t, tc.result, set.Export(), "result")
+}
+
+func sortedSetAddTestCases() []sortedSetAddTestCase {
+	return []sortedSetAddTestCase{
+		newSortedSetAddTestCase("add to empty set",
+			nil, core.S(1, 2, 3), 3, core.S(1, 2, 3)),
+		newSortedSetAddTestCase("add with duplicates",
+			core.S(1, 2), core.S(2, 3, 3, 4), 2, core.S(1, 2, 3, 4)),
+		newSortedSetAddTestCase("add nothing",
+			core.S(1, 2, 3), core.S[int](), 0, core.S(1, 2, 3)),
+		newSortedSetAddTestCase("add to nil set",
+			nil, core.S(1, 2), 2, core.S(1, 2)),
+		newSortedSetAddTestCase("add unsorted values",
+			core.S(2, 4), core.S(5, 1, 3), 3, core.S(1, 2, 3, 4, 5)),
+	}
+}
+
 func TestSortedSet_Add(t *testing.T) {
-	tests := []struct {
-		name     string
-		initial  []int
-		add      []int
-		result   []int
-		expected int
-	}{
-		{
-			name:     "add to empty set",
-			initial:  nil,
-			add:      []int{1, 2, 3},
-			expected: 3,
-			result:   []int{1, 2, 3},
-		},
-		{
-			name:     "add with duplicates",
-			initial:  []int{1, 2},
-			add:      []int{2, 3, 3, 4},
-			expected: 2,
-			result:   []int{1, 2, 3, 4},
-		},
-		{
-			name:     "add nothing",
-			initial:  []int{1, 2, 3},
-			add:      []int{},
-			expected: 0,
-			result:   []int{1, 2, 3},
-		},
-		{
-			name:     "add to nil set",
-			initial:  nil,
-			add:      []int{1, 2},
-			expected: 2,
-			result:   []int{1, 2},
-		},
-		{
-			name:     "add unsorted values",
-			initial:  []int{2, 4},
-			add:      []int{5, 1, 3},
-			expected: 3,
-			result:   []int{1, 2, 3, 4, 5},
-		},
-	}
+	core.RunTestCases(t, sortedSetAddTestCases())
+}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			set := slices.NewOrderedSet[int]()
-			if tt.initial != nil {
-				set.Add(tt.initial...)
-			}
+var _ core.TestCase = sortedSetRemoveTestCase{}
 
-			core.AssertEqual(t, tt.expected, set.Add(tt.add...), "Add count")
-			core.AssertSliceEqual(t, tt.result, set.Export(), "result")
-		})
+// sortedSetRemoveTestCase checks OrderedSet.Remove count and remaining order.
+type sortedSetRemoveTestCase struct {
+	name    string
+	initial []int
+	remove  []int
+	result  []int
+	want    int
+}
+
+func newSortedSetRemoveTestCase(name string, initial, remove []int, want int,
+	result []int) sortedSetRemoveTestCase {
+	return sortedSetRemoveTestCase{
+		initial: initial,
+		remove:  remove,
+		result:  result,
+		name:    name,
+		want:    want,
 	}
 }
 
-//revive:disable-next-line:cognitive-complexity
+func (tc sortedSetRemoveTestCase) Name() string {
+	return tc.name
+}
+
+func (tc sortedSetRemoveTestCase) Test(t *testing.T) {
+	t.Helper()
+	set := slices.NewOrderedSet[int]()
+	set.Add(tc.initial...)
+	core.AssertEqual(t, tc.want, set.Remove(tc.remove...), "Remove count")
+	core.AssertSliceEqual(t, tc.result, set.Export(), "result")
+}
+
+func sortedSetRemoveTestCases() []sortedSetRemoveTestCase {
+	return []sortedSetRemoveTestCase{
+		newSortedSetRemoveTestCase("remove from empty",
+			core.S[int](), core.S(1, 2, 3), 0, core.S[int]()),
+		newSortedSetRemoveTestCase("remove non-existing",
+			core.S(1, 3, 5), core.S(2, 4), 0, core.S(1, 3, 5)),
+		newSortedSetRemoveTestCase("remove duplicates",
+			core.S(1, 2, 3, 4, 5), core.S(2, 2, 4, 4), 2, core.S(1, 3, 5)),
+		newSortedSetRemoveTestCase("remove all",
+			core.S(1, 2, 3), core.S(1, 2, 3), 3, core.S[int]()),
+		newSortedSetRemoveTestCase("remove partial",
+			core.S(1, 2, 3, 4, 5), core.S(2, 4), 2, core.S(1, 3, 5)),
+	}
+}
+
 func TestSortedSet_Remove(t *testing.T) {
-	tests := []struct {
-		name     string
-		initial  []int
-		remove   []int
-		expected []int
-		count    int
-	}{
-		{
-			name:     "remove_from_empty",
-			initial:  []int{},
-			remove:   []int{1, 2, 3},
-			expected: []int{},
-			count:    0,
-		},
-		{
-			name:     "remove_non_existing",
-			initial:  []int{1, 3, 5},
-			remove:   []int{2, 4},
-			expected: []int{1, 3, 5},
-			count:    0,
-		},
-		{
-			name:     "remove_duplicates",
-			initial:  []int{1, 2, 3, 4, 5},
-			remove:   []int{2, 2, 4, 4},
-			expected: []int{1, 3, 5},
-			count:    2,
-		},
-		{
-			name:     "remove_all",
-			initial:  []int{1, 2, 3},
-			remove:   []int{1, 2, 3},
-			expected: []int{},
-			count:    3,
-		},
-		{
-			name:     "remove_partial",
-			initial:  []int{1, 2, 3, 4, 5},
-			remove:   []int{2, 4},
-			expected: []int{1, 3, 5},
-			count:    2,
-		},
-	}
+	core.RunTestCases(t, sortedSetRemoveTestCases())
+}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			set := slices.NewOrderedSet[int]()
-			set.Add(tt.initial...)
+var _ core.TestCase = trimNTestCase{}
 
-			core.AssertEqual(t, tt.count, set.Remove(tt.remove...), "Remove count")
-			core.AssertSliceEqual(t, tt.expected, set.Export(), "result")
-		})
+// trimNTestCase checks OrderedSet.TrimN against a pre-built set fixture.
+type trimNTestCase struct {
+	set         *slices.CustomSet[int]
+	name        string
+	minCapacity int
+	want        bool
+}
+
+func newTrimNTestCase(name string, s *slices.CustomSet[int], minCapacity int,
+	want bool) trimNTestCase {
+	return trimNTestCase{
+		set:         s,
+		name:        name,
+		minCapacity: minCapacity,
+		want:        want,
 	}
 }
 
-//revive:disable-next-line:cognitive-complexity
-func TestSortedSet_TrimN(t *testing.T) {
-	tests := []struct {
-		set         *slices.CustomSet[int]
-		name        string
-		minCapacity int
-		want        bool
-	}{
-		{
-			name:        "nil set",
-			set:         nil,
-			minCapacity: 0,
-			want:        false,
-		},
-		{
-			name:        "empty set",
-			set:         slices.NewOrderedSet[int](),
-			minCapacity: 0,
-			want:        false,
-		},
-		{
-			name:        "set with elements above min capacity",
-			set:         slices.NewOrderedSet(1, 2, 3, 4, 5),
-			minCapacity: 3,
-			want:        false,
-		},
-		{
-			name:        "set with elements below min capacity",
-			set:         slices.NewOrderedSet(1, 2),
-			minCapacity: 5,
-			want:        true,
-		},
-		{
-			name:        "negative min capacity",
-			set:         slices.NewOrderedSet(1, 2, 3),
-			minCapacity: -1,
-			want:        false,
-		},
-	}
+func (tc trimNTestCase) Name() string {
+	return tc.name
+}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			core.AssertEqual(t, tt.want, tt.set.TrimN(tt.minCapacity), "TrimN")
-			if tt.set != nil {
-				_, c := tt.set.Cap()
-				core.AssertTrue(t, c >= tt.minCapacity, "capacity")
-			}
-		})
+func (tc trimNTestCase) Test(t *testing.T) {
+	t.Helper()
+	core.AssertEqual(t, tc.want, tc.set.TrimN(tc.minCapacity), "TrimN")
+	if tc.set != nil {
+		_, c := tc.set.Cap()
+		core.AssertTrue(t, c >= tc.minCapacity, "capacity")
 	}
+}
+
+func trimNTestCases() []trimNTestCase {
+	return []trimNTestCase{
+		newTrimNTestCase("nil set", nil, 0, false),
+		newTrimNTestCase("empty set", slices.NewOrderedSet[int](), 0, false),
+		newTrimNTestCase("set with elements above min capacity",
+			slices.NewOrderedSet(1, 2, 3, 4, 5), 3, false),
+		newTrimNTestCase("set with elements below min capacity",
+			slices.NewOrderedSet(1, 2), 5, true),
+		newTrimNTestCase("negative min capacity",
+			slices.NewOrderedSet(1, 2, 3), -1, false),
+	}
+}
+
+func TestSortedSet_TrimN(t *testing.T) {
+	core.RunTestCases(t, trimNTestCases())
 }

--- a/container/slices/set_ordered_test.go
+++ b/container/slices/set_ordered_test.go
@@ -147,6 +147,8 @@ func sortedSetRemoveTestCases() []sortedSetRemoveTestCase {
 			core.S(1, 2, 3), core.S(1, 2, 3), 3, core.S[int]()),
 		newSortedSetRemoveTestCase("remove partial",
 			core.S(1, 2, 3, 4, 5), core.S(2, 4), 2, core.S(1, 3, 5)),
+		newSortedSetRemoveTestCase("remove more than present",
+			core.S(1, 2, 3), core.S(1, 2, 3, 4), 3, core.S[int]()),
 	}
 }
 
@@ -187,10 +189,19 @@ func (tc trimNTestCase) Test(t *testing.T) {
 	}
 }
 
+// grownEmptySet returns an empty set carrying spare capacity, so that
+// trimming it to zero exercises the capacity == 0 branch of doTrim.
+func grownEmptySet() *slices.CustomSet[int] {
+	s := slices.NewOrderedSet[int]()
+	s.Grow(10)
+	return s
+}
+
 func trimNTestCases() []trimNTestCase {
 	return []trimNTestCase{
 		newTrimNTestCase("nil set", nil, 0, false),
 		newTrimNTestCase("empty set", slices.NewOrderedSet[int](), 0, false),
+		newTrimNTestCase("empty set with spare capacity", grownEmptySet(), 0, true),
 		newTrimNTestCase("set with elements above min capacity",
 			slices.NewOrderedSet(1, 2, 3, 4, 5), 3, false),
 		newTrimNTestCase("set with elements below min capacity",

--- a/container/slices/set_ordered_test.go
+++ b/container/slices/set_ordered_test.go
@@ -49,8 +49,8 @@ func TestSortedSet_Add(t *testing.T) {
 		name     string
 		initial  []int
 		add      []int
-		expected int
 		result   []int
+		expected int
 	}{
 		{
 			name:     "add to empty set",
@@ -175,8 +175,8 @@ func TestSortedSet_Remove(t *testing.T) {
 //revive:disable-next-line:cognitive-complexity
 func TestSortedSet_TrimN(t *testing.T) {
 	tests := []struct {
-		name        string
 		set         *CustomSet[int]
+		name        string
 		minCapacity int
 		want        bool
 	}{


### PR DESCRIPTION
## Summary

Hardens the `container` module's test suite and fixes a latent `Purge`
defect found while closing coverage gaps.

The headline change is **fix(container/list): scan every element in
Purge**. `List.Purge` removes elements whose stored value no longer
satisfies the type parameter `T`. Its iteration callback returned
`true`, which `core.ListForEachElement` treats as *stop*, so Purge
bailed out after the first element and left every later mismatched
value in place. This is live in the released `container/v0.4.1`; a
patch release is warranted once this lands.

The rest is test-quality work — no behavioural change beyond the fix
above and an internal struct reorder.

## Production changes

- **fix(container/list): scan every element in Purge** — return `false`
  from the iteration callback so Purge inspects the whole list. Covered
  by a regression row that injects a wrongly-typed element through
  `Sys()`, plus a nil-receiver row.
- **style(container/slices): fix MustCustomSet param typo cmd → cmp** —
  the comparison parameter was named `cmd`; renamed to `cmp` to match
  `NewCustomSet`. Positional, so no call-site impact.
- **refactor(container): order struct fields for alignment** — move the
  `sync.RWMutex` to the tail of `Set` and `CustomSet` to minimise
  padding. Layout only; no behavioural change.

## Test changes

- **Black-box migration** — `list` and `slices` tests move to
  `package <pkg>_test`, exercising the public surface and dropping the
  local `assertNoError`/`assertFalse` helpers in favour of
  `core.Assert*`.
- **TestCase interface** — the anonymous-struct tables in `slices`
  (Contains, NewOrderedSet, Add/Remove/TrimN) and the shared-shape
  scenario tables in `list` (FrontBack, DeleteMatchFn, PopFirstMatchFn,
  FirstMatchFn) convert to the TESTING.md pattern: named case types with
  field-aligned structs, semantic-order factories, compile-time
  interface assertions, and `RunTestCases`. Scenario tests whose rows
  differ in logic (e.g. `Copy`) stay as `t.Run`.
- **Coverage** — exercise the previously untested `CustomSet` error and
  boundary paths (zero-value panics, nil receivers, `InitCustomSet` nil
  errors, empty-set `Contains`, `doRemoveOne`/`doTrim` edges) and the
  `list` Purge type-mismatch and nil paths.

## Verification

`make tidy-container` (fieldalignment enforced), `make test-container`,
and `make coverage-container` all pass. Module coverage is 99.5%
(`set` 100%, `slices` 100%, `list` 97.6%); the remaining `list` gap is
two defensive nil-guards in unexported helpers, unreachable from the
public surface.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated `Purge()` to continue scanning the entire list and remove all elements that don’t match the expected value type.

* **Tests**
  * Refreshed list/set/slices test suites to use a consistent external, table-driven assertion style.
  * Expanded coverage for `Purge()` (no mismatches, multiple mismatches, and type-mismatch scenarios) and `nil` safety.
  * Strengthened `ForEach`/predicate-based behaviors and added/updated targeted set tests (including `CustomSet`/`OrderedSet`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->