### PR TITLE
fix(build): match cspell ignorePaths at any depth, ignore .srclight

### DIFF
--- a/internal/build/cspell.json
+++ b/internal/build/cspell.json
@@ -130,12 +130,13 @@
     "zeebo"
   ],
   "ignorePaths": [
-    "*.lock",
-    ".coverage",
-    ".git",
-    ".tmp",
-    "go.sum",
-    "node_modules",
-    "vendor"
+    "**/*.lock",
+    "**/.coverage",
+    "**/.git",
+    "**/.srclight",
+    "**/.tmp",
+    "**/go.sum",
+    "**/node_modules",
+    "**/vendor"
   ]
 }


### PR DESCRIPTION
## fix(build): match cspell ignorePaths at any depth, ignore `.srclight`

### Why

cspell resolves `ignorePaths` globs relative to the config file's
location, so the bare patterns in `internal/build/cspell.json` were
anchored to `internal/build/` and matched nowhere else. Spell-checking
runs as `cspell --config internal/build/cspell.json` over the whole
tree, so entries like `.tmp`, `go.sum`, `vendor` and `node_modules`
ignored only their `internal/build/` namesakes — the repo-root and
per-module copies were still scanned.

Confirmed directly: a planted misspelling under a repo-root `.tmp/`
file was flagged with the old patterns and ignored once prefixed.

### What changed

- `internal/build/cspell.json` — prefix every `ignorePaths` entry with
  `**/` so it matches at any depth. A bare `**/vendor` already excludes
  the directory's contents (gitignore-style), so no trailing `/**` is
  needed.
- Add `**/.srclight` — the on-disk home of the srclight semantic index
  — to the ignore set.

### Scope

Build-tooling only; no library or runtime code is touched. The change
is part of the shared darvaza.org build system and applies identically
across the sibling repos. `make check-spelling` stays green (281 files,
0 issues).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved file-ignore patterns to better match nested project files and directories, reducing unnecessary scanning of common generated and dependency-related files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->