### PR TITLE
Enable govet fieldalignment and order struct fields repo-wide

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,6 +24,9 @@ linters:
     - unparam
     - unused
   settings:
+    govet:
+      enable:
+        - fieldalignment
     revive:
       rules:
         - name: blank-imports

--- a/fs/fssyscall/file_test.go
+++ b/fs/fssyscall/file_test.go
@@ -11,10 +11,10 @@ import (
 var _ core.TestCase = fileLockTestCase{}
 
 type fileLockTestCase struct {
-	fn          func(*os.File) error
-	name        string
-	file        *os.File
 	expectedErr error
+	fn          func(*os.File) error
+	file        *os.File
+	name        string
 }
 
 func (tc fileLockTestCase) Name() string {

--- a/fs/fssyscall/syscall_test.go
+++ b/fs/fssyscall/syscall_test.go
@@ -45,9 +45,9 @@ func newHandleTestCase(name string, handle Handle, wantErr bool) handleTestCase 
 
 type openTestCase struct {
 	filename string
+	name     string
 	mode     int
 	perm     fs.FileMode
-	name     string
 	wantErr  bool
 }
 

--- a/fs/utils_test.go
+++ b/fs/utils_test.go
@@ -12,10 +12,10 @@ var _ core.TestCase = unsafeCutRootTestCase{}
 
 // joinRunes test cases
 type joinRunesTestCase struct {
+	name     string
 	before   []rune
 	after    []rune
 	expected []rune
-	name     string
 }
 
 func (tc joinRunesTestCase) Name() string {
@@ -60,8 +60,8 @@ type unsafeCutRootTestCase struct {
 	name     string
 	root     string
 	expected string
-	wantOK   bool
 	testName string
+	wantOK   bool
 }
 
 func (tc unsafeCutRootTestCase) Name() string {

--- a/net/bind/bind.go
+++ b/net/bind/bind.go
@@ -25,41 +25,40 @@ const (
 
 // Config is the configuration for Bind()
 type Config struct {
-	// Interface is the list of interfaces to listen on
-	Interfaces []string
-	// Addresses is the list of addresses to listen on
-	Addresses []string
-	// Port is the port to listen on, for both TCP and UDP
-	Port uint16
-	// PortStrict tells us not to try other ports
-	PortStrict bool
-	// PortAttempts indicates how many times we will try finding a port
-	PortAttempts int
-	// DefaultPort indicates the port to try on the first attempt if Port is zero
-	DefaultPort uint16
-
-	// ReusePort tells if we should set [SO_REUSEADDR] when using the default
-	// listeners.
-	ReusePort bool
-
 	// Context specifies the context to be used by the default listeners.
 	Context context.Context
-	// KeepAlive specifies the keep-alive period used by the default listeners.
-	KeepAlive time.Duration
-
-	// OnlyTCP tells Bind to skip listening UDP ports
-	OnlyTCP bool
-	// OnlyUDP tells Bind to skip listening TCP ports
-	OnlyUDP bool
 
 	// ListenTCP is the helper to use to listen on TCP ports
 	ListenTCP func(network string, laddr *net.TCPAddr) (*net.TCPListener, error)
 	// ListenUDP is the helper to use to listen on UDP ports
 	ListenUDP func(network string, laddr *net.UDPAddr) (*net.UDPConn, error)
 
+	// Interface is the list of interfaces to listen on
+	Interfaces []string
+	// Addresses is the list of addresses to listen on
+	Addresses []string
+
+	// KeepAlive specifies the keep-alive period used by the default listeners.
+	KeepAlive time.Duration
+	// PortAttempts indicates how many times we will try finding a port
+	PortAttempts int
 	// MaxRecvBufferSize is the buffer size we will attempt to set to
 	// UDP listeners
 	MaxRecvBufferSize int
+
+	// Port is the port to listen on, for both TCP and UDP
+	Port uint16
+	// DefaultPort indicates the port to try on the first attempt if Port is zero
+	DefaultPort uint16
+	// PortStrict tells us not to try other ports
+	PortStrict bool
+	// ReusePort tells if we should set [SO_REUSEADDR] when using the default
+	// listeners.
+	ReusePort bool
+	// OnlyTCP tells Bind to skip listening UDP ports
+	OnlyTCP bool
+	// OnlyUDP tells Bind to skip listening TCP ports
+	OnlyUDP bool
 }
 
 // SetDefaults attempts to fill any configuration gap, specially

--- a/net/bind/listen.go
+++ b/net/bind/listen.go
@@ -19,10 +19,10 @@ var (
 // ListenConfig extends the standard net.ListenConfig with a central holder
 // for the Context bound to the listeners
 type ListenConfig struct {
-	net.ListenConfig
-
 	// Context used when registering the listeners
 	Context context.Context
+
+	net.ListenConfig
 }
 
 // NewListenConfig assists creating a ListenConfig due to the two-layer definition

--- a/net/bind/upgrader.go
+++ b/net/bind/upgrader.go
@@ -25,8 +25,8 @@ type Upgrader interface {
 // UpgraderListenConfig represents an object equivalent to a ListenConfig but
 // using a Upgrader in the middle
 type UpgraderListenConfig struct {
-	conf ListenConfig
 	upg  Upgrader
+	conf ListenConfig
 }
 
 // WithUpgrader creates a new ListenConfig using the provided Upgrader

--- a/net/reconnect/client.go
+++ b/net/reconnect/client.go
@@ -18,21 +18,12 @@ var (
 
 // Client is a reconnecting network client.
 type Client struct {
-	mu      sync.Mutex
-	wg      sync.WaitGroup
-	ctx     context.Context
-	cancel  context.CancelCauseFunc
-	started atomic.Bool
-	err     error
-
-	cfg     *Config
-	dialer  net.Dialer
-	network string
-	address string
-	logger  slog.Logger
-
-	readTimeout  time.Duration
-	writeTimeout time.Duration
+	ctx    context.Context
+	cancel context.CancelCauseFunc
+	err    error
+	conn   net.Conn
+	logger slog.Logger
+	cfg    *Config
 
 	waitReconnect func(context.Context) error
 	onConnect     func(context.Context, net.Conn) error
@@ -40,7 +31,17 @@ type Client struct {
 	onDisconnect  func(context.Context, net.Conn) error
 	onError       func(context.Context, net.Conn, error) error
 
-	conn net.Conn
+	dialer  net.Dialer
+	network string
+	address string
+
+	mu sync.Mutex
+	wg sync.WaitGroup
+
+	readTimeout  time.Duration
+	writeTimeout time.Duration
+
+	started atomic.Bool
 }
 
 // Config returns the [Config] object used when [Reload] is called.

--- a/net/reconnect/config.go
+++ b/net/reconnect/config.go
@@ -28,6 +28,28 @@ type Config struct {
 	Context context.Context
 	Logger  slog.Logger
 
+	// WaitReconnect is a helper used to wait between re-connection attempts.
+	WaitReconnect Waiter
+
+	// OnSocket is called, when defined, against the raw socket before attempting to
+	// connect
+	OnSocket func(context.Context, syscall.RawConn) error
+	// OnConnect is called, when defined, immediately after the connection is established
+	// but before the session is created.
+	OnConnect func(context.Context, net.Conn) error
+	// OnSession is expected to block until it's done.
+	OnSession func(context.Context) error
+	// OnDisconnect is called after closing the connection and can be used to
+	// prevent further connection retries.
+	OnDisconnect func(context.Context, net.Conn) error
+	// OnError is called after all errors and gives us the opportunity to
+	// decide how the error should be treated by the reconnection logic.
+	OnError func(context.Context, net.Conn, error) error
+
+	// immutable data
+	c   *Client
+	ctx context.Context
+
 	// Remote indicates the remote endpoint: TCP "host:port" or Unix socket path,
 	// e.g., "/path/to/socket" or "unix:/path".
 	Remote string
@@ -44,32 +66,9 @@ type Config struct {
 	// WriteTimeout is the default write deadline for the connection.
 	// Zero or negative disables the deadline.
 	WriteTimeout time.Duration `default:"2s"`
-
 	// ReconnectDelay specifies how long to wait between re-connections
 	// unless [WaitReconnect] is specified. Negative implies reconnecting is disabled.
 	ReconnectDelay time.Duration
-	// WaitReconnect is a helper used to wait between re-connection attempts.
-	WaitReconnect Waiter
-
-	// OnSocket is called, when defined, against the raw socket before attempting to
-	// connect
-	OnSocket func(context.Context, syscall.RawConn) error
-	// OnConnect is called, when defined, immediately after the connection is established
-	// but before the session is created.
-	OnConnect func(context.Context, net.Conn) error
-
-	// OnSession is expected to block until it's done.
-	OnSession func(context.Context) error
-	// OnDisconnect is called after closing the connection and can be used to
-	// prevent further connection retries.
-	OnDisconnect func(context.Context, net.Conn) error
-	// OnError is called after all errors and gives us the opportunity to
-	// decide how the error should be treated by the reconnection logic.
-	OnError func(context.Context, net.Conn, error) error
-
-	// immutable data
-	c   *Client
-	ctx context.Context
 }
 
 func (cfg *Config) unsafeBindClient(c *Client) {

--- a/net/reconnect/stream.go
+++ b/net/reconnect/stream.go
@@ -18,13 +18,9 @@ var (
 // StreamSession provides an asynchronous stream session
 // using message types for receiving and sending.
 type StreamSession[Input, Output any] struct {
-	wg  core.ErrGroup
 	in  chan Input
 	out chan Output
 
-	// QueueSize specifies how many [Output] type entries can be buffered
-	// for delivery before [StreamSession.Send] blocks.
-	QueueSize uint
 	// Conn specifies the underlying connection
 	Conn io.ReadWriteCloser
 	// Context is an optional [context.Context] to allow cascading cancellations.
@@ -55,6 +51,12 @@ type StreamSession[Input, Output any] struct {
 
 	// OnError is optionally called when an error occurs
 	OnError func(error)
+
+	wg core.ErrGroup
+
+	// QueueSize specifies how many [Output] type entries can be buffered
+	// for delivery before [StreamSession.Send] blocks.
+	QueueSize uint
 }
 
 func (s *StreamSession[Input, Output]) init() error {

--- a/net/reconnect/utils_test.go
+++ b/net/reconnect/utils_test.go
@@ -97,9 +97,9 @@ func TestParseRemote(t *testing.T) {
 // Test case for TimeoutToAbsoluteTime function
 type timeoutToAbsoluteTimeTestCase struct {
 	base     time.Time
-	duration time.Duration
 	expected time.Time
 	name     string
+	duration time.Duration
 }
 
 func newTimeoutToAbsoluteTimeTestCase(name string, base time.Time, duration time.Duration,

--- a/text/lexer/cursor_test.go
+++ b/text/lexer/cursor_test.go
@@ -57,9 +57,9 @@ func TestPeek(t *testing.T) {
 // consumeCase asserts the rune sequence produced by repeated
 // [lexer.Cursor.Consume] calls until the source is exhausted.
 type consumeCase struct {
-	want []rune
 	name string
 	src  string
+	want []rune
 }
 
 func (tc consumeCase) Name() string { return tc.name }

--- a/text/lexer/run_test.go
+++ b/text/lexer/run_test.go
@@ -57,8 +57,8 @@ func newChainCounter(deltas ...int) (c *runCounter, start lexer.StateFn[*runCoun
 }
 
 type chainCase struct {
-	deltas []int
 	name   string
+	deltas []int
 }
 
 func (tc chainCase) Name() string { return tc.name }

--- a/web/assets/assets.go
+++ b/web/assets/assets.go
@@ -39,9 +39,10 @@ type Asset interface {
 type AssetHandler struct {
 	Asset Asset
 
-	mu       sync.Mutex
 	ct       string
 	parsedCT qlist.QualityList
+
+	mu sync.Mutex
 }
 
 func (h *AssetHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {

--- a/web/assets/fs_embed.go
+++ b/web/assets/fs_embed.go
@@ -44,9 +44,10 @@ var (
 // embedFS is the data shared by all views of the given [embed.FS]
 type embedFS struct {
 	*embed.FS
-	sync.Mutex
 
 	files []*embedMeta
+
+	sync.Mutex
 }
 
 // unsafeAddFile registers a static file in the file system.
@@ -64,10 +65,10 @@ func (o *embedFS) unsafeAddFile(fi fs.FileInfo, name, path string) *embedMeta {
 // EmbedFS extends [embed.FS] for serving static assets.
 type EmbedFS struct {
 	base *embedFS
-	root string
 
 	files    map[string]*EmbedMeta
 	resolver func(*http.Request) (string, error)
+	root     string
 }
 
 func (o *EmbedFS) lock()   { o.base.Lock() }
@@ -376,9 +377,9 @@ func (o *EmbedFS) Middleware() func(http.Handler) http.Handler {
 
 // EmbedFile is a readable instance of an embedded static file.
 type EmbedFile struct {
-	mu     sync.Mutex
 	meta   *EmbedMeta
 	reader io.ReadSeeker
+	mu     sync.Mutex
 }
 
 func (fd *EmbedFile) getReader() (io.ReadSeeker, error) {
@@ -471,11 +472,12 @@ func (fd *EmbedFile) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 type embedMeta struct {
 	fs.FileInfo
 
-	mu   sync.Mutex
 	name string
 	path string
 	ct   string
 	tags []string
+
+	mu sync.Mutex
 }
 
 func (fm *embedMeta) Name() string { return fm.name }

--- a/web/assets/fs_wrap.go
+++ b/web/assets/fs_wrap.go
@@ -20,12 +20,12 @@ var (
 // WrapFS is an assets [FS] that tests multiple layers
 // and name variants.
 type WrapFS struct {
+	resolver func(*http.Request) (string, error)
+
 	layers []fs.FS
 	globs  [][]fs.Matcher
-	names  []func(string) []string
 	root   string
-
-	resolver func(*http.Request) (string, error)
+	names  []func(string) []string
 }
 
 func (o *WrapFS) forEachLayer(h func(fs.FS) bool) {

--- a/web/assets/fs_wrap_file.go
+++ b/web/assets/fs_wrap_file.go
@@ -19,13 +19,13 @@ var (
 )
 
 type wrapFSFile struct {
-	mu sync.Mutex
 	r  *bytes.Reader
-
-	h  AssetHandler
 	fs fs.FS
 	fi fs.FileInfo
 	fn string
+
+	h  AssetHandler
+	mu sync.Mutex
 }
 
 func (*WrapFS) newFileHandler(fSys fs.FS, fn string) (*wrapFSFile, bool) {

--- a/web/error.go
+++ b/web/error.go
@@ -26,8 +26,8 @@ type Error interface {
 // HTTPError extends [core.WrappedError] with HTTP Status Code
 type HTTPError struct {
 	Err  error
-	Code int
 	Hdr  http.Header
+	Code int
 }
 
 // HTTPStatus returns the HTTP status code associated with the Error

--- a/web/errors_gen_test.go
+++ b/web/errors_gen_test.go
@@ -20,8 +20,8 @@ var (
 
 // basicStatusTestCase tests NewStatus* functions that take no parameters
 type basicStatusTestCase struct {
-	name         string
 	factory      func() *HTTPError
+	name         string
 	expectedCode int
 }
 
@@ -50,9 +50,9 @@ func newBasicStatusTestCase(name string, factory func() *HTTPError,
 
 // wrapperStatusTestCase tests NewStatus* functions that wrap an error
 type wrapperStatusTestCase struct {
-	name         string
-	factory      func(error) *HTTPError
 	inputErr     error
+	factory      func(error) *HTTPError
+	name         string
 	expectedCode int
 }
 
@@ -85,11 +85,11 @@ func newWrapperStatusTestCase(name string, factory func(error) *HTTPError,
 
 // retryStatusTestCase tests NewStatus* functions with Retry-After header
 type retryStatusTestCase struct {
-	name           string
 	factory        func(time.Duration) *HTTPError
+	name           string
+	expectedHeader string
 	retryAfter     time.Duration
 	expectedCode   int
-	expectedHeader string
 }
 
 func (tc retryStatusTestCase) Name() string {

--- a/web/errors_test.go
+++ b/web/errors_test.go
@@ -26,10 +26,10 @@ var (
 // DNS label-length check — caller asked for 302, factory
 // wraps the failure as a 500.
 type redirectTestCase struct {
-	args    []any
 	name    string
 	dest    string
 	want    string
+	args    []any
 	wantErr bool
 }
 
@@ -132,10 +132,10 @@ func TestNewRedirect(t *testing.T) {
 // off to newRedirect with the right status code, and — via the
 // dirty-input row — that it actually routes through Clean.
 type redirectStatusTestCase struct {
+	factory func(string, ...any) *web.HTTPError
 	name    string
 	dest    string
 	want    string
-	factory func(string, ...any) *web.HTTPError
 	code    int
 	wantErr bool
 }

--- a/web/headers_test.go
+++ b/web/headers_test.go
@@ -23,8 +23,8 @@ var (
 type hasHeaderTestCase struct {
 	name    string
 	setKey  string
-	values  []string
 	queryAs string
+	values  []string
 	want    bool
 }
 
@@ -78,8 +78,8 @@ type setHeaderTestCase struct {
 	name     string
 	key      string
 	value    string
-	args     []any
 	expected string
+	args     []any
 }
 
 func (tc setHeaderTestCase) Name() string {
@@ -118,8 +118,8 @@ func TestSetHeader(t *testing.T) {
 
 type setCacheTestCase struct {
 	name     string
-	duration time.Duration
 	expected string
+	duration time.Duration
 }
 
 func (tc setCacheTestCase) Name() string {
@@ -168,8 +168,8 @@ func TestSetNoCache(t *testing.T) {
 // setRetryAfterTestCase tests SetRetryAfter function
 type setRetryAfterTestCase struct {
 	name           string
-	retryAfter     time.Duration
 	expectedHeader string
+	retryAfter     time.Duration
 }
 
 func (tc setRetryAfterTestCase) Name() string {

--- a/web/qlist/qlist.go
+++ b/web/qlist/qlist.go
@@ -245,7 +245,7 @@ func splitFields(s string) []string {
 		v = strings.TrimSpace(v)
 
 		// remove empty attributes
-		if len(partial) == 0 || len(v) > 0 {
+		if len(partial) == 0 || v != "" {
 			keep = true
 		}
 

--- a/web/qlist/qlist.go
+++ b/web/qlist/qlist.go
@@ -22,9 +22,9 @@ const (
 
 // QualityValue is a parsed item of a [QualityList]
 type QualityValue struct {
+	attrs   map[string]string
 	value   []string
 	quality float32
-	attrs   map[string]string
 }
 
 // IsZero tells if the QualityValue doesn't hold any information

--- a/web/resource/render_tmpl_test.go
+++ b/web/resource/render_tmpl_test.go
@@ -19,13 +19,13 @@ var _ TemplateRenderer[string] = (*testTemplateRenderer)(nil)
 var _ TemplateRendererWithCode[string] = (*testTemplateRendererWithCode)(nil)
 
 type renderTemplateTestCase struct {
+	data           any
 	expectedBody   string
 	templateString string
-	data           any
 	name           string
+	method         string
 	inputCode      int
 	expectedCode   int
-	method         string
 	expectError    bool
 	nilTemplate    bool
 }
@@ -38,7 +38,7 @@ func (tc renderTemplateTestCase) Test(t *testing.T) {
 	t.Helper()
 
 	rw := httptest.NewRecorder()
-	req := httptest.NewRequest(tc.method, "/", nil)
+	req := httptest.NewRequest(tc.method, "/", http.NoBody)
 
 	var tmpl *template.Template
 	if !tc.nilTemplate {
@@ -56,9 +56,14 @@ func (tc renderTemplateTestCase) Test(t *testing.T) {
 
 	core.AssertNoError(t, err, "RenderTemplate")
 	core.AssertEqual(t, tc.expectedCode, rw.Code, "status code")
+	core.AssertEqual(t, tc.expectedBody, rw.Body.String(), "response body")
 
-	if tc.method != consts.HEAD {
-		core.AssertEqual(t, tc.expectedBody, rw.Body.String(), "response body")
+	// The implementation writes only the status line for HEAD, so
+	// it emits no Content-Length; assert its absence. For the other
+	// methods Content-Length must match the body length.
+	if tc.method == consts.HEAD {
+		core.AssertEqual(t, "", rw.Header().Get(consts.ContentLength), "content length")
+	} else {
 		contentLength := rw.Header().Get(consts.ContentLength)
 		expectedLength := len(tc.expectedBody)
 		core.AssertEqual(t, fmt.Sprintf("%d", expectedLength), contentLength, "content length")
@@ -75,29 +80,35 @@ func newRenderTemplateTestCase(name, templateString string, data any, expectedBo
 		expectedBody:   expectedBody,
 		inputCode:      code,
 		expectedCode:   code,
-		method:         "GET",
+		method:         consts.GET,
 		expectError:    false,
 		nilTemplate:    false,
 	}
 }
 
-//revive:disable-next-line:argument-limit
-func newRenderTemplateTestCaseMethod(name, method, templateString string, data any,
-	expectedBody string, code int) renderTemplateTestCase {
+// newRenderTemplateTestCaseHead builds a HEAD-method case. HEAD
+// responses carry no body, so the template and data are immaterial
+// fixtures; only the status mapping matters, and RenderTemplate may
+// adjust it (e.g. 200 → 204), so inputCode and expectedCode are
+// supplied independently.
+func newRenderTemplateTestCaseHead(name string, inputCode,
+	expectedCode int) renderTemplateTestCase {
 	return renderTemplateTestCase{
 		name:           name,
-		templateString: templateString,
-		data:           data,
-		expectedBody:   expectedBody,
-		inputCode:      code,
-		expectedCode:   code,
-		method:         method,
+		templateString: "{{.}}",
+		data:           "head",
+		expectedBody:   "",
+		inputCode:      inputCode,
+		expectedCode:   expectedCode,
+		method:         consts.HEAD,
 		expectError:    false,
 		nilTemplate:    false,
 	}
 }
 
-func newRenderTemplateTestCaseError(name string, nilTemplate bool) renderTemplateTestCase {
+// newRenderTemplateTestCaseNilTemplate builds a GET case whose template
+// is nil, so RenderTemplate fails before any rendering.
+func newRenderTemplateTestCaseNilTemplate(name string) renderTemplateTestCase {
 	return renderTemplateTestCase{
 		name:           name,
 		templateString: "",
@@ -105,9 +116,27 @@ func newRenderTemplateTestCaseError(name string, nilTemplate bool) renderTemplat
 		expectedBody:   "",
 		inputCode:      http.StatusOK,
 		expectedCode:   http.StatusOK,
-		method:         "GET",
+		method:         consts.GET,
 		expectError:    true,
-		nilTemplate:    nilTemplate,
+		nilTemplate:    true,
+	}
+}
+
+// newRenderTemplateTestCaseExecError builds a GET case whose template
+// parses but fails during execution, so the error surfaces through
+// RenderTemplate rather than from a nil template.
+func newRenderTemplateTestCaseExecError(name, templateString string,
+	data any) renderTemplateTestCase {
+	return renderTemplateTestCase{
+		name:           name,
+		templateString: templateString,
+		data:           data,
+		expectedBody:   "",
+		inputCode:      http.StatusOK,
+		expectedCode:   http.StatusOK,
+		method:         consts.GET,
+		expectError:    true,
+		nilTemplate:    false,
 	}
 }
 
@@ -121,7 +150,7 @@ func newRenderTemplateTestCaseNormalization(name, templateString string, data an
 		expectedBody:   expectedBody,
 		inputCode:      inputCode,
 		expectedCode:   expectedCode,
-		method:         "GET",
+		method:         consts.GET,
 		expectError:    false,
 		nilTemplate:    false,
 	}
@@ -135,6 +164,10 @@ func renderTemplateTestCases() []renderTemplateTestCase {
 			"Data: test", http.StatusCreated),
 		newRenderTemplateTestCase("status accepted", "{{.}}", "accepted",
 			"accepted", http.StatusAccepted),
+		// GET keeps a non-2xx status and still renders the body — the
+		// mirror of "HEAD keeps not found", which suppresses it.
+		newRenderTemplateTestCase("status not found renders body", "{{.}}",
+			"missing", "missing", http.StatusNotFound),
 		newRenderTemplateTestCase("complex template",
 			"Name: {{.Name}}, Age: {{.Age}}", testData{Name: "John", Age: 25},
 			"Name: John, Age: 25", http.StatusOK),
@@ -142,76 +175,33 @@ func renderTemplateTestCases() []renderTemplateTestCase {
 			"{{.}}", "default", "default", 0, http.StatusOK),
 		newRenderTemplateTestCaseNormalization("negative status code becomes 500",
 			"{{.}}", "error", "error", -1, http.StatusInternalServerError),
-		newRenderTemplateTestCaseMethod("HEAD request", consts.HEAD,
-			"{{.}}", "head", "", http.StatusNoContent),
-		newRenderTemplateTestCaseMethod("HEAD with custom status", consts.HEAD,
-			"{{.}}", "head", "", http.StatusAccepted),
-		newRenderTemplateTestCaseError("nil template", true),
+		// HEAD adjusts a 200 to 204 and leaves every other status
+		// untouched, always with an empty body. Normalisation runs
+		// first, so a 0 reaches the adjustment as 200 and becomes 204,
+		// while a negative settles at 500 and is left alone.
+		newRenderTemplateTestCaseHead("HEAD adjusts 200 to 204",
+			http.StatusOK, http.StatusNoContent),
+		newRenderTemplateTestCaseHead("HEAD normalises 0 then adjusts to 204",
+			0, http.StatusNoContent),
+		newRenderTemplateTestCaseHead("HEAD negative becomes 500",
+			-1, http.StatusInternalServerError),
+		newRenderTemplateTestCaseHead("HEAD keeps 204",
+			http.StatusNoContent, http.StatusNoContent),
+		newRenderTemplateTestCaseHead("HEAD keeps created",
+			http.StatusCreated, http.StatusCreated),
+		newRenderTemplateTestCaseHead("HEAD keeps accepted",
+			http.StatusAccepted, http.StatusAccepted),
+		newRenderTemplateTestCaseHead("HEAD keeps not found",
+			http.StatusNotFound, http.StatusNotFound),
+		newRenderTemplateTestCaseNilTemplate("nil template"),
+		newRenderTemplateTestCaseExecError("template execution error",
+			"{{.NonExistentField}}", "simple string"),
 	}
 }
 
 // TestRenderTemplate tests the RenderTemplate function
 func TestRenderTemplate(t *testing.T) {
 	core.RunTestCases(t, renderTemplateTestCases())
-}
-
-// TestRenderTemplateStatusCodes tests various status code scenarios
-func TestRenderTemplateStatusCodes(t *testing.T) {
-	t.Run("status code normalization", runTestRenderTemplateStatusCodeNormalization)
-	t.Run("head method status adjustment", runTestRenderTemplateHeadStatusAdjustment)
-}
-
-func runTestRenderTemplateStatusCodeNormalization(t *testing.T) {
-	tmpl, err := template.New("test").Parse("{{.}}")
-	core.AssertMustNoError(t, err, "template parse")
-
-	testCases := []struct {
-		name         string
-		inputCode    int
-		expectedCode int
-	}{
-		{"zero becomes 200", 0, http.StatusOK},
-		{"negative becomes 500", -1, http.StatusInternalServerError},
-		{"positive unchanged", http.StatusCreated, http.StatusCreated},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			rw := httptest.NewRecorder()
-			req := httptest.NewRequest("GET", "/", nil)
-
-			err := RenderTemplate(rw, req, tc.inputCode, tmpl, "test")
-			core.AssertNoError(t, err, "RenderTemplate")
-			core.AssertEqual(t, tc.expectedCode, rw.Code, "status code")
-		})
-	}
-}
-
-func runTestRenderTemplateHeadStatusAdjustment(t *testing.T) {
-	tmpl, err := template.New("test").Parse("{{.}}")
-	core.AssertMustNoError(t, err, "template parse")
-
-	testCases := []struct {
-		name         string
-		inputCode    int
-		expectedCode int
-	}{
-		{"200 becomes 204", http.StatusOK, http.StatusNoContent},
-		{"201 unchanged", http.StatusCreated, http.StatusCreated},
-		{"404 unchanged", http.StatusNotFound, http.StatusNotFound},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			rw := httptest.NewRecorder()
-			req := httptest.NewRequest(consts.HEAD, "/", nil)
-
-			err := RenderTemplate(rw, req, tc.inputCode, tmpl, "test")
-			core.AssertNoError(t, err, "RenderTemplate")
-			core.AssertEqual(t, tc.expectedCode, rw.Code, "status code")
-			core.AssertEqual(t, "", rw.Body.String(), "empty body for HEAD")
-		})
-	}
 }
 
 // TestDoRenderTemplate tests the doRenderTemplate function directly
@@ -280,7 +270,7 @@ func runTestWithTemplateCreatesOption(t *testing.T) {
 
 	// Test the renderer works
 	rw := httptest.NewRecorder()
-	req := httptest.NewRequest("GET", "/", nil)
+	req := httptest.NewRequest("GET", "/", http.NoBody)
 	err = renderer(rw, req, http.StatusOK, "test")
 
 	core.AssertNoError(t, err, "renderer execution")
@@ -304,7 +294,7 @@ func runTestWithTemplateCustomMediaType(t *testing.T) {
 	core.AssertNotNil(t, renderer, "XML renderer registered")
 
 	rw := httptest.NewRecorder()
-	req := httptest.NewRequest("GET", "/", nil)
+	req := httptest.NewRequest("GET", "/", http.NoBody)
 	err = renderer(rw, req, http.StatusOK, "test")
 
 	core.AssertNoError(t, err, "XML renderer execution")
@@ -322,7 +312,7 @@ func runTestTemplateRenderer(t *testing.T) {
 	renderer := &testTemplateRenderer{data: "legacy template test"}
 
 	rw := httptest.NewRecorder()
-	req := httptest.NewRequest("GET", "/", nil)
+	req := httptest.NewRequest("GET", "/", http.NoBody)
 
 	err := renderer.RenderTemplate(rw, req, "test data")
 	core.AssertNoError(t, err, "legacy template renderer")
@@ -333,7 +323,7 @@ func runTestTemplateRendererWithCode(t *testing.T) {
 	renderer := &testTemplateRendererWithCode{data: "code-aware template test"}
 
 	rw := httptest.NewRecorder()
-	req := httptest.NewRequest("GET", "/", nil)
+	req := httptest.NewRequest("GET", "/", http.NoBody)
 
 	err := renderer.RenderTemplate(rw, req, http.StatusCreated, "test data")
 	core.AssertNoError(t, err, "code-aware template renderer")

--- a/web/respond/registry.go
+++ b/web/respond/registry.go
@@ -11,10 +11,10 @@ import (
 
 // A Registry is a collection of Renderers
 type Registry struct {
-	mu sync.Mutex
-	m  map[string]registryEntry
-
+	m        map[string]registryEntry
 	identity string
+
+	mu sync.Mutex
 }
 
 type registryEntry struct {

--- a/web/respond/renderer.go
+++ b/web/respond/renderer.go
@@ -17,8 +17,8 @@ var (
 )
 
 type renderer struct {
-	ct string
 	h  RenderFunc
+	ct string
 }
 
 func (r renderer) ContentType() string             { return r.ct }

--- a/web/respond/respond.go
+++ b/web/respond/respond.go
@@ -14,9 +14,9 @@ import (
 type Responder struct {
 	registry *Registry
 
+	identity  string
 	supported []string
 	ql        qlist.QualityList
-	identity  string
 }
 
 // Supports sets additional supported media types on the
@@ -46,8 +46,8 @@ type Response struct {
 	req  *http.Request
 	rw   http.ResponseWriter
 	hdrs http.Header
-	code int
 	h    Renderer
+	code int
 }
 
 // ContentType is the preferred Media Type for this Response


### PR DESCRIPTION
## Summary

Enables the `govet fieldalignment` analyser in `.golangci.yml` and brings
every struct in the repo into line with it, so `make tidy` now flags any
field order that leaves the GC scanning more pointer words — or carrying more
padding — than necessary.

The reorders are layout-only. Every affected composite literal is keyed, so
no field is moved across a positional call site: the API and runtime
behaviour are unchanged. Documented config fields keep their comments and
`default:` tags as they move.

## Changes

- **build(lint): enable govet fieldalignment** — turns on the analyser as a
  shared, repo-wide gate.
- **refactor(net) / refactor(web)** — align the production structs. Notable
  shrinks: `bind.Config` 128→112, `bind.ListenConfig` 72→24,
  `bind.UpgraderListenConfig` 88→40 (a cascade once `ListenConfig` moved),
  `reconnect.Config` 160→112, `reconnect.Client` 216→160,
  `reconnect.StreamSession` 232→192.
- **test(fs) / test(text/lexer)** and the test-table reorders folded into the
  net/web commits — align the table-driven test-case structs.
- **test(web/resource): modernise RenderTemplate tests and widen status
  coverage** — folds the anonymous-struct status-code loops into rows on the
  `renderTemplateTestCase` table, splits the error factory so `expectError`
  and `nilTemplate` no longer move together, drives the execution-error case
  through the public `RenderTemplate`, and adds the status cells the loops
  never reached (HEAD 0→204, HEAD −1→500, a GET 404 that still renders its
  body). The test now asserts the HEAD response body and confirms HEAD emits
  no `Content-Length`.

## Verification

All CI workflows green on the pushed branch — Build (which runs the new
fieldalignment gate repo-wide), Test, Race Detection, and Codecov.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Consolidated and reorganized template rendering tests using improved table-driven cases, including explicit handling for `HEAD` vs non-`HEAD` responses (body and `Content-Length` expectations), and reduced redundant test functions.
  * Updated test request creation to use `http.NoBody` where appropriate.

* **Chores**
  * Enabled the Go `govet` `fieldalignment` lint rule for additional consistency checks.
  * Reordered struct field layouts across the project (including some exported types) for consistent organization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->