### PR TITLE
tls/x509utils: fix latent defects and expand test coverage

### DIFF
--- a/tls/verify.go
+++ b/tls/verify.go
@@ -17,28 +17,18 @@ func Verify(cert *tls.Certificate, roots *x509.CertPool) error {
 
 	switch {
 	case cert == nil:
-		return &x509utils.ErrInvalidCert{
-			Reason: "none provided",
-		}
+		return x509utils.NewErrInvalidCert(nil, nil, "none provided")
 	case cert.Leaf == nil || len(cert.Certificate) == 0:
-		return &x509utils.ErrInvalidCert{
-			Reason: "missing leaf certificate",
-		}
+		return x509utils.NewErrInvalidCert(nil, nil, "missing leaf certificate")
 	case len(cert.Leaf.Raw) == 0,
 		cert.Leaf.NotAfter.Before(now),
 		cert.Leaf.NotBefore.After(now),
 		!bytes.Equal(cert.Leaf.Raw, cert.Certificate[0]):
-		return &x509utils.ErrInvalidCert{
-			Reason: "invalid leaf certificate",
-		}
+		return x509utils.NewErrInvalidCert(nil, nil, "invalid leaf certificate")
 	case cert.PrivateKey == nil:
-		return &x509utils.ErrInvalidCert{
-			Reason: "missing private key",
-		}
+		return x509utils.NewErrInvalidCert(nil, nil, "missing private key")
 	case !x509utils.ValidCertKeyPair(cert.Leaf, cert.PrivateKey):
-		return &x509utils.ErrInvalidCert{
-			Reason: "invalid private key",
-		}
+		return x509utils.NewErrInvalidCert(nil, nil, "invalid private key")
 	case roots != nil:
 		return doVerifyRoots(cert, roots, now)
 	default:

--- a/tls/verify_test.go
+++ b/tls/verify_test.go
@@ -1,0 +1,155 @@
+package tls_test
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"testing"
+	"time"
+
+	"darvaza.org/core"
+
+	"darvaza.org/x/tls"
+)
+
+var _ core.TestCase = verifyRejectTestCase{}
+
+// mkVerifyLeaf mints a self-signed certificate valid across the given window,
+// formed so it can act as its own trust root (CA plus server auth), and returns
+// it with the key that owns it.
+func mkVerifyLeaf(t *testing.T, notBefore, notAfter time.Time) (
+	*x509.Certificate, *ecdsa.PrivateKey) {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	core.AssertMustNoError(t, err, "key")
+
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "verify-test"},
+		NotBefore:             notBefore,
+		NotAfter:              notAfter,
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, key.Public(), key)
+	core.AssertMustNoError(t, err, "create")
+
+	cert, err := x509.ParseCertificate(der)
+	core.AssertMustNoError(t, err, "parse")
+	return cert, key
+}
+
+// mkValidCert returns a tls.Certificate whose leaf, chain and key all agree, so
+// Verify runs past the rejection arms into the structural checks.
+func mkValidCert(t *testing.T) *tls.Certificate {
+	t.Helper()
+
+	now := time.Now().UTC()
+	leaf, key := mkVerifyLeaf(t, now.Add(-time.Hour), now.Add(time.Hour))
+	return &tls.Certificate{
+		Certificate: [][]byte{leaf.Raw},
+		PrivateKey:  key,
+		Leaf:        leaf,
+	}
+}
+
+// verifyRejectTestCase feeds a tls.Certificate that Verify must reject, checking
+// the message and that it reports invalid input.
+type verifyRejectTestCase struct {
+	cert    *tls.Certificate
+	name    string
+	wantMsg string
+}
+
+func (tc verifyRejectTestCase) Name() string { return tc.name }
+
+func (tc verifyRejectTestCase) Test(t *testing.T) {
+	t.Helper()
+
+	err := tls.Verify(tc.cert, nil)
+	core.AssertMustError(t, err, "error")
+	core.AssertEqual(t, tc.wantMsg, err.Error(), "message")
+	core.AssertErrorIs(t, err, core.ErrInvalid, "invalid")
+	core.AssertTrue(t, tls.IsInvalid(err), "IsInvalid")
+}
+
+func newVerifyRejectTestCase(name string, cert *tls.Certificate,
+	wantMsg string) verifyRejectTestCase {
+	return verifyRejectTestCase{cert: cert, name: name, wantMsg: wantMsg}
+}
+
+func verifyRejectTestCases(t *testing.T) []verifyRejectTestCase {
+	t.Helper()
+
+	now := time.Now().UTC()
+	valid, _ := mkVerifyLeaf(t, now.Add(-time.Hour), now.Add(time.Hour))
+	expired, _ := mkVerifyLeaf(t, now.Add(-2*time.Hour), now.Add(-time.Hour))
+	future, _ := mkVerifyLeaf(t, now.Add(time.Hour), now.Add(2*time.Hour))
+
+	wrongKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	core.AssertMustNoError(t, err, "wrong key")
+
+	return core.S(
+		newVerifyRejectTestCase("nil certificate", nil,
+			"invalid certificate: none provided"),
+		// arm 2, both halves: a nil leaf, and a leaf with an empty chain.
+		newVerifyRejectTestCase("nil leaf",
+			&tls.Certificate{Certificate: [][]byte{{0x01}}},
+			"invalid certificate: missing leaf certificate"),
+		newVerifyRejectTestCase("empty chain",
+			&tls.Certificate{Leaf: valid},
+			"invalid certificate: missing leaf certificate"),
+		// arm 3, each guarded condition in turn.
+		newVerifyRejectTestCase("empty leaf DER",
+			&tls.Certificate{Leaf: &x509.Certificate{}, Certificate: [][]byte{{0x01}}},
+			"invalid certificate: invalid leaf certificate"),
+		newVerifyRejectTestCase("chain mismatch",
+			&tls.Certificate{Leaf: valid, Certificate: [][]byte{{0x01}}},
+			"invalid certificate: invalid leaf certificate"),
+		newVerifyRejectTestCase("expired leaf",
+			&tls.Certificate{Leaf: expired, Certificate: [][]byte{expired.Raw}},
+			"invalid certificate: invalid leaf certificate"),
+		newVerifyRejectTestCase("not yet valid leaf",
+			&tls.Certificate{Leaf: future, Certificate: [][]byte{future.Raw}},
+			"invalid certificate: invalid leaf certificate"),
+		// arm 4 and arm 5: the key is missing, then present but mismatched.
+		newVerifyRejectTestCase("missing private key",
+			&tls.Certificate{Leaf: valid, Certificate: [][]byte{valid.Raw}},
+			"invalid certificate: missing private key"),
+		newVerifyRejectTestCase("wrong private key",
+			&tls.Certificate{
+				Leaf: valid, Certificate: [][]byte{valid.Raw}, PrivateKey: wrongKey,
+			},
+			"invalid certificate: invalid private key"),
+	)
+}
+
+func TestVerify(t *testing.T) {
+	core.RunTestCases(t, verifyRejectTestCases(t))
+}
+
+// TestVerifyNoRoots covers the default arm: a well-formed certificate with no
+// roots passes the structural checks.
+func TestVerifyNoRoots(t *testing.T) {
+	err := tls.Verify(mkValidCert(t), nil)
+	core.AssertNoError(t, err, "verify")
+}
+
+// TestVerifyWithRoots covers the roots arm: the chain is validated against a
+// pool that trusts the self-signed leaf.
+func TestVerifyWithRoots(t *testing.T) {
+	cert := mkValidCert(t)
+
+	roots := x509.NewCertPool()
+	roots.AddCert(cert.Leaf)
+
+	err := tls.Verify(cert, roots)
+	core.AssertNoError(t, err, "verify")
+}

--- a/tls/x509utils/certpool/cert_set_test.go
+++ b/tls/x509utils/certpool/cert_set_test.go
@@ -1,0 +1,118 @@
+package certpool_test
+
+import (
+	"crypto"
+	"io"
+	"testing"
+
+	"darvaza.org/core"
+
+	"darvaza.org/x/tls/x509utils/certpool"
+)
+
+// badSigner satisfies x509utils.PrivateKey but its Public returns a value
+// without an Equal method, so GetByPrivateKey's non-PublicKey arm is reachable.
+type badSigner struct{}
+
+func (badSigner) Public() crypto.PublicKey { return struct{}{} }
+
+func (badSigner) Sign(io.Reader, []byte, crypto.SignerOpts) ([]byte, error) {
+	return nil, nil
+}
+
+func (badSigner) Equal(crypto.PrivateKey) bool { return false }
+
+// mkCertSet builds a CertSet holding two independently keyed leaves, returning
+// the set and both leaves so a lookup can be checked against a known member and
+// against a second, distinctly keyed one.
+func mkCertSet(t *testing.T) (cs *certpool.CertSet, one, two testCert) {
+	t.Helper()
+	one = mkTestLeaf(t, "set-one.example.com", nil)
+	two = mkTestLeaf(t, "set-two.example.com", nil)
+	cs = certpool.MustCertSet(one.cert, two.cert)
+	return cs, one, two
+}
+
+// TestCertSetGetByKey confirms GetByKey returns the certificate owning a public
+// key and rejects a nil, non-key or nil-receiver lookup.
+func TestCertSetGetByKey(t *testing.T) {
+	cs, one, two := mkCertSet(t)
+
+	got := cs.GetByKey(one.cert.PublicKey)
+	core.AssertMustEqual(t, 1, len(got), "one match")
+	core.AssertTrue(t, got[0].Equal(one.cert), "match is the owner")
+
+	other := cs.GetByKey(two.cert.PublicKey)
+	core.AssertMustEqual(t, 1, len(other), "one match")
+	core.AssertTrue(t, other[0].Equal(two.cert), "second key finds its own cert")
+
+	core.AssertNil(t, cs.GetByKey(nil), "nil key")
+	core.AssertNil(t, cs.GetByKey("not a key"), "non-key value")
+	core.AssertNil(t, (*certpool.CertSet)(nil).GetByKey(one.cert.PublicKey),
+		"nil receiver")
+}
+
+// TestCertSetGetByPrivateKey confirms GetByPrivateKey resolves a certificate
+// through its private key and rejects a nil, non-key, wrong-public-type or
+// nil-receiver lookup.
+func TestCertSetGetByPrivateKey(t *testing.T) {
+	cs, one, two := mkCertSet(t)
+
+	got := cs.GetByPrivateKey(one.key)
+	core.AssertMustEqual(t, 1, len(got), "one match")
+	core.AssertTrue(t, got[0].Equal(one.cert), "match is the owner")
+
+	other := cs.GetByPrivateKey(two.key)
+	core.AssertMustEqual(t, 1, len(other), "one match")
+	core.AssertTrue(t, other[0].Equal(two.cert), "second key finds its own cert")
+
+	core.AssertNil(t, cs.GetByPrivateKey(nil), "nil key")
+	core.AssertNil(t, cs.GetByPrivateKey("not a key"), "non-key value")
+	core.AssertNil(t, cs.GetByPrivateKey(badSigner{}), "public not a key")
+	core.AssertNil(t, (*certpool.CertSet)(nil).GetByPrivateKey(one.key),
+		"nil receiver")
+}
+
+// assertSetIndependent confirms mutating dup — a Copy or Clone of src — leaves
+// src untouched, proving the duplicate does not share storage with its source.
+// Equal length would pass even for a shared backing store; the mutation is the
+// load-bearing proof.
+func assertSetIndependent(t *testing.T, src, dup *certpool.CertSet, name string) {
+	t.Helper()
+	srcLen := src.Len()
+	extra := mkTestLeaf(t, name+"-extra.example.com", nil).cert
+	_, err := dup.Push(extra)
+	core.AssertMustNoError(t, err, "%s: push extra", name)
+	core.AssertEqual(t, srcLen+1, dup.Len(), "%s grew", name)
+	core.AssertEqual(t, srcLen, src.Len(), "%s source unchanged", name)
+}
+
+// TestCertSetCopyAndClone confirms Copy fills a destination (creating one when
+// absent), Clone duplicates, both produce a set independent of the source, and
+// both handle a nil receiver.
+func TestCertSetCopyAndClone(t *testing.T) {
+	cs, _, _ := mkCertSet(t)
+	before := cs.Len()
+
+	fresh := cs.Copy(nil, nil)
+	core.AssertMustNotNil(t, fresh, "copy into fresh")
+	core.AssertNotSame(t, cs, fresh, "copy is a distinct set")
+	core.AssertEqual(t, before, fresh.Len(), "copied all")
+	assertSetIndependent(t, cs, fresh, "copy")
+
+	clone := cs.Clone()
+	core.AssertMustNotNil(t, clone, "clone")
+	core.AssertNotSame(t, cs, clone, "clone is a distinct set")
+	core.AssertEqual(t, before, clone.Len(), "cloned all")
+	assertSetIndependent(t, cs, clone, "clone")
+
+	core.AssertNil(t, (*certpool.CertSet)(nil).Clone(), "nil clone")
+
+	created := (*certpool.CertSet)(nil).Copy(nil, nil)
+	core.AssertMustNotNil(t, created, "nil receiver, nil dst creates a set")
+	core.AssertEqual(t, 0, created.Len(), "created set is empty")
+
+	dst := certpool.MustCertSet()
+	same := (*certpool.CertSet)(nil).Copy(dst, nil)
+	core.AssertSame(t, dst, same, "nil receiver returns destination")
+}

--- a/tls/x509utils/certpool/certpool.go
+++ b/tls/x509utils/certpool/certpool.go
@@ -74,7 +74,7 @@ func (s *CertPool) IsCA() bool {
 	}
 
 	for _, ce := range s.entries {
-		if !ce.cert.IsCA {
+		if !ce.IsCA() {
 			return false
 		}
 	}

--- a/tls/x509utils/certpool/certpool.go
+++ b/tls/x509utils/certpool/certpool.go
@@ -68,6 +68,11 @@ func (s *CertPool) IsCA() bool {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
+	if len(s.entries) == 0 {
+		// an empty pool holds no CAs
+		return false
+	}
+
 	for _, ce := range s.entries {
 		if !ce.cert.IsCA {
 			return false

--- a/tls/x509utils/certpool/certpool_copy_test.go
+++ b/tls/x509utils/certpool/certpool_copy_test.go
@@ -1,0 +1,86 @@
+package certpool_test
+
+import (
+	"crypto/x509"
+	"testing"
+
+	"darvaza.org/core"
+
+	"darvaza.org/x/tls/x509utils/certpool"
+)
+
+// TestPoolCopyNilReceiver confirms Copy on a nil pool creates a destination
+// when none is given and returns the supplied one otherwise.
+func TestPoolCopyNilReceiver(t *testing.T) {
+	fresh := (*certpool.CertPool)(nil).Copy(nil, nil)
+	core.AssertMustNotNil(t, fresh, "created destination")
+	core.AssertEqual(t, 0, fresh.Count(), "empty")
+
+	dst := certpool.New()
+	got := (*certpool.CertPool)(nil).Copy(dst, nil)
+	core.AssertSame(t, dst, got, "returns supplied destination")
+}
+
+// TestPoolCopyToSelf confirms copying a pool onto itself is a no-op returning
+// the same pool.
+func TestPoolCopyToSelf(t *testing.T) {
+	pool, _ := mkPopulatedPool(t)
+	core.AssertSame(t, pool, pool.Copy(pool, nil), "self copy")
+}
+
+// TestPoolCopyClonesWhenNoDestination confirms Copy with no destination clones
+// every certificate into a fresh, independent pool.
+func TestPoolCopyClonesWhenNoDestination(t *testing.T) {
+	pool, certs := mkPopulatedPool(t)
+
+	clone := pool.Copy(nil, nil)
+	core.AssertMustNotNil(t, clone, "clone")
+	core.AssertEqual(t, len(certs), clone.Count(), "all copied")
+
+	extra := mkTestLeaf(t, "extra.example.com", nil).cert
+	core.AssertMustTrue(t, clone.AddCert(extra), "add to clone")
+	core.AssertEqual(t, len(certs), pool.Count(), "source unchanged")
+}
+
+// TestPoolCopyIntoDestinationSkipsKnown confirms Copy into a destination adds
+// only the certificates it lacks: a second copy adds nothing.
+func TestPoolCopyIntoDestinationSkipsKnown(t *testing.T) {
+	pool, certs := mkPopulatedPool(t)
+	dst := certpool.New()
+
+	pool.Copy(dst, nil)
+	core.AssertMustEqual(t, len(certs), dst.Count(), "all copied")
+
+	pool.Copy(dst, nil)
+	core.AssertEqual(t, len(certs), dst.Count(), "no duplicates")
+}
+
+// TestPoolCopyCondition confirms the condition filters which certificates are
+// copied: only CAs land in the destination.
+func TestPoolCopyCondition(t *testing.T) {
+	root := mkTestCA(t, "Copy Root", nil)
+	leaf := mkTestLeaf(t, "copy.example.com", &root)
+	pool := certpool.New()
+	core.AssertMustTrue(t, pool.AddCert(root.cert), "add root")
+	core.AssertMustTrue(t, pool.AddCert(leaf.cert), "add leaf")
+
+	caOnly := pool.Copy(nil, func(cert *x509.Certificate) bool {
+		return cert.IsCA
+	})
+	core.AssertEqual(t, 1, caOnly.Count(), "only the CA copied")
+	core.AssertTrue(t, caOnly.IsCA(), "destination holds only CAs")
+}
+
+// TestPoolClone confirms Clone duplicates a pool independently and returns nil
+// for a nil receiver.
+func TestPoolClone(t *testing.T) {
+	core.AssertNil(t, (*certpool.CertPool)(nil).Clone(), "nil receiver")
+
+	pool, certs := mkPopulatedPool(t)
+	clone := core.AssertMustTypeIs[*certpool.CertPool](t, pool.Clone(), "clone")
+	core.AssertEqual(t, len(certs), clone.Count(), "all cloned")
+
+	extra := mkTestLeaf(t, "clone-extra.example.com", nil).cert
+	core.AssertMustTrue(t, clone.AddCert(extra), "add to clone")
+	core.AssertEqual(t, len(certs), pool.Count(), "source unchanged")
+}

--- a/tls/x509utils/certpool/certpool_entry_internal_test.go
+++ b/tls/x509utils/certpool/certpool_entry_internal_test.go
@@ -1,0 +1,62 @@
+package certpool
+
+import (
+	"context"
+	"crypto/x509"
+	"testing"
+
+	"darvaza.org/core"
+)
+
+// TestCertPoolEntryEqual confirms certPoolEntry.Equal: identity and equal DER
+// match, a nil operand or receiver does not, and differing DER does not.
+func TestCertPoolEntryEqual(t *testing.T) {
+	a := &certPoolEntry{cert: &x509.Certificate{Raw: []byte{0x01}}}
+	sameDER := &certPoolEntry{cert: &x509.Certificate{Raw: []byte{0x01}}}
+	otherDER := &certPoolEntry{cert: &x509.Certificate{Raw: []byte{0x02}}}
+
+	core.AssertTrue(t, a.Equal(a), "identity")
+	core.AssertTrue(t, a.Equal(sameDER), "equal DER")
+	core.AssertFalse(t, a.Equal(otherDER), "different DER")
+	core.AssertFalse(t, a.Equal(nil), "nil operand")
+	core.AssertFalse(t, (*certPoolEntry)(nil).Equal(a), "nil receiver")
+}
+
+// TestCertPoolEntryIsCA confirms certPoolEntry.IsCA: only a valid entry over a
+// CA certificate is a CA; a leaf and an invalid entry are not.
+func TestCertPoolEntryIsCA(t *testing.T) {
+	ca := &certPoolEntry{cert: &x509.Certificate{Raw: []byte{0x01}, IsCA: true}}
+	leaf := &certPoolEntry{cert: &x509.Certificate{Raw: []byte{0x01}}}
+
+	core.AssertTrue(t, ca.IsCA(), "CA entry")
+	core.AssertFalse(t, leaf.IsCA(), "leaf entry")
+	core.AssertFalse(t, (&certPoolEntry{}).IsCA(), "invalid entry")
+}
+
+// TestBySubjectEmptyBucketRetained pins both arms of GetBySubjectHash's
+// `!ok || l.Len() == 0` guard. Deleting the sole holder of a subject empties
+// the bucket's list but keeps its map key, so the l.Len()==0 arm is reachable
+// and distinct from the !ok arm a never-indexed hash produces.
+func TestBySubjectEmptyBucketRetained(t *testing.T) {
+	cert := fullCert()
+	pool := New()
+	core.AssertMustTrue(t, pool.AddCert(cert), "add")
+
+	h, ok := HashSubject(cert)
+	core.AssertMustTrue(t, ok, "hash subject")
+
+	l, ok := pool.bySubject[h]
+	core.AssertMustTrue(t, ok, "bucket present")
+	core.AssertMustEqual(t, 1, l.Len(), "one entry")
+
+	core.AssertMustNoError(t, pool.DeleteCert(context.Background(), cert),
+		"delete")
+
+	l, ok = pool.bySubject[h]
+	core.AssertTrue(t, ok, "bucket key retained")
+	core.AssertEqual(t, 0, l.Len(), "bucket emptied")
+	core.AssertNil(t, pool.GetBySubjectHash(h), "empty bucket misses")
+
+	// a hash never indexed exercises the !ok arm.
+	core.AssertNil(t, pool.GetBySubjectHash(Hash{}), "absent key misses")
+}

--- a/tls/x509utils/certpool/certpool_helpers_test.go
+++ b/tls/x509utils/certpool/certpool_helpers_test.go
@@ -1,0 +1,52 @@
+package certpool_test
+
+import (
+	"bytes"
+	"crypto/x509"
+	"encoding/pem"
+	"net"
+	"testing"
+
+	"darvaza.org/core"
+
+	"darvaza.org/x/tls/x509utils/certpool"
+)
+
+// mkIPLeaf builds a self-signed leaf whose only SAN is an IP address, so it is
+// reachable through the IP name key rather than a DNS name.
+func mkIPLeaf(t *testing.T, ip string) testCert {
+	t.Helper()
+	parsed := net.ParseIP(ip)
+	core.AssertMustNotNil(t, parsed, "parse ip")
+
+	tmpl := baseTemplate(t, ip, nil)
+	tmpl.IPAddresses = []net.IP{parsed}
+	return signAndParse(t, tmpl, nil)
+}
+
+// mkPopulatedPool builds a pool holding a root CA and two leaves it signed,
+// returning the pool and the certificates it contains in insertion order.
+func mkPopulatedPool(t *testing.T) (*certpool.CertPool, []*x509.Certificate) {
+	t.Helper()
+	root := mkTestCA(t, "Pool Root", nil)
+	one := mkTestLeaf(t, "one.example.com", &root)
+	two := mkTestLeaf(t, "two.example.com", &root)
+
+	pool := certpool.New()
+	certs := core.S(root.cert, one.cert, two.cert)
+	for _, c := range certs {
+		core.AssertMustTrue(t, pool.AddCert(c), "add")
+	}
+	return pool, certs
+}
+
+// certPEM encodes certificates as concatenated PEM CERTIFICATE blocks.
+func certPEM(t *testing.T, certs ...*x509.Certificate) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	for _, c := range certs {
+		err := pem.Encode(&buf, &pem.Block{Type: "CERTIFICATE", Bytes: c.Raw})
+		core.AssertMustNoError(t, err, "encode pem")
+	}
+	return buf.Bytes()
+}

--- a/tls/x509utils/certpool/certpool_issuer_test.go
+++ b/tls/x509utils/certpool/certpool_issuer_test.go
@@ -154,8 +154,7 @@ func TestGetBySubjectHashSurvivesClone(t *testing.T) {
 	pool := certpool.New()
 	core.AssertMustTrue(t, pool.AddCert(sub.cert), "add sub")
 
-	clone, ok := pool.Clone().(*certpool.CertPool)
-	core.AssertMustTrue(t, ok, "clone is *CertPool")
+	clone := core.AssertMustTypeIs[*certpool.CertPool](t, pool.Clone(), "clone")
 
 	got := clone.GetByIssuer(leaf.cert)
 	core.AssertMustEqual(t, 1, len(got), "candidate found in clone")

--- a/tls/x509utils/certpool/certpool_pool_test.go
+++ b/tls/x509utils/certpool/certpool_pool_test.go
@@ -8,6 +8,16 @@ import (
 	"darvaza.org/x/tls/x509utils/certpool"
 )
 
+// TestIsZero confirms IsZero: a nil pool is never zero, a fresh pool is, and a
+// populated one is not.
+func TestIsZero(t *testing.T) {
+	core.AssertFalse(t, (*certpool.CertPool)(nil).IsZero(), "nil pool")
+	core.AssertTrue(t, certpool.New().IsZero(), "empty pool")
+
+	pool, _ := mkPopulatedPool(t)
+	core.AssertFalse(t, pool.IsZero(), "populated pool")
+}
+
 // TestIsCA confirms IsCA: neither a nil pool nor an empty one is a CA pool, a
 // pool of only CAs is, and a pool holding any leaf is not.
 func TestIsCA(t *testing.T) {
@@ -24,4 +34,16 @@ func TestIsCA(t *testing.T) {
 	leaf := mkTestLeaf(t, "leaf.example.com", &root)
 	core.AssertMustTrue(t, caPool.AddCert(leaf.cert), "add leaf")
 	core.AssertFalse(t, caPool.IsCA(), "one leaf breaks it")
+}
+
+// TestReset confirms Reset empties a populated pool and reports ErrNilReceiver
+// for a nil one.
+func TestReset(t *testing.T) {
+	core.AssertErrorIs(t, (*certpool.CertPool)(nil).Reset(),
+		core.ErrNilReceiver, "nil receiver")
+
+	pool, _ := mkPopulatedPool(t)
+	core.AssertMustNoError(t, pool.Reset(), "reset")
+	core.AssertEqual(t, 0, pool.Count(), "empty after reset")
+	core.AssertTrue(t, pool.IsZero(), "zero after reset")
 }

--- a/tls/x509utils/certpool/certpool_pool_test.go
+++ b/tls/x509utils/certpool/certpool_pool_test.go
@@ -1,0 +1,27 @@
+package certpool_test
+
+import (
+	"testing"
+
+	"darvaza.org/core"
+
+	"darvaza.org/x/tls/x509utils/certpool"
+)
+
+// TestIsCA confirms IsCA: neither a nil pool nor an empty one is a CA pool, a
+// pool of only CAs is, and a pool holding any leaf is not.
+func TestIsCA(t *testing.T) {
+	core.AssertFalse(t, (*certpool.CertPool)(nil).IsCA(), "nil pool")
+	core.AssertFalse(t, certpool.New().IsCA(), "empty pool")
+
+	root := mkTestCA(t, "CA Root", nil)
+	sub := mkTestCA(t, "CA Sub", &root)
+	caPool := certpool.New()
+	core.AssertMustTrue(t, caPool.AddCert(root.cert), "add root")
+	core.AssertMustTrue(t, caPool.AddCert(sub.cert), "add sub")
+	core.AssertTrue(t, caPool.IsCA(), "all CAs")
+
+	leaf := mkTestLeaf(t, "leaf.example.com", &root)
+	core.AssertMustTrue(t, caPool.AddCert(leaf.cert), "add leaf")
+	core.AssertFalse(t, caPool.IsCA(), "one leaf breaks it")
+}

--- a/tls/x509utils/certpool/certpool_reader_test.go
+++ b/tls/x509utils/certpool/certpool_reader_test.go
@@ -1,0 +1,195 @@
+package certpool_test
+
+import (
+	"context"
+	"crypto/x509"
+	"testing"
+
+	"darvaza.org/core"
+
+	"darvaza.org/x/tls/x509utils/certpool"
+)
+
+var _ core.TestCase = getTestCase{}
+
+// mkWildcardLeaf builds a self-signed leaf whose only SAN is a wildcard, so it
+// is reachable through the pattern index rather than an exact name.
+func mkWildcardLeaf(t *testing.T, wildcard string) testCert {
+	t.Helper()
+	tmpl := baseTemplate(t, wildcard, []string{wildcard})
+	return signAndParse(t, tmpl, nil)
+}
+
+// getTestCase exercises Get's name resolution against a shared pool: exact
+// names, wildcard suffixes and IP SANs resolve to their certificate; a bad
+// name and an absent name surface their errors.
+type getTestCase struct {
+	pool    *certpool.CertPool
+	want    *x509.Certificate
+	wantErr error
+	name    string
+	query   string
+}
+
+func (tc getTestCase) Name() string { return tc.name }
+
+func (tc getTestCase) Test(t *testing.T) {
+	t.Helper()
+	got, err := tc.pool.Get(context.Background(), tc.query)
+	if tc.wantErr != nil {
+		core.AssertErrorIs(t, err, tc.wantErr, "error")
+		core.AssertNil(t, got, "cert")
+		return
+	}
+	core.AssertMustNoError(t, err, "get")
+	core.AssertMustNotNil(t, got, "cert")
+	core.AssertTrue(t, got.Equal(tc.want), "cert")
+}
+
+func newGetTestCase(name string, pool *certpool.CertPool, query string,
+	want *x509.Certificate, wantErr error) getTestCase {
+	return getTestCase{
+		pool:    pool,
+		want:    want,
+		name:    name,
+		query:   query,
+		wantErr: wantErr,
+	}
+}
+
+func getTestCases(t *testing.T) []getTestCase {
+	t.Helper()
+
+	exact := mkTestLeaf(t, "exact.example.com", nil)
+	wild := mkWildcardLeaf(t, "*.wild.example.com")
+	ipLeaf := mkIPLeaf(t, "203.0.113.7")
+
+	pool := certpool.New()
+	core.AssertMustTrue(t, pool.AddCert(exact.cert), "add exact")
+	core.AssertMustTrue(t, pool.AddCert(wild.cert), "add wildcard")
+	core.AssertMustTrue(t, pool.AddCert(ipLeaf.cert), "add ip")
+
+	return core.S(
+		newGetTestCase("exact name", pool, "exact.example.com", exact.cert, nil),
+		newGetTestCase("wildcard suffix", pool, "host.wild.example.com",
+			wild.cert, nil),
+		newGetTestCase("ip address", pool, "203.0.113.7", ipLeaf.cert, nil),
+		newGetTestCase("absent name", pool, "absent.example.com", nil,
+			core.ErrNotExists),
+		newGetTestCase("bad name", pool, "", nil, core.ErrInvalid),
+	)
+}
+
+func TestGet(t *testing.T) {
+	core.RunTestCases(t, getTestCases(t))
+}
+
+// TestGetNilReceiver confirms a nil pool reports ErrNilReceiver rather than
+// panicking.
+func TestGetNilReceiver(t *testing.T) {
+	got, err := (*certpool.CertPool)(nil).Get(context.Background(), "x")
+	core.AssertErrorIs(t, err, core.ErrNilReceiver, "error")
+	core.AssertNil(t, got, "cert")
+}
+
+// TestGetCancelledContext confirms a cancelled context short-circuits the
+// lookup after the name check.
+func TestGetCancelledContext(t *testing.T) {
+	leaf := mkTestLeaf(t, "cancel.example.com", nil)
+	pool := certpool.New()
+	core.AssertMustTrue(t, pool.AddCert(leaf.cert), "add")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	got, err := pool.Get(ctx, "cancel.example.com")
+	core.AssertErrorIs(t, err, context.Canceled, "error")
+	core.AssertNil(t, got, "cert")
+}
+
+// TestExportCachesAndInvalidates confirms Export assembles an x509.CertPool,
+// caches it across calls, and rebuilds it after the pool changes.
+func TestExportCachesAndInvalidates(t *testing.T) {
+	leaf := mkTestLeaf(t, "export.example.com", nil)
+	pool := certpool.New()
+	core.AssertMustTrue(t, pool.AddCert(leaf.cert), "add")
+
+	first := pool.Export()
+	core.AssertMustNotNil(t, first, "export")
+	core.AssertSame(t, first, pool.Export(), "cached")
+
+	other := mkTestLeaf(t, "export2.example.com", nil)
+	core.AssertMustTrue(t, pool.AddCert(other.cert), "add second")
+	core.AssertNotSame(t, first, pool.Export(), "rebuilt after change")
+}
+
+// TestExportNilReceiver confirms a nil pool still yields a usable empty pool.
+func TestExportNilReceiver(t *testing.T) {
+	got := (*certpool.CertPool)(nil).Export()
+	core.AssertNotNil(t, got, "export")
+}
+
+// TestForEachVisitsAll confirms ForEach visits every certificate exactly once.
+func TestForEachVisitsAll(t *testing.T) {
+	pool, certs := mkPopulatedPool(t)
+
+	var visited int
+	pool.ForEach(context.Background(),
+		func(_ context.Context, _ *x509.Certificate) bool {
+			visited++
+			return true
+		})
+	core.AssertEqual(t, len(certs), visited, "visited all")
+}
+
+// TestForEachAborts confirms returning false stops the walk early.
+func TestForEachAborts(t *testing.T) {
+	pool, _ := mkPopulatedPool(t)
+
+	var visited int
+	pool.ForEach(context.Background(),
+		func(_ context.Context, _ *x509.Certificate) bool {
+			visited++
+			return false
+		})
+	core.AssertEqual(t, 1, visited, "stopped after first")
+}
+
+// TestForEachCancelledMidWalk confirms cancelling the context between
+// iterations stops the walk: the callback cancels on its first call and the
+// second iteration never runs.
+func TestForEachCancelledMidWalk(t *testing.T) {
+	pool, certs := mkPopulatedPool(t)
+	core.AssertMustTrue(t, len(certs) > 1, "need multiple certs")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var visited int
+	pool.ForEach(ctx, func(_ context.Context, _ *x509.Certificate) bool {
+		visited++
+		cancel()
+		return true
+	})
+	core.AssertEqual(t, 1, visited, "stopped after cancel")
+}
+
+// TestForEachNoOp confirms the guard arms: a nil receiver, a nil callback and a
+// pre-cancelled context each visit nothing.
+func TestForEachNoOp(t *testing.T) {
+	pool, _ := mkPopulatedPool(t)
+	ctx := context.Background()
+
+	(*certpool.CertPool)(nil).ForEach(ctx,
+		func(context.Context, *x509.Certificate) bool { return true })
+	pool.ForEach(ctx, nil)
+
+	cancelled, cancel := context.WithCancel(ctx)
+	cancel()
+	var visited int
+	pool.ForEach(cancelled, func(_ context.Context, _ *x509.Certificate) bool {
+		visited++
+		return true
+	})
+	core.AssertEqual(t, 0, visited, "cancelled visits nothing")
+}

--- a/tls/x509utils/certpool/certpool_writer.go
+++ b/tls/x509utils/certpool/certpool_writer.go
@@ -121,14 +121,10 @@ func (s *CertPool) unsafeDeleteCertEntry(ce *certPoolEntry) {
 
 	delete(s.entries, cert)
 
-	eq := func(p *certPoolEntry) bool {
-		return ce == p
-	}
-
-	deleteMapListMatchFn(s.names, ce.names, eq)
-	deleteMapListMatchFn(s.patterns, ce.patterns, eq)
+	deleteMapListMatchFn(s.names, ce.names, ce.Equal)
+	deleteMapListMatchFn(s.patterns, ce.patterns, ce.Equal)
 	if h, ok := HashSubject(ce.cert); ok {
-		deleteMapListMatchFn(s.bySubject, []Hash{h}, eq)
+		deleteMapListMatchFn(s.bySubject, []Hash{h}, ce.Equal)
 	}
 }
 

--- a/tls/x509utils/certpool/certpool_writer_test.go
+++ b/tls/x509utils/certpool/certpool_writer_test.go
@@ -1,0 +1,345 @@
+package certpool_test
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/pem"
+	"testing"
+
+	"darvaza.org/core"
+
+	"darvaza.org/x/tls/x509utils/certpool"
+)
+
+var (
+	_ core.TestCase = deleteCertErrorTestCase{}
+	_ core.TestCase = deleteErrorTestCase{}
+	_ core.TestCase = putErrorTestCase{}
+)
+
+// keyPEM marshals a leaf's private key as a PKCS8 "PRIVATE KEY" block, so
+// import paths can be handed a non-certificate block to ignore.
+func keyPEM(t *testing.T, tc testCert) []byte {
+	t.Helper()
+	der, err := x509.MarshalPKCS8PrivateKey(tc.key)
+	core.AssertMustNoError(t, err, "marshal key")
+	return pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})
+}
+
+// TestPutStoresAndAliases confirms Put stores a certificate under a sanitised
+// name and that a second Put adds a further alias reachable by Get.
+func TestPutStoresAndAliases(t *testing.T) {
+	leaf := mkTestLeaf(t, "put.example.com", nil)
+	pool := certpool.New()
+	ctx := context.Background()
+
+	core.AssertMustNoError(t, pool.Put(ctx, "put.example.com", leaf.cert),
+		"put")
+	core.AssertMustNoError(t, pool.Put(ctx, "alias.example.com", leaf.cert),
+		"alias")
+
+	got, err := pool.Get(ctx, "alias.example.com")
+	core.AssertMustNoError(t, err, "get alias")
+	core.AssertMustNotNil(t, got, "cert")
+	core.AssertTrue(t, got.Equal(leaf.cert), "same cert by alias")
+}
+
+// TestPutDuplicateReportsExists confirms re-putting the same name for the same
+// certificate is a no-op reported as ErrExists.
+func TestPutDuplicateReportsExists(t *testing.T) {
+	leaf := mkTestLeaf(t, "dup.example.com", nil)
+	pool := certpool.New()
+	ctx := context.Background()
+
+	core.AssertMustNoError(t, pool.Put(ctx, "dup.example.com", leaf.cert),
+		"put")
+	err := pool.Put(ctx, "dup.example.com", leaf.cert)
+	core.AssertErrorIs(t, err, core.ErrExists, "duplicate")
+}
+
+// putErrorTestCase exercises Put's rejection arms: a bad name, an invalid
+// certificate, a nil receiver and a cancelled context each surface their error
+// without storing anything.
+type putErrorTestCase struct {
+	pool     *certpool.CertPool
+	cert     *x509.Certificate
+	wantErr  error
+	name     string
+	caseName string
+	cancel   bool
+}
+
+func (tc putErrorTestCase) Name() string { return tc.caseName }
+
+func (tc putErrorTestCase) Test(t *testing.T) {
+	t.Helper()
+	ctx := context.Background()
+	if tc.cancel {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithCancel(ctx)
+		cancel()
+	}
+	core.AssertErrorIs(t, tc.pool.Put(ctx, tc.name, tc.cert), tc.wantErr,
+		"error")
+}
+
+// revive:disable:argument-limit
+func newPutErrorTestCase(caseName string, pool *certpool.CertPool,
+	name string, cert *x509.Certificate, cancel bool,
+	wantErr error) putErrorTestCase {
+	// revive:enable:argument-limit
+	return putErrorTestCase{
+		pool:     pool,
+		cert:     cert,
+		name:     name,
+		caseName: caseName,
+		wantErr:  wantErr,
+		cancel:   cancel,
+	}
+}
+
+func putErrorTestCases(t *testing.T) []putErrorTestCase {
+	t.Helper()
+	cert := mkTestLeaf(t, "err.example.com", nil).cert
+	pool := certpool.New()
+
+	return core.S(
+		newPutErrorTestCase("bad name", pool, "", cert, false, core.ErrInvalid),
+		newPutErrorTestCase("invalid cert", pool, "ok.example.com", nil, false,
+			core.ErrInvalid),
+		newPutErrorTestCase("nil receiver", nil, "ok.example.com", cert, false,
+			core.ErrNilReceiver),
+		newPutErrorTestCase("cancelled", pool, "ok.example.com", cert, true,
+			context.Canceled),
+	)
+}
+
+func TestPutErrors(t *testing.T) {
+	core.RunTestCases(t, putErrorTestCases(t))
+}
+
+// TestDeleteRemovesByName confirms Delete removes every certificate held under
+// a name, after which Get misses.
+func TestDeleteRemovesByName(t *testing.T) {
+	leaf := mkTestLeaf(t, "del.example.com", nil)
+	pool := certpool.New()
+	ctx := context.Background()
+	core.AssertMustNoError(t, pool.Put(ctx, "del.example.com", leaf.cert),
+		"put")
+
+	core.AssertMustNoError(t, pool.Delete(ctx, "del.example.com"), "delete")
+
+	_, err := pool.Get(ctx, "del.example.com")
+	core.AssertErrorIs(t, err, core.ErrNotExists, "gone")
+}
+
+// deleteErrorTestCase exercises Delete's rejection arms: a bad name, a nil
+// receiver, a cancelled context and an absent (but valid) name.
+type deleteErrorTestCase struct {
+	pool     *certpool.CertPool
+	wantErr  error
+	name     string
+	caseName string
+	cancel   bool
+}
+
+func (tc deleteErrorTestCase) Name() string { return tc.caseName }
+
+func (tc deleteErrorTestCase) Test(t *testing.T) {
+	t.Helper()
+	ctx := context.Background()
+	if tc.cancel {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithCancel(ctx)
+		cancel()
+	}
+	core.AssertErrorIs(t, tc.pool.Delete(ctx, tc.name), tc.wantErr, "error")
+}
+
+func newDeleteErrorTestCase(caseName string, pool *certpool.CertPool,
+	name string, cancel bool, wantErr error) deleteErrorTestCase {
+	return deleteErrorTestCase{
+		pool:     pool,
+		name:     name,
+		caseName: caseName,
+		wantErr:  wantErr,
+		cancel:   cancel,
+	}
+}
+
+func deleteErrorTestCases(t *testing.T) []deleteErrorTestCase {
+	t.Helper()
+	pool := certpool.New()
+
+	return core.S(
+		newDeleteErrorTestCase("bad name", pool, "", false, core.ErrInvalid),
+		newDeleteErrorTestCase("nil receiver", nil, "ok.example.com", false,
+			core.ErrNilReceiver),
+		newDeleteErrorTestCase("cancelled", pool, "ok.example.com", true,
+			context.Canceled),
+		newDeleteErrorTestCase("absent name", pool, "absent.example.com", false,
+			core.ErrNotExists),
+	)
+}
+
+func TestDeleteErrors(t *testing.T) {
+	core.RunTestCases(t, deleteErrorTestCases(t))
+}
+
+// deleteCertErrorTestCase exercises DeleteCert's rejection arms: an invalid
+// certificate, a nil receiver, a cancelled context and an absent certificate.
+type deleteCertErrorTestCase struct {
+	pool     *certpool.CertPool
+	cert     *x509.Certificate
+	wantErr  error
+	caseName string
+	cancel   bool
+}
+
+func (tc deleteCertErrorTestCase) Name() string { return tc.caseName }
+
+func (tc deleteCertErrorTestCase) Test(t *testing.T) {
+	t.Helper()
+	ctx := context.Background()
+	if tc.cancel {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithCancel(ctx)
+		cancel()
+	}
+	core.AssertErrorIs(t, tc.pool.DeleteCert(ctx, tc.cert), tc.wantErr, "error")
+}
+
+func newDeleteCertErrorTestCase(caseName string, pool *certpool.CertPool,
+	cert *x509.Certificate, cancel bool, wantErr error) deleteCertErrorTestCase {
+	return deleteCertErrorTestCase{
+		pool:     pool,
+		cert:     cert,
+		caseName: caseName,
+		wantErr:  wantErr,
+		cancel:   cancel,
+	}
+}
+
+func deleteCertErrorTestCases(t *testing.T) []deleteCertErrorTestCase {
+	t.Helper()
+	pool, _ := mkPopulatedPool(t)
+	valid := mkTestLeaf(t, "valid.example.com", nil).cert
+	absent := mkTestLeaf(t, "absent.example.com", nil).cert
+
+	return core.S(
+		newDeleteCertErrorTestCase("invalid cert", pool, nil, false,
+			core.ErrInvalid),
+		newDeleteCertErrorTestCase("nil receiver", nil, valid, false,
+			core.ErrNilReceiver),
+		newDeleteCertErrorTestCase("cancelled", pool, valid, true,
+			context.Canceled),
+		newDeleteCertErrorTestCase("absent", pool, absent, false,
+			core.ErrNotExists),
+	)
+}
+
+func TestDeleteCertErrors(t *testing.T) {
+	core.RunTestCases(t, deleteCertErrorTestCases(t))
+}
+
+// TestAddCertGuards confirms AddCert rejects a nil receiver, an invalid
+// certificate and a duplicate, while accepting a fresh one.
+func TestAddCertGuards(t *testing.T) {
+	pool := certpool.New()
+	leaf := mkTestLeaf(t, "add.example.com", nil).cert
+
+	core.AssertFalse(t, (*certpool.CertPool)(nil).AddCert(leaf), "nil receiver")
+	core.AssertFalse(t, pool.AddCert(nil), "invalid cert")
+	core.AssertTrue(t, pool.AddCert(leaf), "fresh")
+	core.AssertFalse(t, pool.AddCert(leaf), "duplicate")
+}
+
+// TestImportGuards confirms Import's short-circuit arms: nil receiver,
+// cancelled context, nil source and self-import each add nothing.
+func TestImportGuards(t *testing.T) {
+	pool, _ := mkPopulatedPool(t)
+	ctx := context.Background()
+
+	n, err := (*certpool.CertPool)(nil).Import(ctx, pool)
+	core.AssertErrorIs(t, err, core.ErrNilReceiver, "nil receiver")
+	core.AssertEqual(t, 0, n, "count")
+
+	cancelled, cancel := context.WithCancel(ctx)
+	cancel()
+	n, err = pool.Import(cancelled, pool)
+	core.AssertErrorIs(t, err, context.Canceled, "cancelled")
+	core.AssertEqual(t, 0, n, "count")
+
+	n, err = pool.Import(ctx, nil)
+	core.AssertMustNoError(t, err, "nil source")
+	core.AssertEqual(t, 0, n, "count")
+
+	n, err = pool.Import(ctx, pool)
+	core.AssertMustNoError(t, err, "self import")
+	core.AssertEqual(t, 0, n, "count")
+}
+
+// TestImportCopiesFreshCerts confirms Import adds the source's certificates the
+// destination lacks and skips the ones it already holds.
+func TestImportCopiesFreshCerts(t *testing.T) {
+	src, certs := mkPopulatedPool(t)
+	dst := certpool.New()
+	ctx := context.Background()
+
+	n, err := dst.Import(ctx, src)
+	core.AssertMustNoError(t, err, "import")
+	core.AssertEqual(t, len(certs), n, "all fresh")
+
+	n, err = dst.Import(ctx, src)
+	core.AssertMustNoError(t, err, "re-import")
+	core.AssertEqual(t, 0, n, "none fresh")
+}
+
+// TestImportPEMGuards confirms ImportPEM's short-circuit arms: nil receiver,
+// cancelled context and empty input each add nothing.
+func TestImportPEMGuards(t *testing.T) {
+	pool := certpool.New()
+	ctx := context.Background()
+	leaf := mkTestLeaf(t, "pem.example.com", nil)
+
+	n, err := (*certpool.CertPool)(nil).ImportPEM(ctx, certPEM(t, leaf.cert))
+	core.AssertErrorIs(t, err, core.ErrNilReceiver, "nil receiver")
+	core.AssertEqual(t, 0, n, "count")
+
+	cancelled, cancel := context.WithCancel(ctx)
+	cancel()
+	n, err = pool.ImportPEM(cancelled, certPEM(t, leaf.cert))
+	core.AssertErrorIs(t, err, context.Canceled, "cancelled")
+	core.AssertEqual(t, 0, n, "count")
+
+	n, err = pool.ImportPEM(ctx, nil)
+	core.AssertMustNoError(t, err, "empty")
+	core.AssertEqual(t, 0, n, "count")
+}
+
+// TestImportPEMParsesAndIgnores confirms ImportPEM adds certificate blocks and
+// silently skips a non-certificate block (a private key).
+func TestImportPEMParsesAndIgnores(t *testing.T) {
+	one := mkTestLeaf(t, "one.pem.example.com", nil)
+	two := mkTestLeaf(t, "two.pem.example.com", nil)
+	blob := append(certPEM(t, one.cert, two.cert), keyPEM(t, one)...)
+
+	pool := certpool.New()
+	n, err := pool.ImportPEM(context.Background(), blob)
+	core.AssertMustNoError(t, err, "import pem")
+	core.AssertEqual(t, 2, n, "two certs, key ignored")
+}
+
+// TestImportPEMSurfacesParseError confirms a malformed certificate block
+// aborts the import with the decoder's error.
+func TestImportPEMSurfacesParseError(t *testing.T) {
+	blob := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: []byte("not a certificate"),
+	})
+
+	pool := certpool.New()
+	n, err := pool.ImportPEM(context.Background(), blob)
+	core.AssertError(t, err, "parse error")
+	core.AssertEqual(t, 0, n, "count")
+}

--- a/tls/x509utils/certpool/env_test.go
+++ b/tls/x509utils/certpool/env_test.go
@@ -1,0 +1,102 @@
+package certpool_test
+
+import (
+	"testing"
+
+	"darvaza.org/core"
+
+	"darvaza.org/x/tls/x509utils/certpool"
+)
+
+var _ core.TestCase = envFnTestCase{}
+
+// envFnTestCase exercises the argument and lookup guards of NewFromEnvFn: a
+// missing accessor or name is invalid; an undefined or empty variable does
+// not exist.
+type envFnTestCase struct {
+	getEnv  func(string) (string, bool)
+	wantErr error
+	name    string
+	varName string
+}
+
+func (tc envFnTestCase) Name() string { return tc.name }
+
+func (tc envFnTestCase) Test(t *testing.T) {
+	t.Helper()
+	_, err := certpool.NewFromEnvFn(tc.getEnv, tc.varName)
+	core.AssertErrorIs(t, err, tc.wantErr, "error")
+}
+
+func newEnvFnTestCase(name string, getEnv func(string) (string, bool),
+	varName string, wantErr error) envFnTestCase {
+	return envFnTestCase{
+		getEnv:  getEnv,
+		name:    name,
+		varName: varName,
+		wantErr: wantErr,
+	}
+}
+
+func envFnTestCases() []envFnTestCase {
+	absent := func(string) (string, bool) { return "", false }
+	empty := func(string) (string, bool) { return "", true }
+
+	return core.S(
+		newEnvFnTestCase("nil accessor", nil, "VAR", core.ErrInvalid),
+		newEnvFnTestCase("empty name", absent, "", core.ErrInvalid),
+		newEnvFnTestCase("undefined variable", absent, "VAR", core.ErrNotExists),
+		newEnvFnTestCase("empty value", empty, "VAR", core.ErrNotExists),
+	)
+}
+
+func TestNewFromEnvFnErrors(t *testing.T) {
+	core.RunTestCases(t, envFnTestCases())
+}
+
+// TestNewFromEnvFnSuccess confirms a PEM value resolved through the accessor
+// yields a populated pool.
+func TestNewFromEnvFnSuccess(t *testing.T) {
+	leaf := mkTestLeaf(t, "env.example.com", nil)
+	getEnv := func(string) (string, bool) {
+		return string(certPEM(t, leaf.cert)), true
+	}
+
+	pool, err := certpool.NewFromEnvFn(getEnv, "VAR")
+	core.AssertMustNoError(t, err, "from env fn")
+	core.AssertMustNotNil(t, pool, "pool")
+	core.AssertEqual(t, 1, pool.Count(), "one cert")
+}
+
+// TestNewFromEnv confirms NewFromEnv reads the process environment: a set
+// variable yields the pool, an empty one is treated as absent.
+func TestNewFromEnv(t *testing.T) {
+	leaf := mkTestLeaf(t, "process-env.example.com", nil)
+	t.Setenv("CERTPOOL_TEST_PEM", string(certPEM(t, leaf.cert)))
+
+	pool, err := certpool.NewFromEnv("CERTPOOL_TEST_PEM")
+	core.AssertMustNoError(t, err, "from env")
+	core.AssertEqual(t, 1, pool.Count(), "one cert")
+
+	// an empty value counts as absent; set it explicitly so the assertion
+	// does not depend on the ambient environment.
+	t.Setenv("CERTPOOL_TEST_EMPTY", "")
+	_, err = certpool.NewFromEnv("CERTPOOL_TEST_EMPTY")
+	core.AssertErrorIs(t, err, core.ErrNotExists, "empty variable")
+}
+
+// TestNewFromStrings confirms PEM content is parsed into a pool and that empty
+// input reports no certificates found.
+func TestNewFromStrings(t *testing.T) {
+	one := mkTestLeaf(t, "s-one.example.com", nil)
+	two := mkTestLeaf(t, "s-two.example.com", nil)
+
+	pool, err := certpool.NewFromStrings(string(certPEM(t, one.cert, two.cert)))
+	core.AssertMustNoError(t, err, "from strings")
+	core.AssertEqual(t, 2, pool.Count(), "two certs")
+
+	// PEM that parses cleanly but holds no certificate (only a key) leaves the
+	// pool empty, which reports ErrNoCertificatesFound.
+	_, err = certpool.NewFromStrings(string(keyPEM(t, one)))
+	core.AssertErrorIs(t, err, certpool.ErrNoCertificatesFound, "no certs")
+}

--- a/tls/x509utils/certpool/hash_test.go
+++ b/tls/x509utils/certpool/hash_test.go
@@ -1,0 +1,83 @@
+package certpool_test
+
+import (
+	"crypto/x509"
+	"testing"
+
+	"darvaza.org/core"
+
+	"darvaza.org/x/tls/x509utils/certpool"
+)
+
+// TestHashProducers confirms the four hash producers digest a valid
+// certificate and reject an invalid one, and that each keys on a distinct
+// field: subject, issuer and DER all differ for a leaf signed by a CA.
+func TestHashProducers(t *testing.T) {
+	root := mkTestCA(t, "Hash Root", nil)
+	leaf := mkTestLeaf(t, "hash.example.com", &root)
+	invalid := &x509.Certificate{}
+
+	cert, ok := certpool.HashCert(leaf.cert)
+	core.AssertMustTrue(t, ok, "hash cert")
+	subject, ok := certpool.HashSubject(leaf.cert)
+	core.AssertMustTrue(t, ok, "hash subject")
+	issuer, ok := certpool.HashIssuer(leaf.cert)
+	core.AssertMustTrue(t, ok, "hash issuer")
+	spki, ok := certpool.HashSubjectPublicKey(leaf.cert)
+	core.AssertMustTrue(t, ok, "hash spki")
+
+	core.AssertFalse(t, cert.Equal(subject), "cert vs subject differ")
+	core.AssertFalse(t, subject.Equal(issuer), "subject vs issuer differ")
+	core.AssertFalse(t, cert.Equal(spki), "cert vs spki differ")
+	core.AssertEqual(t, subject, certpool.Sum(leaf.cert.RawSubject), "subject")
+
+	assertHashMiss(t, invalid)
+}
+
+// assertHashMiss confirms every producer reports failure for a certificate that
+// fails validCert.
+func assertHashMiss(t *testing.T, cert *x509.Certificate) {
+	t.Helper()
+	_, ok := certpool.HashCert(cert)
+	core.AssertFalse(t, ok, "hash cert miss")
+	_, ok = certpool.HashSubject(cert)
+	core.AssertFalse(t, ok, "hash subject miss")
+	_, ok = certpool.HashIssuer(cert)
+	core.AssertFalse(t, ok, "hash issuer miss")
+	_, ok = certpool.HashSubjectPublicKey(cert)
+	core.AssertFalse(t, ok, "hash spki miss")
+}
+
+// TestHashSubjectPublicKeyUnsupportedKey confirms a certificate that passes
+// validCert but carries a public key that cannot be encoded is a miss:
+// validCert only checks the field is non-nil, so the SubjectPublicKeyBytes
+// error arm is reachable.
+func TestHashSubjectPublicKeyUnsupportedKey(t *testing.T) {
+	cert := &x509.Certificate{
+		Raw:        []byte{0x01},
+		RawSubject: []byte{0x02},
+		RawIssuer:  []byte{0x03},
+		PublicKey:  struct{}{},
+	}
+	_, ok := certpool.HashSubjectPublicKey(cert)
+	core.AssertFalse(t, ok, "unsupported key miss")
+}
+
+// TestHashEqualAndZero confirms Hash.Equal, IsZero and EqualCert: a digest
+// equals only itself, the zero value reports IsZero, and EqualCert matches the
+// certificate that produced the hash but not another or an invalid one.
+func TestHashEqualAndZero(t *testing.T) {
+	leaf := mkTestLeaf(t, "eq.example.com", nil)
+	other := mkTestLeaf(t, "other.example.com", nil)
+
+	h, ok := certpool.HashCert(leaf.cert)
+	core.AssertMustTrue(t, ok, "hash")
+
+	core.AssertTrue(t, h.Equal(h), "equal self")
+	core.AssertFalse(t, h.IsZero(), "non-zero")
+	core.AssertTrue(t, certpool.Hash{}.IsZero(), "zero value")
+
+	core.AssertTrue(t, h.EqualCert(leaf.cert), "matches own cert")
+	core.AssertFalse(t, h.EqualCert(other.cert), "rejects other cert")
+	core.AssertFalse(t, h.EqualCert(&x509.Certificate{}), "rejects invalid")
+}

--- a/tls/x509utils/certpool/system_test.go
+++ b/tls/x509utils/certpool/system_test.go
@@ -8,14 +8,15 @@ import (
 	"fmt"
 	"testing"
 
+	"darvaza.org/core"
+
 	"darvaza.org/x/tls/x509utils/certpool"
 )
 
 func TestSystemCertPool(t *testing.T) {
 	pool, err := certpool.SystemCertPool()
-	if err != nil {
-		t.Fatal(err)
-	}
+	core.AssertMustNoError(t, err, "system pool")
+	core.AssertMustNotNil(t, pool, "pool")
 
 	ctx := context.Background()
 	if deadLine, ok := t.Deadline(); ok {
@@ -30,6 +31,7 @@ func TestSystemCertPool(t *testing.T) {
 		i++
 		return true
 	})
+	core.AssertEqual(t, count, i-1, "visited all")
 }
 
 func printSystemCertTest(t *testing.T, i, count int, cert *x509.Certificate) {

--- a/tls/x509utils/certpool/utils.go
+++ b/tls/x509utils/certpool/utils.go
@@ -23,10 +23,6 @@ func validCert(cert *x509.Certificate) bool {
 }
 
 func copyMap[K comparable, V any](m map[K]V, fn func(V) (V, bool)) map[K]V {
-	if fn == nil {
-		fn = copyFn
-	}
-
 	out := make(map[K]V, len(m))
 	for k, v := range m {
 		if v, ok := fn(v); ok {
@@ -37,10 +33,6 @@ func copyMap[K comparable, V any](m map[K]V, fn func(V) (V, bool)) map[K]V {
 }
 
 func copyMapList[K comparable, V any](m map[K]*list.List[V], fn func(V) (V, bool)) map[K]*list.List[V] {
-	if fn == nil {
-		fn = copyFn
-	}
-
 	out := make(map[K]*list.List[V], len(m))
 	for k, l1 := range m {
 		if l2 := l1.Copy(fn); l2.Len() > 0 {
@@ -48,10 +40,6 @@ func copyMapList[K comparable, V any](m map[K]*list.List[V], fn func(V) (V, bool
 		}
 	}
 	return out
-}
-
-func copyFn[V any](v V) (V, bool) {
-	return v, true
 }
 
 func sliceForEach[T any](ctx context.Context, fn func(context.Context, T) bool, values []T) {

--- a/tls/x509utils/certpool/utils_internal_test.go
+++ b/tls/x509utils/certpool/utils_internal_test.go
@@ -7,6 +7,8 @@ import (
 	"darvaza.org/core"
 )
 
+var _ core.TestCase = validCertTestCase{}
+
 // validCertTestCase exercises validCert: a certificate is valid only when it
 // carries DER bytes, a public key, and both a non-empty subject and issuer
 // (RFC 5280 makes issuer a mandatory field).
@@ -24,8 +26,6 @@ func (tc validCertTestCase) Test(t *testing.T) {
 	t.Helper()
 	core.AssertEqual(t, tc.want, validCert(tc.cert), "validCert")
 }
-
-var _ core.TestCase = validCertTestCase{}
 
 func newValidCertTestCase(name string, cert *x509.Certificate,
 	want bool) validCertTestCase {

--- a/tls/x509utils/errors.go
+++ b/tls/x509utils/errors.go
@@ -19,6 +19,22 @@ type ErrInvalidCert struct {
 	Reason string
 }
 
+// NewErrInvalidCert builds an [ErrInvalidCert] reporting that cert was not
+// acceptable for the stated reason, optionally wrapping the underlying err.
+// Both cert and err may be nil; when err is nil the error defaults to wrapping
+// [core.ErrInvalid], so every [ErrInvalidCert] from this constructor satisfies
+// errors.Is(err, core.ErrInvalid).
+func NewErrInvalidCert(cert *x509.Certificate, err error, reason string) *ErrInvalidCert {
+	if err == nil {
+		err = core.ErrInvalid
+	}
+	return &ErrInvalidCert{
+		Cert:   cert,
+		Err:    err,
+		Reason: reason,
+	}
+}
+
 func (err ErrInvalidCert) Error() string {
 	s := make([]string, 0, 3)
 	s = append(s, "invalid certificate")
@@ -27,7 +43,10 @@ func (err ErrInvalidCert) Error() string {
 		s = append(s, err.Reason)
 	}
 
-	if err.Err != nil {
+	// core.ErrInvalid is the default cause and adds nothing beyond the
+	// "invalid certificate" prefix, so it is left out of the message; a
+	// caller-supplied cause is always shown.
+	if err.Err != nil && err.Err != core.ErrInvalid {
 		s = append(s, err.Err.Error())
 	}
 

--- a/tls/x509utils/errors.go
+++ b/tls/x509utils/errors.go
@@ -2,6 +2,8 @@ package x509utils
 
 import (
 	"crypto/x509"
+	"fmt"
+	"io/fs"
 	"strings"
 
 	"darvaza.org/core"
@@ -55,4 +57,29 @@ func (err ErrInvalidCert) Error() string {
 
 func (err ErrInvalidCert) Unwrap() error {
 	return err.Err
+}
+
+// newInvalidPathError reports a path as unusable for the stated
+// reason, wrapping fs.ErrInvalid so errors.Is matches against the
+// stdlib sentinel regardless of the core release in use.
+func newInvalidPathError(op, path, reason string) *fs.PathError {
+	return &fs.PathError{
+		Op:   op,
+		Path: clampErrPath(path),
+		Err:  core.Wrap(fs.ErrInvalid, reason),
+	}
+}
+
+// maxErrPathLen bounds how much of an offending path an error echoes. A
+// candidate longer than a real file name is a raw blob mistaken for one, and
+// storing it whole would flood the error; any genuine path sits well under it.
+const maxErrPathLen = 256
+
+// clampErrPath keeps an over-long path from filling the error with the entire
+// input, showing a leading slice and the original byte count instead.
+func clampErrPath(path string) string {
+	if len(path) <= maxErrPathLen {
+		return path
+	}
+	return fmt.Sprintf("%s… (%d bytes)", path[:maxErrPathLen], len(path))
 }

--- a/tls/x509utils/errors_test.go
+++ b/tls/x509utils/errors_test.go
@@ -1,0 +1,107 @@
+package x509utils_test
+
+import (
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"testing"
+
+	"darvaza.org/core"
+
+	"darvaza.org/x/tls/x509utils"
+)
+
+var _ core.TestCase = errInvalidCertTestCase{}
+
+// errInvalidCertTestCase exercises the message and core.ErrInvalid membership
+// of an error built by NewErrInvalidCert.
+type errInvalidCertTestCase struct {
+	inErr         error
+	name          string
+	reason        string
+	wantMsg       string
+	wantIsInvalid bool
+}
+
+func (tc errInvalidCertTestCase) Name() string { return tc.name }
+
+func (tc errInvalidCertTestCase) Test(t *testing.T) {
+	t.Helper()
+
+	err := x509utils.NewErrInvalidCert(nil, tc.inErr, tc.reason)
+
+	core.AssertEqual(t, tc.wantMsg, err.Error(), "message")
+	core.AssertEqual(t, tc.wantIsInvalid,
+		errors.Is(err, core.ErrInvalid), "is invalid")
+}
+
+func newErrInvalidCertTestCase(name string, inErr error, reason,
+	wantMsg string, wantIsInvalid bool) errInvalidCertTestCase {
+	return errInvalidCertTestCase{
+		inErr:         inErr,
+		name:          name,
+		reason:        reason,
+		wantMsg:       wantMsg,
+		wantIsInvalid: wantIsInvalid,
+	}
+}
+
+func errInvalidCertTestCases() []errInvalidCertTestCase {
+	boom := errors.New("boom")
+	wrapped := fmt.Errorf("deeper: %w", core.ErrInvalid)
+
+	return core.S(
+		// A nil cause defaults to core.ErrInvalid: hidden from the message
+		// but enough to satisfy errors.Is, with or without a reason.
+		newErrInvalidCertTestCase("reason only", nil,
+			"none provided", "invalid certificate: none provided", true),
+		newErrInvalidCertTestCase("no reason", nil,
+			"", "invalid certificate", true),
+		// The sentinel passed explicitly behaves like the default: hidden but
+		// invalid.
+		newErrInvalidCertTestCase("explicit sentinel", core.ErrInvalid,
+			"bad", "invalid certificate: bad", true),
+		// An unrelated explicit cause is shown and is not promoted to
+		// core.ErrInvalid, whether or not a reason is given.
+		newErrInvalidCertTestCase("explicit cause", boom,
+			"failed to encode certificate",
+			"invalid certificate: failed to encode certificate: boom", false),
+		newErrInvalidCertTestCase("explicit cause, no reason", boom,
+			"", "invalid certificate: boom", false),
+		// An explicit cause that itself wraps core.ErrInvalid is shown and
+		// still satisfies errors.Is.
+		newErrInvalidCertTestCase("explicit wrapped invalid", wrapped,
+			"bad", "invalid certificate: bad: deeper: invalid argument", true),
+	)
+}
+
+func TestNewErrInvalidCert(t *testing.T) {
+	core.RunTestCases(t, errInvalidCertTestCases())
+}
+
+// TestNewErrInvalidCertFields confirms the constructor keeps the certificate
+// and the unwrap target: the default core.ErrInvalid when no cause is given,
+// and the caller's cause otherwise.
+func TestNewErrInvalidCertFields(t *testing.T) {
+	cert := &x509.Certificate{}
+	boom := errors.New("boom")
+
+	def := x509utils.NewErrInvalidCert(cert, nil, "x")
+	core.AssertSame(t, cert, def.Cert, "cert")
+	core.AssertSame(t, core.ErrInvalid, def.Unwrap(), "default cause")
+
+	wrap := x509utils.NewErrInvalidCert(nil, boom, "x")
+	core.AssertSame(t, boom, wrap.Unwrap(), "explicit cause")
+	core.AssertErrorIs(t, wrap, boom, "wraps cause")
+}
+
+// TestErrInvalidCertDirect covers the zero-cause path the constructor never
+// produces: a struct built by hand with a nil Err keeps the message clean,
+// unwraps to nil, and does not satisfy core.ErrInvalid.
+func TestErrInvalidCertDirect(t *testing.T) {
+	raw := x509utils.ErrInvalidCert{Reason: "raw"}
+
+	core.AssertEqual(t, "invalid certificate: raw", raw.Error(), "message")
+	core.AssertNil(t, raw.Unwrap(), "unwrap")
+	core.AssertNotErrorIs(t, &raw, core.ErrInvalid, "not invalid")
+}

--- a/tls/x509utils/names.go
+++ b/tls/x509utils/names.go
@@ -12,8 +12,12 @@ import (
 )
 
 // Names returns a list of exact names and patterns the certificate
-// supports
+// supports. A nil certificate yields no names.
 func Names(cert *x509.Certificate) (names, patterns []string) {
+	if cert == nil {
+		return nil, nil
+	}
+
 	names, patterns = splitDNSNames(cert.DNSNames)
 	names = appendIPAddresses(names, cert.IPAddresses)
 

--- a/tls/x509utils/names.go
+++ b/tls/x509utils/names.go
@@ -71,25 +71,12 @@ func SanitizeName(name string) (string, bool) {
 
 func doSanitizeName(name string) (string, bool) {
 	if addr, err := core.ParseAddr(name); err == nil {
-		// IP
-		addr = addr.Unmap()
-		addr = addr.WithZone("")
-		name = addr.String()
-	} else {
-		// Name
-		name = removeZone(name)
+		// IP: drop any 4-in-6 mapping and scope zone.
+		name = addr.Unmap().WithZone("").String()
 	}
+	// A non-IP name arrives already validated by SplitHostPort, whose idna
+	// check rejects '%', so it cannot carry a scope zone — nothing to strip.
 	return name, len(name) > 0
-}
-
-func removeZone(name string) string {
-	idx := strings.LastIndexFunc(name, func(r rune) bool {
-		return r == '%'
-	})
-	if idx < 0 {
-		return name
-	}
-	return name[:idx]
 }
 
 // NameAsIP prepares a sanitised IP address name for matching certificates

--- a/tls/x509utils/names.go
+++ b/tls/x509utils/names.go
@@ -46,11 +46,12 @@ func splitDNSNames(dnsNames []string) (names, patterns []string) {
 
 func appendIPAddresses(names []string, addrs []net.IP) []string {
 	for _, ip := range addrs {
+		// AddrFromSlice reports ok only for 4- or 16-byte slices, both of
+		// which yield a valid address; Unmap drops any 4-in-6 mapping so the
+		// stored key matches the form the lookup paths produce.
 		if addr, ok := netip.AddrFromSlice(ip); ok {
-			if addr.IsValid() {
-				name := fmt.Sprintf("[%s]", addr.String())
-				names = append(names, name)
-			}
+			name := fmt.Sprintf("[%s]", addr.Unmap())
+			names = append(names, name)
 		}
 	}
 	return names
@@ -74,20 +75,29 @@ func SanitizeName(name string) (string, bool) {
 }
 
 func doSanitizeName(name string) (string, bool) {
-	if addr, err := core.ParseAddr(name); err == nil {
-		// IP: drop any 4-in-6 mapping and scope zone.
-		name = addr.Unmap().WithZone("").String()
+	if addr, err := sanitizeAddr(name); err == nil {
+		name = addr.String()
 	}
 	// A non-IP name arrives already validated by SplitHostPort, whose idna
 	// check rejects '%', so it cannot carry a scope zone — nothing to strip.
 	return name, len(name) > 0
 }
 
+// sanitizeAddr parses an IP address and canonicalises it into the single form
+// the certificate name keys use — dropping any 4-in-6 mapping and scope zone —
+// so the storage (Names) and lookup (SanitizeName/NameAsIP) paths agree.
+func sanitizeAddr(name string) (netip.Addr, error) {
+	addr, err := core.ParseAddr(name)
+	if err != nil {
+		return netip.Addr{}, err
+	}
+	return addr.Unmap().WithZone(""), nil
+}
+
 // NameAsIP prepares a sanitised IP address name for matching certificates
 func NameAsIP(name string) (string, bool) {
-	if addr, err := core.ParseAddr(name); err == nil {
-		s := fmt.Sprintf("[%s]", addr)
-		return s, true
+	if addr, err := sanitizeAddr(name); err == nil {
+		return fmt.Sprintf("[%s]", addr), true
 	}
 	return "", false
 }

--- a/tls/x509utils/names_test.go
+++ b/tls/x509utils/names_test.go
@@ -146,6 +146,14 @@ func sanitizeNameTestCases() []sanitizeNameTestCase {
 		newSanitizeNameTestCase("ipv4", "1.2.3.4", "1.2.3.4"),
 		newSanitizeNameTestCase("ipv6 with port", "[2001:DB8::1]:443",
 			"2001:db8::1"),
+		// An IP scope zone is stripped on the IP branch by WithZone(""),
+		// never by removeZone.
+		newSanitizeNameTestCase("ipv6 zone", "[fe80::1%eth0]:443",
+			"fe80::1"),
+		// A '%' can only survive nameRE inside a non-final label, and idna's
+		// STD3 rules then reject it, so SplitHostPort fails before
+		// doSanitizeName: the removeZone name-branch is never reached.
+		newSanitizeNameTestCase("percent in host", "foo%bar.example", ""),
 		newSanitizeNameTestCase("empty", "", ""),
 	)
 }

--- a/tls/x509utils/names_test.go
+++ b/tls/x509utils/names_test.go
@@ -14,6 +14,7 @@ import (
 var (
 	_ core.TestCase = nameAsIPTestCase{}
 	_ core.TestCase = nameAsSuffixTestCase{}
+	_ core.TestCase = namesIPTestCase{}
 	_ core.TestCase = namesTestCase{}
 	_ core.TestCase = sanitizeNameTestCase{}
 )
@@ -52,6 +53,8 @@ func nameAsIPTestCases() []nameAsIPTestCase {
 		newNameAsIPTestCase("ipv4", "1.2.3.4", "[1.2.3.4]"),
 		newNameAsIPTestCase("overflow octet", "1.2.3.400", ""),
 		newNameAsIPTestCase("ipv6 unspecified", "::", "[::]"),
+		newNameAsIPTestCase("ipv4-mapped ipv6", "::ffff:1.2.3.4", "[1.2.3.4]"),
+		newNameAsIPTestCase("zoned link-local", "fe80::1%eth0", "[fe80::1]"),
 		newNameAsIPTestCase("fqdn", "foo.example.org", ""),
 	)
 }
@@ -262,6 +265,72 @@ func TestNamesDropsAndDeduplicates(t *testing.T) {
 	core.AssertSliceEqual(t, core.S("a.example.com", "[1.2.3.4]"), names,
 		"names")
 	core.AssertSliceEqual(t, core.S(".example.com"), patterns, "patterns")
+}
+
+// TestNamesMappedIP confirms a 16-byte IPv4-mapped-IPv6 iPAddress SAN is
+// stored under the canonical unmapped key ([1.2.3.4]), matching what the
+// lookup paths produce for the same address, rather than [::ffff:1.2.3.4]
+// (F61). A certificate literal carries the mapped SAN verbatim; a minted cert
+// would normalise it to a 4-byte SAN.
+func TestNamesMappedIP(t *testing.T) {
+	mapped := net.IP{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 1, 2, 3, 4}
+	cert := &x509.Certificate{IPAddresses: []net.IP{mapped}}
+
+	names, _ := x509utils.Names(cert)
+	core.AssertSliceEqual(t, core.S("[1.2.3.4]"), names, "names")
+}
+
+// namesIPTestCase feeds appendIPAddresses (through the exported Names) IP SANs
+// of every boundary length. netip.AddrFromSlice accepts only 4- and 16-byte
+// slices, both of which yield a valid address, so nothing shorter or longer
+// survives and no ok-but-invalid address exists. That is why appendIPAddresses
+// needs no IsValid() guard: these rows produce the same output with or without
+// it, and would catch a bad address leaking through if one ever could (F72).
+type namesIPTestCase struct {
+	name  string
+	ips   []net.IP
+	names []string
+}
+
+func (tc namesIPTestCase) Name() string { return tc.name }
+
+func (tc namesIPTestCase) Test(t *testing.T) {
+	t.Helper()
+	cert := &x509.Certificate{IPAddresses: tc.ips}
+	names, _ := x509utils.Names(cert)
+	core.AssertSliceEqual(t, tc.names, names, "names")
+}
+
+func newNamesIPTestCase(name string, ips []net.IP,
+	names []string) namesIPTestCase {
+	return namesIPTestCase{
+		ips:   ips,
+		names: names,
+		name:  name,
+	}
+}
+
+func namesIPTestCases() []namesIPTestCase {
+	none := core.S[string]()
+	return core.S(
+		newNamesIPTestCase("nil element", core.S[net.IP](nil), none),
+		newNamesIPTestCase("empty", []net.IP{{}}, none),
+		newNamesIPTestCase("three bytes", []net.IP{{1, 2, 3}}, none),
+		newNamesIPTestCase("ipv4", []net.IP{{1, 2, 3, 4}},
+			core.S("[1.2.3.4]")),
+		newNamesIPTestCase("five bytes", []net.IP{{1, 2, 3, 4, 5}}, none),
+		newNamesIPTestCase("fifteen bytes", []net.IP{make([]byte, 15)}, none),
+		newNamesIPTestCase("ipv4-mapped ipv6",
+			[]net.IP{{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 1, 2, 3, 4}},
+			core.S("[1.2.3.4]")),
+		newNamesIPTestCase("ipv6", []net.IP{net.ParseIP("2001:db8::1")},
+			core.S("[2001:db8::1]")),
+		newNamesIPTestCase("seventeen bytes", []net.IP{make([]byte, 17)}, none),
+	)
+}
+
+func TestNamesIPLengths(t *testing.T) {
+	core.RunTestCases(t, namesIPTestCases())
 }
 
 // TestHostname confirms Hostname sanitises a URL host the same way SanitizeName

--- a/tls/x509utils/names_test.go
+++ b/tls/x509utils/names_test.go
@@ -1,49 +1,105 @@
-package x509utils
+package x509utils_test
 
 import (
 	"testing"
+
+	"darvaza.org/core"
+
+	"darvaza.org/x/tls/x509utils"
 )
 
-type nameAsTest struct {
-	Name     string
-	Expected string
-	Ok       bool
+var (
+	_ core.TestCase = nameAsIPTestCase{}
+	_ core.TestCase = nameAsSuffixTestCase{}
+)
+
+// nameAsIPTestCase exercises NameAsIP: a parseable address is bracketed and
+// accepted, anything else is rejected. Acceptance and a non-empty result are
+// inseparable, so ok is asserted as the invariant expected != "" rather than
+// declared as a redundant column.
+type nameAsIPTestCase struct {
+	input    string
+	expected string
+	name     string
+}
+
+func (tc nameAsIPTestCase) Name() string { return tc.name }
+
+func (tc nameAsIPTestCase) Test(t *testing.T) {
+	t.Helper()
+	got, ok := x509utils.NameAsIP(tc.input)
+	core.AssertEqual(t, tc.expected, got, "addr")
+	core.AssertEqual(t, tc.expected != "", ok, "ok")
+}
+
+func newNameAsIPTestCase(name, input, expected string) nameAsIPTestCase {
+	return nameAsIPTestCase{
+		input:    input,
+		expected: expected,
+		name:     name,
+	}
+}
+
+func nameAsIPTestCases() []nameAsIPTestCase {
+	return core.S(
+		newNameAsIPTestCase("hostname", "a.b.c", ""),
+		newNameAsIPTestCase("bare zero", "0", "[0.0.0.0]"),
+		newNameAsIPTestCase("ipv4", "1.2.3.4", "[1.2.3.4]"),
+		newNameAsIPTestCase("overflow octet", "1.2.3.400", ""),
+		newNameAsIPTestCase("ipv6 unspecified", "::", "[::]"),
+		newNameAsIPTestCase("fqdn", "foo.example.org", ""),
+	)
 }
 
 func TestNameAsIP(t *testing.T) {
-	var entries = []nameAsTest{
-		{"a.b.c", "", false},
-		{"0", "[0.0.0.0]", true},
-		{"1.2.3.4", "[1.2.3.4]", true},
-		{"1.2.3.400", "", false},
-		{"::", "[::]", true},
-		{"foo.example.org", "", false},
-	}
+	core.RunTestCases(t, nameAsIPTestCases())
+}
 
-	for _, entry := range entries {
-		s, ok := NameAsIP(entry.Name)
-		if s != entry.Expected || ok != entry.Ok {
-			t.Errorf("NameAsIP(%q) -> %q, %v", entry.Name, s, ok)
-		}
+// nameAsSuffixTestCase exercises NameAsSuffix: the name is reduced to the
+// dotted suffix after its first label, accepted only when that suffix is
+// longer than a lone dot. ok is therefore the invariant len(expected) > 1, not
+// expected != "": "a." yields "." yet is rejected.
+type nameAsSuffixTestCase struct {
+	input    string
+	expected string
+	name     string
+}
+
+func (tc nameAsSuffixTestCase) Name() string { return tc.name }
+
+func (tc nameAsSuffixTestCase) Test(t *testing.T) {
+	t.Helper()
+	got, ok := x509utils.NameAsSuffix(tc.input)
+	core.AssertEqual(t, tc.expected, got, "suffix")
+	core.AssertEqual(t, len(tc.expected) > 1, ok, "ok")
+}
+
+func newNameAsSuffixTestCase(name, input,
+	expected string) nameAsSuffixTestCase {
+	return nameAsSuffixTestCase{
+		input:    input,
+		expected: expected,
+		name:     name,
 	}
 }
 
-func TestNameAsSuffix(t *testing.T) {
-	var entries = []nameAsTest{
-		{"foo.example.com", ".example.com", true},
-		{".example.com", "", false},
-		{"a.b.c", ".b.c", true},
-		{".b.c", "", false},
-		{"b.c", ".c", true},
-		{".c", "", false},
-		{"c", "", false},
-		{"", "", false},
-	}
+func nameAsSuffixTestCases() []nameAsSuffixTestCase {
+	return core.S(
+		newNameAsSuffixTestCase("dotted host", "foo.example.com",
+			".example.com"),
+		newNameAsSuffixTestCase("leading dot", ".example.com", ""),
+		newNameAsSuffixTestCase("two labels", "a.b.c", ".b.c"),
+		newNameAsSuffixTestCase("leading dot two labels", ".b.c", ""),
+		newNameAsSuffixTestCase("single inner label", "b.c", ".c"),
+		newNameAsSuffixTestCase("leading dot one label", ".c", ""),
+		newNameAsSuffixTestCase("bare label", "c", ""),
+		// idx>0 yields a lone dot, which fails the len>1 gate: a non-empty
+		// result with ok=false, the row that makes the invariant load-bearing.
+		newNameAsSuffixTestCase("trailing dot", "a.", "."),
+		newNameAsSuffixTestCase("empty", "", ""),
+	)
+}
 
-	for _, entry := range entries {
-		s, ok := NameAsSuffix(entry.Name)
-		if s != entry.Expected || ok != entry.Ok {
-			t.Errorf("NameAsSuffix(%q) -> %q, %v", entry.Name, s, ok)
-		}
-	}
+func TestNameAsSuffix(t *testing.T) {
+	core.RunTestCases(t, nameAsSuffixTestCases())
 }

--- a/tls/x509utils/names_test.go
+++ b/tls/x509utils/names_test.go
@@ -11,6 +11,7 @@ import (
 var (
 	_ core.TestCase = nameAsIPTestCase{}
 	_ core.TestCase = nameAsSuffixTestCase{}
+	_ core.TestCase = sanitizeNameTestCase{}
 )
 
 // nameAsIPTestCase exercises NameAsIP: a parseable address is bracketed and
@@ -102,4 +103,53 @@ func nameAsSuffixTestCases() []nameAsSuffixTestCase {
 
 func TestNameAsSuffix(t *testing.T) {
 	core.RunTestCases(t, nameAsSuffixTestCases())
+}
+
+// sanitizeNameTestCase exercises SanitizeName: the name is split from its
+// optional port and case-folded to the form Names stores under (RFC 6125),
+// with IP addresses normalised. Acceptance and a non-empty result are
+// inseparable, so ok is asserted as the invariant expected != "".
+type sanitizeNameTestCase struct {
+	input    string
+	expected string
+	name     string
+}
+
+func (tc sanitizeNameTestCase) Name() string { return tc.name }
+
+func (tc sanitizeNameTestCase) Test(t *testing.T) {
+	t.Helper()
+	got, ok := x509utils.SanitizeName(tc.input)
+	core.AssertEqual(t, tc.expected, got, "name")
+	core.AssertEqual(t, tc.expected != "", ok, "ok")
+}
+
+func newSanitizeNameTestCase(name, input,
+	expected string) sanitizeNameTestCase {
+	return sanitizeNameTestCase{
+		input:    input,
+		expected: expected,
+		name:     name,
+	}
+}
+
+func sanitizeNameTestCases() []sanitizeNameTestCase {
+	return core.S(
+		// DNS names are case-insensitive (RFC 6125): an uppercase query
+		// folds to the lower-cased form Names stores under.
+		newSanitizeNameTestCase("uppercase host", "WWW.EXAMPLE.COM",
+			"www.example.com"),
+		newSanitizeNameTestCase("lowercase host", "www.example.com",
+			"www.example.com"),
+		newSanitizeNameTestCase("mixed case with port", "Mixed.Case.ORG:443",
+			"mixed.case.org"),
+		newSanitizeNameTestCase("ipv4", "1.2.3.4", "1.2.3.4"),
+		newSanitizeNameTestCase("ipv6 with port", "[2001:DB8::1]:443",
+			"2001:db8::1"),
+		newSanitizeNameTestCase("empty", "", ""),
+	)
+}
+
+func TestSanitizeName(t *testing.T) {
+	core.RunTestCases(t, sanitizeNameTestCases())
 }

--- a/tls/x509utils/names_test.go
+++ b/tls/x509utils/names_test.go
@@ -1,6 +1,9 @@
 package x509utils_test
 
 import (
+	"crypto/x509"
+	"net"
+	"net/url"
 	"testing"
 
 	"darvaza.org/core"
@@ -11,6 +14,7 @@ import (
 var (
 	_ core.TestCase = nameAsIPTestCase{}
 	_ core.TestCase = nameAsSuffixTestCase{}
+	_ core.TestCase = namesTestCase{}
 	_ core.TestCase = sanitizeNameTestCase{}
 )
 
@@ -160,4 +164,111 @@ func sanitizeNameTestCases() []sanitizeNameTestCase {
 
 func TestSanitizeName(t *testing.T) {
 	core.RunTestCases(t, sanitizeNameTestCases())
+}
+
+// namesTestCase exercises Names: DNS literals fold to lower case, wildcards
+// become dotted patterns, and IP SANs are bracketed. The certificates are
+// minted and re-parsed so their SANs are in the DER-canonical form the basic
+// store feeds Names via cert.Leaf.
+type namesTestCase struct {
+	cert     *x509.Certificate
+	name     string
+	names    []string
+	patterns []string
+}
+
+func (tc namesTestCase) Name() string { return tc.name }
+
+func (tc namesTestCase) Test(t *testing.T) {
+	t.Helper()
+	names, patterns := x509utils.Names(tc.cert)
+	core.AssertSliceEqual(t, tc.names, names, "names")
+	core.AssertSliceEqual(t, tc.patterns, patterns, "patterns")
+}
+
+func newNamesTestCase(name string, cert *x509.Certificate,
+	names, patterns []string) namesTestCase {
+	return namesTestCase{
+		cert:     cert,
+		name:     name,
+		names:    names,
+		patterns: patterns,
+	}
+}
+
+func namesTestCases(t *testing.T) []namesTestCase {
+	t.Helper()
+
+	dns := func(ds ...string) *x509.Certificate {
+		return certSpec{cn: ds[0], dns: ds}.build(t).cert
+	}
+	ip := func(cn string, ips ...net.IP) *x509.Certificate {
+		return certSpec{cn: cn, ips: ips}.build(t).cert
+	}
+	none := core.S[string]()
+
+	return core.S(
+		newNamesTestCase("dns literal", dns("a.example.com"),
+			core.S("a.example.com"), none),
+		// RFC 6125: DNS names are case-insensitive; Names lower-cases them.
+		newNamesTestCase("uppercase folds", dns("Foo.Example.COM"),
+			core.S("foo.example.com"), none),
+		// a wildcard becomes a dotted suffix pattern, not a literal name.
+		newNamesTestCase("wildcard pattern", dns("*.example.com"),
+			none, core.S(".example.com")),
+		newNamesTestCase("literal and wildcard",
+			dns("a.example.com", "*.example.com"),
+			core.S("a.example.com"), core.S(".example.com")),
+		newNamesTestCase("ipv4 bracketed",
+			ip("host", net.ParseIP("1.2.3.4")),
+			core.S("[1.2.3.4]"), none),
+		newNamesTestCase("ipv6 bracketed",
+			ip("host", net.ParseIP("2001:db8::1")),
+			core.S("[2001:db8::1]"), none),
+	)
+}
+
+func TestNames(t *testing.T) {
+	core.RunTestCases(t, namesTestCases(t))
+}
+
+// TestNamesNil confirms a nil certificate yields no names rather than
+// dereferencing into a panic.
+func TestNamesNil(t *testing.T) {
+	names, patterns := x509utils.Names(nil)
+	core.AssertNil(t, names, "names")
+	core.AssertNil(t, patterns, "patterns")
+}
+
+// TestNamesDropsAndDeduplicates covers splitDNSNames' empty-name drop, the
+// SliceUnique deduplication, and appendIPAddresses' malformed-IP drop, using
+// certificate literals so Names reads the SANs verbatim (a minted cert could
+// not carry an empty DNSName or a 3-byte IP address).
+func TestNamesDropsAndDeduplicates(t *testing.T) {
+	goodIP, err := core.ParseNetIP("1.2.3.4")
+	core.AssertMustNoError(t, err, "parse ip")
+
+	// a 3-byte address fails netip.AddrFromSlice and is dropped; the
+	// parsed one is canonical (unmapped) and is bracketed.
+	badIP := net.IP{1, 2, 3}
+
+	cert := &x509.Certificate{
+		DNSNames: []string{"a.example.com", "", "a.example.com", "*.example.com",
+			"*.example.com"},
+		IPAddresses: []net.IP{badIP, goodIP},
+	}
+
+	names, patterns := x509utils.Names(cert)
+	core.AssertSliceEqual(t, core.S("a.example.com", "[1.2.3.4]"), names,
+		"names")
+	core.AssertSliceEqual(t, core.S(".example.com"), patterns, "patterns")
+}
+
+// TestHostname confirms Hostname sanitises a URL host the same way SanitizeName
+// does: it strips the port and folds case.
+func TestHostname(t *testing.T) {
+	u := &url.URL{Host: "WWW.Example.COM:443"}
+	got, ok := x509utils.Hostname(u)
+	core.AssertMustTrue(t, ok, "ok")
+	core.AssertEqual(t, "www.example.com", got, "host")
 }

--- a/tls/x509utils/pair.go
+++ b/tls/x509utils/pair.go
@@ -51,16 +51,14 @@ func ValidKeyPair(pub crypto.PublicKey, key crypto.PrivateKey) bool {
 }
 
 // IsSelfSigned tests if a certificate corresponds to a self-signed CA.
+//
+// This is a structural test: the certificate must be a CA whose Subject and
+// Issuer match and whose signature verifies against its own key. It does not
+// check time validity, so an expired self-signed root is still recognised —
+// deliberately, since callers use it to classify roots and terminate issuer
+// walks, where validity is a separate handshake-time concern.
 func IsSelfSigned(c *x509.Certificate) bool {
-	if c != nil && c.IsCA && bytes.Equal(c.RawSubject, c.RawIssuer) {
-		pool := x509.NewCertPool()
-
-		pool.AddCert(c)
-		_, err := c.Verify(x509.VerifyOptions{
-			Roots: pool,
-		})
-
-		return err == nil
-	}
-	return false
+	return c != nil && c.IsCA &&
+		bytes.Equal(c.RawSubject, c.RawIssuer) &&
+		c.CheckSignatureFrom(c) == nil
 }

--- a/tls/x509utils/pair_test.go
+++ b/tls/x509utils/pair_test.go
@@ -1,0 +1,252 @@
+package x509utils_test
+
+import (
+	"bytes"
+	"crypto"
+	"crypto/x509"
+	"testing"
+	"time"
+
+	"darvaza.org/core"
+
+	"darvaza.org/x/tls/x509utils"
+)
+
+var (
+	_ core.TestCase = certKeyPairTestCase{}
+	_ core.TestCase = isSelfSignedTestCase{}
+	_ core.TestCase = keyEqualTestCase{}
+	_ core.TestCase = privateKeyEqualTestCase{}
+	_ core.TestCase = validKeyPairTestCase{}
+)
+
+// isSelfSignedTestCase exercises IsSelfSigned: only a self-signed CA whose
+// signature verifies returns true.
+type isSelfSignedTestCase struct {
+	cert *x509.Certificate
+	name string
+	want bool
+}
+
+func (tc isSelfSignedTestCase) Name() string { return tc.name }
+
+func (tc isSelfSignedTestCase) Test(t *testing.T) {
+	t.Helper()
+	core.AssertEqual(t, tc.want, x509utils.IsSelfSigned(tc.cert), "self-signed")
+}
+
+func newIsSelfSignedTestCase(name string, cert *x509.Certificate,
+	want bool) isSelfSignedTestCase {
+	return isSelfSignedTestCase{cert: cert, name: name, want: want}
+}
+
+func isSelfSignedTestCases(t *testing.T) []isSelfSignedTestCase {
+	t.Helper()
+
+	root := certSpec{cn: "Root", isCA: true}.build(t)
+	sub := certSpec{cn: "Sub", isCA: true, parent: &root}.build(t)
+	leaf := certSpec{cn: "leaf.example.com",
+		dns: core.S("leaf.example.com"), parent: &sub}.build(t)
+	selfLeaf := certSpec{cn: "self.example.com"}.build(t)
+	expiredRoot := certSpec{cn: "Expired Root", isCA: true,
+		notBefore: time.Now().Add(-2 * time.Hour),
+		notAfter:  time.Now().Add(-time.Hour)}.build(t)
+	// self-issued but not self-signed (RFC 5280): a root re-key — same
+	// subject and issuer name as root, signed by root's old key. The
+	// premise assertion keeps the row honest: subject and issuer must
+	// be byte-identical or the row stops reaching the signature check.
+	rekeyedRoot := certSpec{cn: "Root", isCA: true, parent: &root}.build(t)
+	core.AssertMustTrue(t, bytes.Equal(rekeyedRoot.cert.RawSubject,
+		rekeyedRoot.cert.RawIssuer), "self-issued premise")
+
+	return core.S(
+		newIsSelfSignedTestCase("nil", nil, false),
+		newIsSelfSignedTestCase("self-signed CA", root.cert, true),
+		newIsSelfSignedTestCase("intermediate CA", sub.cert, false),
+		newIsSelfSignedTestCase("end-entity leaf", leaf.cert, false),
+		// self-signed but not a CA: subject==issuer yet IsCA is false.
+		newIsSelfSignedTestCase("self-signed non-CA", selfLeaf.cert, false),
+		// IsSelfSigned is a structural check, not a validity check: an expired
+		// self-signed root is still recognised so the basic store classifies
+		// it as a root rather than mis-filing it as an intermediate.
+		newIsSelfSignedTestCase("expired self-signed CA", expiredRoot.cert,
+			true),
+		// subject and issuer bytes match and IsCA holds, so only the
+		// CheckSignatureFrom clause rejects it — the row that keeps the
+		// signature check load-bearing.
+		newIsSelfSignedTestCase("self-issued not self-signed",
+			rekeyedRoot.cert, false),
+	)
+}
+
+func TestIsSelfSigned(t *testing.T) {
+	core.RunTestCases(t, isSelfSignedTestCases(t))
+}
+
+// certKeyPairTestCase exercises ValidCertKeyPair: the key must own the cert's
+// public key; nil operands are never comparable.
+type certKeyPairTestCase struct {
+	cert *x509.Certificate
+	key  crypto.PrivateKey
+	name string
+	want bool
+}
+
+func (tc certKeyPairTestCase) Name() string { return tc.name }
+
+func (tc certKeyPairTestCase) Test(t *testing.T) {
+	t.Helper()
+	got := x509utils.ValidCertKeyPair(tc.cert, tc.key)
+	core.AssertEqual(t, tc.want, got, "valid pair")
+}
+
+func newCertKeyPairTestCase(name string, cert *x509.Certificate,
+	key crypto.PrivateKey, want bool) certKeyPairTestCase {
+	return certKeyPairTestCase{cert: cert, key: key, name: name, want: want}
+}
+
+func certKeyPairTestCases(t *testing.T) []certKeyPairTestCase {
+	t.Helper()
+
+	leaf := certSpec{cn: "pair.example.com",
+		dns: core.S("pair.example.com")}.build(t)
+	stray := mkKey(t)
+
+	return core.S(
+		newCertKeyPairTestCase("matching", leaf.cert, leaf.key, true),
+		newCertKeyPairTestCase("mismatched key", leaf.cert, stray, false),
+		newCertKeyPairTestCase("nil cert", nil, leaf.key, false),
+		newCertKeyPairTestCase("nil key", leaf.cert, nil, false),
+		// a value that is not an x509utils.PrivateKey never matches.
+		newCertKeyPairTestCase("non-key value", leaf.cert, "not a key", false),
+	)
+}
+
+func TestValidCertKeyPair(t *testing.T) {
+	core.RunTestCases(t, certKeyPairTestCases(t))
+}
+
+// keyEqualTestCase exercises PublicKeyEqual: the first operand must satisfy the
+// PublicKey interface and Equal the second.
+type keyEqualTestCase struct {
+	a    crypto.PublicKey
+	b    crypto.PublicKey
+	name string
+	want bool
+}
+
+func (tc keyEqualTestCase) Name() string { return tc.name }
+
+func (tc keyEqualTestCase) Test(t *testing.T) {
+	t.Helper()
+	core.AssertEqual(t, tc.want, x509utils.PublicKeyEqual(tc.a, tc.b), "equal")
+}
+
+func newKeyEqualTestCase(name string, a, b crypto.PublicKey,
+	want bool) keyEqualTestCase {
+	return keyEqualTestCase{a: a, b: b, name: name, want: want}
+}
+
+func keyEqualTestCases(t *testing.T) []keyEqualTestCase {
+	t.Helper()
+
+	k1, k2 := mkKey(t), mkKey(t)
+	pub1, pub2 := k1.Public(), k2.Public()
+
+	return core.S(
+		newKeyEqualTestCase("same key", pub1, pub1, true),
+		newKeyEqualTestCase("different keys", pub1, pub2, false),
+		newKeyEqualTestCase("nil first", nil, pub1, false),
+		newKeyEqualTestCase("nil second", pub1, nil, false),
+		// the first operand must implement PublicKey (Equal); a bare value
+		// fails the type assertion and is treated as incomparable.
+		newKeyEqualTestCase("non-key first", "not a key", pub1, false),
+	)
+}
+
+func TestPublicKeyEqual(t *testing.T) {
+	core.RunTestCases(t, keyEqualTestCases(t))
+}
+
+// privateKeyEqualTestCase exercises PrivateKeyEqual: the first operand must
+// satisfy the PrivateKey interface and Equal the second.
+type privateKeyEqualTestCase struct {
+	a    crypto.PrivateKey
+	b    crypto.PrivateKey
+	name string
+	want bool
+}
+
+func (tc privateKeyEqualTestCase) Name() string { return tc.name }
+
+func (tc privateKeyEqualTestCase) Test(t *testing.T) {
+	t.Helper()
+	got := x509utils.PrivateKeyEqual(tc.a, tc.b)
+	core.AssertEqual(t, tc.want, got, "equal")
+}
+
+func newPrivateKeyEqualTestCase(name string, a, b crypto.PrivateKey,
+	want bool) privateKeyEqualTestCase {
+	return privateKeyEqualTestCase{a: a, b: b, name: name, want: want}
+}
+
+func privateKeyEqualTestCases(t *testing.T) []privateKeyEqualTestCase {
+	t.Helper()
+
+	k1, k2 := mkKey(t), mkKey(t)
+
+	return core.S(
+		newPrivateKeyEqualTestCase("same key", k1, k1, true),
+		newPrivateKeyEqualTestCase("different keys", k1, k2, false),
+		newPrivateKeyEqualTestCase("nil first", nil, k1, false),
+		newPrivateKeyEqualTestCase("nil second", k1, nil, false),
+		// the first operand must implement PrivateKey (Equal); a bare value
+		// fails the type assertion and is treated as incomparable.
+		newPrivateKeyEqualTestCase("non-key first", "not a key", k1, false),
+	)
+}
+
+func TestPrivateKeyEqual(t *testing.T) {
+	core.RunTestCases(t, privateKeyEqualTestCases(t))
+}
+
+// validKeyPairTestCase exercises ValidKeyPair: the public key must match the
+// private key that owns it; nil operands are never comparable.
+type validKeyPairTestCase struct {
+	pub  crypto.PublicKey
+	key  crypto.PrivateKey
+	name string
+	want bool
+}
+
+func (tc validKeyPairTestCase) Name() string { return tc.name }
+
+func (tc validKeyPairTestCase) Test(t *testing.T) {
+	t.Helper()
+	got := x509utils.ValidKeyPair(tc.pub, tc.key)
+	core.AssertEqual(t, tc.want, got, "valid pair")
+}
+
+func newValidKeyPairTestCase(name string, pub crypto.PublicKey,
+	key crypto.PrivateKey, want bool) validKeyPairTestCase {
+	return validKeyPairTestCase{pub: pub, key: key, name: name, want: want}
+}
+
+func validKeyPairTestCases(t *testing.T) []validKeyPairTestCase {
+	t.Helper()
+
+	k1, k2 := mkKey(t), mkKey(t)
+
+	return core.S(
+		newValidKeyPairTestCase("matching", k1.Public(), k1, true),
+		newValidKeyPairTestCase("mismatched", k2.Public(), k1, false),
+		newValidKeyPairTestCase("nil pub", nil, k1, false),
+		newValidKeyPairTestCase("nil key", k1.Public(), nil, false),
+		// a value that does not implement PrivateKey is incomparable.
+		newValidKeyPairTestCase("non-key", k1.Public(), "not a key", false),
+	)
+}
+
+func TestValidKeyPair(t *testing.T) {
+	core.RunTestCases(t, validKeyPairTestCases(t))
+}

--- a/tls/x509utils/pem_block.go
+++ b/tls/x509utils/pem_block.go
@@ -21,23 +21,30 @@ var (
 	ErrNotSupported = errors.New("key type not supported")
 )
 
-// BlockToPrivateKey parses a pem Block looking for rsa, ecdsa or ed25519 Private Keys
+// BlockToPrivateKey parses a PEM block into an rsa, ecdsa or ed25519 private
+// key, accepting the PKCS1, SEC1 and PKCS8 encodings.
 func BlockToPrivateKey(block *pem.Block) (PrivateKey, error) {
 	if block.Type == "PRIVATE KEY" || strings.HasSuffix(block.Type, " PRIVATE KEY") {
-		if pk, _ := x509.ParsePKCS1PrivateKey(block.Bytes); pk != nil {
-			// *rsa.PrivateKey
-			return pk, nil
-		}
-
-		pk, err := parsePKCS8PrivateKey(block.Bytes)
-		if err != nil {
-			return nil, err
-		}
-
-		return pk, nil
+		return parsePrivateKeyDER(block.Bytes)
 	}
 
 	return nil, ErrIgnored
+}
+
+// parsePrivateKeyDER decodes a DER private key, trying the PKCS1, SEC1 and
+// PKCS8 encodings in turn.
+func parsePrivateKeyDER(b []byte) (PrivateKey, error) {
+	if pk, _ := x509.ParsePKCS1PrivateKey(b); pk != nil {
+		// *rsa.PrivateKey (PKCS1)
+		return pk, nil
+	}
+
+	if pk, _ := x509.ParseECPrivateKey(b); pk != nil {
+		// *ecdsa.PrivateKey (SEC1)
+		return pk, nil
+	}
+
+	return parsePKCS8PrivateKey(b)
 }
 
 func parsePKCS8PrivateKey(b []byte) (PrivateKey, error) {

--- a/tls/x509utils/pem_block.go
+++ b/tls/x509utils/pem_block.go
@@ -7,6 +7,8 @@ import (
 	"encoding/pem"
 	"errors"
 	"strings"
+
+	"darvaza.org/core"
 )
 
 var (
@@ -24,6 +26,10 @@ var (
 // BlockToPrivateKey parses a PEM block into an rsa, ecdsa or ed25519 private
 // key, accepting the PKCS1, SEC1 and PKCS8 encodings.
 func BlockToPrivateKey(block *pem.Block) (PrivateKey, error) {
+	if block == nil {
+		return nil, core.ErrInvalid
+	}
+
 	if block.Type == "PRIVATE KEY" || strings.HasSuffix(block.Type, " PRIVATE KEY") {
 		return parsePrivateKeyDER(block.Bytes)
 	}
@@ -75,6 +81,10 @@ func BlockToRSAPrivateKey(block *pem.Block) (*rsa.PrivateKey, error) {
 
 // BlockToCertificate attempts to parse a pem.Block to extract a x509.Certificate
 func BlockToCertificate(block *pem.Block) (*x509.Certificate, error) {
+	if block == nil {
+		return nil, core.ErrInvalid
+	}
+
 	if block.Type == "CERTIFICATE" {
 		cert, err := x509.ParseCertificate(block.Bytes)
 		if err != nil {

--- a/tls/x509utils/pem_block_test.go
+++ b/tls/x509utils/pem_block_test.go
@@ -1,6 +1,8 @@
 package x509utils_test
 
 import (
+	"crypto"
+	"crypto/ecdh"
 	"crypto/ecdsa"
 	"crypto/ed25519"
 	"crypto/rand"
@@ -14,7 +16,11 @@ import (
 	"darvaza.org/x/tls/x509utils"
 )
 
-var _ core.TestCase = blockToPrivateKeyTestCase{}
+var (
+	_ core.TestCase = blockToCertificateTestCase{}
+	_ core.TestCase = blockToPrivateKeyTestCase{}
+	_ core.TestCase = blockToRSAPrivateKeyTestCase{}
+)
 
 // mkRSAKey generates a fresh RSA key.
 func mkRSAKey(t *testing.T) *rsa.PrivateKey {
@@ -32,14 +38,24 @@ func mkEd25519Key(t *testing.T) ed25519.PrivateKey {
 	return key
 }
 
+// mkX25519Key generates a fresh X25519 key. It marshals to PKCS8 but is a
+// key-agreement key, not a crypto.Signer, so it is not an x509utils.PrivateKey.
+func mkX25519Key(t *testing.T) *ecdh.PrivateKey {
+	t.Helper()
+	key, err := ecdh.X25519().GenerateKey(rand.Reader)
+	core.AssertMustNoError(t, err, "generate X25519 key")
+	return key
+}
+
 // pkcs1Block wraps an RSA key as a PKCS1 "RSA PRIVATE KEY" block.
 func pkcs1Block(t *testing.T, key *rsa.PrivateKey) *pem.Block {
 	t.Helper()
 	return &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)}
 }
 
-// pkcs8Block wraps any key as a PKCS8 "PRIVATE KEY" block.
-func pkcs8Block(t *testing.T, key x509utils.PrivateKey) *pem.Block {
+// pkcs8Block wraps any PKCS8-marshallable key as a "PRIVATE KEY" block,
+// including key types (such as X25519) that are not x509utils.PrivateKey.
+func pkcs8Block(t *testing.T, key crypto.PrivateKey) *pem.Block {
 	t.Helper()
 	der, err := x509.MarshalPKCS8PrivateKey(key)
 	core.AssertMustNoError(t, err, "marshal PKCS8")
@@ -73,9 +89,7 @@ func newBlockToPrivateKeyTestCase(name string, block *pem.Block,
 	}
 }
 
-func (tc blockToPrivateKeyTestCase) Name() string {
-	return tc.name
-}
+func (tc blockToPrivateKeyTestCase) Name() string { return tc.name }
 
 func (tc blockToPrivateKeyTestCase) Test(t *testing.T) {
 	t.Helper()
@@ -108,6 +122,10 @@ func blockToPrivateKeyTestCases(t *testing.T) []blockToPrivateKeyTestCase {
 			sec1Block(t, ecKey), ecKey, nil),
 		newBlockToPrivateKeyTestCase("Ed25519 PKCS8",
 			pkcs8Block(t, edKey), edKey, nil),
+		// X25519 parses as PKCS8 but is not a crypto.Signer, so the
+		// PrivateKey assertion fails: ErrNotSupported, not a defensive arm.
+		newBlockToPrivateKeyTestCase("X25519 PKCS8 unsupported",
+			pkcs8Block(t, mkX25519Key(t)), nil, x509utils.ErrNotSupported),
 		newBlockToPrivateKeyTestCase("certificate block",
 			&pem.Block{Type: "CERTIFICATE"}, nil, x509utils.ErrIgnored),
 	)
@@ -115,6 +133,18 @@ func blockToPrivateKeyTestCases(t *testing.T) []blockToPrivateKeyTestCase {
 
 func TestBlockToPrivateKey(t *testing.T) {
 	core.RunTestCases(t, blockToPrivateKeyTestCases(t))
+}
+
+// TestBlockToPrivateKeyMalformed covers parsePKCS8PrivateKey's parse-error arm:
+// a PRIVATE KEY block whose bytes are rejected by the PKCS1, SEC1 and PKCS8
+// decoders in turn surfaces x509's parse error.
+func TestBlockToPrivateKeyMalformed(t *testing.T) {
+	got, err := x509utils.BlockToPrivateKey(&pem.Block{
+		Type:  "PRIVATE KEY",
+		Bytes: []byte("not der"),
+	})
+	core.AssertError(t, err, "parse error")
+	core.AssertNil(t, got, "key")
 }
 
 // TestBlockNilGuards checks the public block parsers reject a nil *pem.Block
@@ -132,4 +162,173 @@ func TestBlockNilGuards(t *testing.T) {
 		_, err := x509utils.BlockToCertificate(nil)
 		core.AssertErrorIs(t, err, core.ErrInvalid, "error")
 	})
+}
+
+// blockToCertificateTestCase feeds a PEM block to BlockToCertificate and checks
+// the returned error and, on success, that it parses back to the original cert.
+type blockToCertificateTestCase struct {
+	want    *x509.Certificate
+	wantErr error
+	block   *pem.Block
+	name    string
+}
+
+func newBlockToCertificateTestCase(name string, block *pem.Block,
+	want *x509.Certificate, wantErr error) blockToCertificateTestCase {
+	return blockToCertificateTestCase{
+		want:    want,
+		wantErr: wantErr,
+		block:   block,
+		name:    name,
+	}
+}
+
+func (tc blockToCertificateTestCase) Name() string { return tc.name }
+
+func (tc blockToCertificateTestCase) Test(t *testing.T) {
+	t.Helper()
+
+	got, err := x509utils.BlockToCertificate(tc.block)
+	if tc.wantErr != nil {
+		core.AssertErrorIs(t, err, tc.wantErr, "error")
+		core.AssertNil(t, got, "cert")
+		return
+	}
+
+	core.AssertMustNoError(t, err, "parse")
+	core.AssertMustNotNil(t, got, "cert")
+	core.AssertTrue(t, got.Equal(tc.want), "round-trip")
+}
+
+func blockToCertificateTestCases(t *testing.T) []blockToCertificateTestCase {
+	t.Helper()
+
+	cert := certSpec{cn: "block.test"}.build(t).cert
+
+	return core.S(
+		newBlockToCertificateTestCase("certificate",
+			&pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw}, cert, nil),
+		newBlockToCertificateTestCase("wrong type",
+			&pem.Block{Type: "PRIVATE KEY"}, nil, x509utils.ErrIgnored),
+	)
+}
+
+func TestBlockToCertificate(t *testing.T) {
+	core.RunTestCases(t, blockToCertificateTestCases(t))
+}
+
+// TestBlockToCertificateMalformed covers the parse-error arm: a CERTIFICATE
+// block whose bytes are not valid DER surfaces x509's parse error.
+func TestBlockToCertificateMalformed(t *testing.T) {
+	got, err := x509utils.BlockToCertificate(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: []byte("not der"),
+	})
+	core.AssertError(t, err, "parse error")
+	core.AssertNil(t, got, "cert")
+}
+
+// blockToRSAPrivateKeyTestCase feeds a PEM block to BlockToRSAPrivateKey and
+// checks the type-assertion arms after a successful parse: a genuine RSA key
+// round-trips, any other key type is ErrIgnored.
+type blockToRSAPrivateKeyTestCase struct {
+	want    *rsa.PrivateKey
+	wantErr error
+	block   *pem.Block
+	name    string
+}
+
+func newBlockToRSAPrivateKeyTestCase(name string, block *pem.Block,
+	want *rsa.PrivateKey, wantErr error) blockToRSAPrivateKeyTestCase {
+	return blockToRSAPrivateKeyTestCase{
+		want:    want,
+		wantErr: wantErr,
+		block:   block,
+		name:    name,
+	}
+}
+
+func (tc blockToRSAPrivateKeyTestCase) Name() string { return tc.name }
+
+func (tc blockToRSAPrivateKeyTestCase) Test(t *testing.T) {
+	t.Helper()
+
+	got, err := x509utils.BlockToRSAPrivateKey(tc.block)
+	if tc.wantErr != nil {
+		core.AssertErrorIs(t, err, tc.wantErr, "error")
+		core.AssertNil(t, got, "key")
+		return
+	}
+
+	core.AssertMustNoError(t, err, "parse")
+	core.AssertMustNotNil(t, got, "key")
+	core.AssertTrue(t, got.Equal(tc.want), "round-trip")
+}
+
+func blockToRSAPrivateKeyTestCases(t *testing.T) []blockToRSAPrivateKeyTestCase {
+	t.Helper()
+
+	rsaKey := mkRSAKey(t)
+
+	return core.S(
+		newBlockToRSAPrivateKeyTestCase("RSA PKCS1",
+			pkcs1Block(t, rsaKey), rsaKey, nil),
+		newBlockToRSAPrivateKeyTestCase("EC ignored",
+			pkcs8Block(t, mkKey(t)), nil, x509utils.ErrIgnored),
+	)
+}
+
+func TestBlockToRSAPrivateKey(t *testing.T) {
+	core.RunTestCases(t, blockToRSAPrivateKeyTestCases(t))
+}
+
+// TestEncodePKCS1PrivateKey covers the nil-key arm (empty output) and the
+// round-trip: the PEM it produces parses back to the original RSA key.
+func TestEncodePKCS1PrivateKey(t *testing.T) {
+	core.AssertNil(t, x509utils.EncodePKCS1PrivateKey(nil), "nil key")
+
+	key := mkRSAKey(t)
+	block, _ := pem.Decode(x509utils.EncodePKCS1PrivateKey(key))
+	core.AssertMustNotNil(t, block, "block")
+	got, err := x509utils.BlockToPrivateKey(block)
+	core.AssertMustNoError(t, err, "parse")
+	core.AssertMustNotNil(t, got, "key")
+	core.AssertTrue(t, got.Equal(key), "round-trip")
+}
+
+// TestEncodePKCS8PrivateKey covers the nil-key arm (empty output, no error),
+// the marshal-error arm (a key type PKCS8 rejects) and the round-trip.
+func TestEncodePKCS8PrivateKey(t *testing.T) {
+	out, err := x509utils.EncodePKCS8PrivateKey(nil)
+	core.AssertNoError(t, err, "nil key")
+	core.AssertNil(t, out, "nil output")
+
+	_, err = x509utils.EncodePKCS8PrivateKey(unsupportedKey{})
+	core.AssertError(t, err, "unsupported")
+
+	key := mkKey(t)
+	out, err = x509utils.EncodePKCS8PrivateKey(key)
+	core.AssertMustNoError(t, err, "encode")
+	block, _ := pem.Decode(out)
+	core.AssertMustNotNil(t, block, "block")
+	got, err := x509utils.BlockToPrivateKey(block)
+	core.AssertMustNoError(t, err, "parse")
+	core.AssertMustNotNil(t, got, "key")
+	core.AssertTrue(t, got.Equal(key), "round-trip")
+}
+
+// TestEncodeCertificate covers the certificate encode path, and EncodeBytes
+// underneath: the PEM it produces is a CERTIFICATE block that parses back to
+// the original certificate.
+func TestEncodeCertificate(t *testing.T) {
+	cert := certSpec{cn: "encode.test"}.build(t).cert
+
+	block, _ := pem.Decode(x509utils.EncodeCertificate(cert.Raw))
+	core.AssertMustNotNil(t, block, "block")
+	core.AssertEqual(t, "CERTIFICATE", block.Type, "type")
+
+	got, err := x509utils.BlockToCertificate(block)
+	core.AssertMustNoError(t, err, "parse")
+	core.AssertMustNotNil(t, got, "cert")
+	core.AssertTrue(t, got.Equal(cert), "round-trip")
 }

--- a/tls/x509utils/pem_block_test.go
+++ b/tls/x509utils/pem_block_test.go
@@ -1,0 +1,118 @@
+package x509utils_test
+
+import (
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"testing"
+
+	"darvaza.org/core"
+
+	"darvaza.org/x/tls/x509utils"
+)
+
+var _ core.TestCase = blockToPrivateKeyTestCase{}
+
+// mkRSAKey generates a fresh RSA key.
+func mkRSAKey(t *testing.T) *rsa.PrivateKey {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	core.AssertMustNoError(t, err, "generate RSA key")
+	return key
+}
+
+// mkEd25519Key generates a fresh Ed25519 key.
+func mkEd25519Key(t *testing.T) ed25519.PrivateKey {
+	t.Helper()
+	_, key, err := ed25519.GenerateKey(rand.Reader)
+	core.AssertMustNoError(t, err, "generate Ed25519 key")
+	return key
+}
+
+// pkcs1Block wraps an RSA key as a PKCS1 "RSA PRIVATE KEY" block.
+func pkcs1Block(t *testing.T, key *rsa.PrivateKey) *pem.Block {
+	t.Helper()
+	return &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)}
+}
+
+// pkcs8Block wraps any key as a PKCS8 "PRIVATE KEY" block.
+func pkcs8Block(t *testing.T, key x509utils.PrivateKey) *pem.Block {
+	t.Helper()
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	core.AssertMustNoError(t, err, "marshal PKCS8")
+	return &pem.Block{Type: "PRIVATE KEY", Bytes: der}
+}
+
+// sec1Block wraps an ECDSA key as a SEC1 "EC PRIVATE KEY" block.
+func sec1Block(t *testing.T, key *ecdsa.PrivateKey) *pem.Block {
+	t.Helper()
+	der, err := x509.MarshalECPrivateKey(key)
+	core.AssertMustNoError(t, err, "marshal SEC1")
+	return &pem.Block{Type: "EC PRIVATE KEY", Bytes: der}
+}
+
+// blockToPrivateKeyTestCase feeds a PEM block to BlockToPrivateKey and checks
+// the returned error and, on success, that the key round-trips to the original.
+type blockToPrivateKeyTestCase struct {
+	want    x509utils.PrivateKey
+	wantErr error
+	block   *pem.Block
+	name    string
+}
+
+func newBlockToPrivateKeyTestCase(name string, block *pem.Block,
+	want x509utils.PrivateKey, wantErr error) blockToPrivateKeyTestCase {
+	return blockToPrivateKeyTestCase{
+		want:    want,
+		wantErr: wantErr,
+		block:   block,
+		name:    name,
+	}
+}
+
+func (tc blockToPrivateKeyTestCase) Name() string {
+	return tc.name
+}
+
+func (tc blockToPrivateKeyTestCase) Test(t *testing.T) {
+	t.Helper()
+
+	got, err := x509utils.BlockToPrivateKey(tc.block)
+	if tc.wantErr != nil {
+		core.AssertErrorIs(t, err, tc.wantErr, "error")
+		core.AssertNil(t, got, "key")
+		return
+	}
+
+	core.AssertMustNoError(t, err, "parse")
+	core.AssertMustNotNil(t, got, "key")
+	core.AssertTrue(t, got.Equal(tc.want), "key round-trip")
+}
+
+func blockToPrivateKeyTestCases(t *testing.T) []blockToPrivateKeyTestCase {
+	t.Helper()
+
+	rsaKey := mkRSAKey(t)
+	ecKey := mkKey(t)
+	edKey := mkEd25519Key(t)
+
+	return core.S(
+		newBlockToPrivateKeyTestCase("RSA PKCS1",
+			pkcs1Block(t, rsaKey), rsaKey, nil),
+		newBlockToPrivateKeyTestCase("EC PKCS8",
+			pkcs8Block(t, ecKey), ecKey, nil),
+		newBlockToPrivateKeyTestCase("EC SEC1",
+			sec1Block(t, ecKey), ecKey, nil),
+		newBlockToPrivateKeyTestCase("Ed25519 PKCS8",
+			pkcs8Block(t, edKey), edKey, nil),
+		newBlockToPrivateKeyTestCase("certificate block",
+			&pem.Block{Type: "CERTIFICATE"}, nil, x509utils.ErrIgnored),
+	)
+}
+
+func TestBlockToPrivateKey(t *testing.T) {
+	core.RunTestCases(t, blockToPrivateKeyTestCases(t))
+}

--- a/tls/x509utils/pem_block_test.go
+++ b/tls/x509utils/pem_block_test.go
@@ -116,3 +116,20 @@ func blockToPrivateKeyTestCases(t *testing.T) []blockToPrivateKeyTestCase {
 func TestBlockToPrivateKey(t *testing.T) {
 	core.RunTestCases(t, blockToPrivateKeyTestCases(t))
 }
+
+// TestBlockNilGuards checks the public block parsers reject a nil *pem.Block
+// with core.ErrInvalid instead of dereferencing it and panicking (F63).
+func TestBlockNilGuards(t *testing.T) {
+	t.Run("BlockToPrivateKey", func(t *testing.T) {
+		_, err := x509utils.BlockToPrivateKey(nil)
+		core.AssertErrorIs(t, err, core.ErrInvalid, "error")
+	})
+	t.Run("BlockToRSAPrivateKey", func(t *testing.T) {
+		_, err := x509utils.BlockToRSAPrivateKey(nil)
+		core.AssertErrorIs(t, err, core.ErrInvalid, "error")
+	})
+	t.Run("BlockToCertificate", func(t *testing.T) {
+		_, err := x509utils.BlockToCertificate(nil)
+		core.AssertErrorIs(t, err, core.ErrInvalid, "error")
+	})
+}

--- a/tls/x509utils/pem_read.go
+++ b/tls/x509utils/pem_read.go
@@ -2,6 +2,7 @@ package x509utils
 
 import (
 	"encoding/pem"
+	"errors"
 	"io/fs"
 	"os"
 	"path"
@@ -171,11 +172,11 @@ func (r *readOptions) run(s string) error {
 		return r.readPathPEM(s, st)
 	}
 
-	if pe, ok := err.(*os.PathError); ok {
-		if pe.Err == os.ErrInvalid {
-			// not a path
-			err = fs.ErrInvalid
-		}
+	var pe *fs.PathError
+	if errors.As(err, &pe) && errors.Is(pe.Err, fs.ErrInvalid) {
+		// stat rejected the string as an invalid path; surface the bare
+		// sentinel rather than the PathError wrapping it.
+		err = fs.ErrInvalid
 	}
 
 	return err

--- a/tls/x509utils/pem_read.go
+++ b/tls/x509utils/pem_read.go
@@ -5,6 +5,7 @@ import (
 	"io/fs"
 	"os"
 	"path"
+	"strings"
 
 	"darvaza.org/core"
 )
@@ -14,29 +15,31 @@ import (
 type DecodePEMBlockFunc func(fSys fs.FS, filename string, block *pem.Block) bool
 
 // ReadPEM invokes a callback for each PEM block found in the input data.
-// It returns ErrEmpty if the input is empty, core.ErrInvalid if it
-// fails to decode.
+// It returns ErrEmpty if the input is empty, and core.ErrInvalid if no
+// PEM block is found at all. Non-PEM text around the blocks is skipped,
+// matching [pem.Decode]'s tolerance for surrounding commentary.
 func ReadPEM(b []byte, cb DecodePEMBlockFunc) error {
-	var block *pem.Block
-
 	if len(b) == 0 {
 		return ErrEmpty
 	}
 
-	for {
-		block, b = pem.Decode(b)
-		switch {
-		case block == nil:
-			// failed to decode
-			return core.ErrInvalid
-		case cb != nil && !cb(nil, "", block):
+	block, rest := pem.Decode(b)
+	if block == nil {
+		// no PEM block in the input
+		return core.ErrInvalid
+	}
+
+	for block != nil {
+		if cb != nil && !cb(nil, "", block) {
 			// aborted
 			return nil
-		case len(b) == 0:
-			// EOF
-			return nil
 		}
+
+		block, rest = pem.Decode(rest)
 	}
+
+	// EOF; trailing non-PEM content after the last block is skipped
+	return nil
 }
 
 // ReadFilePEM reads a PEM file calling cb for each block
@@ -142,10 +145,24 @@ type readOptions struct {
 	dirs bool
 }
 
+// maxPathLen caps how long a string can still be considered a
+// candidate file name once it failed to parse as raw PEM. It matches
+// Linux's PATH_MAX, which includes the terminating NUL, so a path of
+// this length is already impossible.
+const maxPathLen = 4096
+
 func (r *readOptions) run(s string) error {
 	if ReadPEM([]byte(s), r.cb) == nil {
 		// raw. done.
 		return nil
+	}
+
+	// not a possible path, don't bother stat-ing
+	switch {
+	case len(s) >= maxPathLen:
+		return newInvalidPathError("stat", s, "path too long")
+	case strings.Contains(s, "\x00"):
+		return newInvalidPathError("stat", s, "NUL byte in path")
 	}
 
 	st, err := r.stat(s)
@@ -175,11 +192,7 @@ func (r *readOptions) stat(s string) (fs.FileInfo, error) {
 func (r *readOptions) readDirPEM(s string) error {
 	switch {
 	case !r.dirs:
-		return &fs.PathError{
-			Op:   "Read",
-			Path: s,
-			Err:  core.Wrap(core.ErrInvalid, "directories support disabled"),
-		}
+		return newInvalidPathError("read", s, "directories support disabled")
 	case r.fs == nil:
 		return ReadDirPEM(os.DirFS(s), ".", r.cb)
 	default:

--- a/tls/x509utils/pem_read_test.go
+++ b/tls/x509utils/pem_read_test.go
@@ -1,0 +1,215 @@
+package x509utils_test
+
+import (
+	"bytes"
+	"encoding/pem"
+	"io/fs"
+	"strings"
+	"testing"
+	"testing/fstest"
+
+	"darvaza.org/core"
+
+	"darvaza.org/x/tls/x509utils"
+)
+
+var (
+	_ core.TestCase = readPEMTestCase{}
+	_ core.TestCase = readStringPEMTestCase{}
+)
+
+// newBlockCounter returns a callback counting the blocks it receives,
+// asserting each one is non-nil.
+func newBlockCounter(t *testing.T, got *int) x509utils.DecodePEMBlockFunc {
+	return func(_ fs.FS, _ string, block *pem.Block) bool {
+		core.AssertNotNil(t, block, "block")
+		*got++
+		return true
+	}
+}
+
+// checkReadPEMResult asserts the error and delivered-block count of a
+// ReadPEM/ReadStringPEM call.
+func checkReadPEMResult(t *testing.T, wantErr, err error,
+	wantBlocks, got int) {
+	t.Helper()
+
+	if wantErr == nil {
+		core.AssertNoError(t, err, "read")
+	} else {
+		core.AssertErrorIs(t, err, wantErr, "error")
+	}
+	core.AssertEqual(t, wantBlocks, got, "blocks")
+}
+
+// readPEMTestCase feeds raw input to ReadPEM and checks the returned
+// error and how many blocks reached the callback.
+type readPEMTestCase struct {
+	wantErr    error
+	name       string
+	input      string
+	wantBlocks int
+}
+
+func newReadPEMTestCase(name, input string, wantErr error,
+	wantBlocks int) readPEMTestCase {
+	return readPEMTestCase{
+		name:       name,
+		input:      input,
+		wantErr:    wantErr,
+		wantBlocks: wantBlocks,
+	}
+}
+
+func (tc readPEMTestCase) Name() string {
+	return tc.name
+}
+
+func (tc readPEMTestCase) Test(t *testing.T) {
+	t.Helper()
+
+	var got int
+	err := x509utils.ReadPEM([]byte(tc.input), newBlockCounter(t, &got))
+	checkReadPEMResult(t, tc.wantErr, err, tc.wantBlocks, got)
+}
+
+func readPEMTestCases() []readPEMTestCase {
+	block := string(pem.EncodeToMemory(&pem.Block{
+		Type:  "TEST BLOCK",
+		Bytes: []byte("test data"),
+	}))
+
+	return core.S(
+		newReadPEMTestCase("empty input", "", x509utils.ErrEmpty, 0),
+		newReadPEMTestCase("garbage only", "no PEM here\n",
+			core.ErrInvalid, 0),
+		newReadPEMTestCase("single block", block, nil, 1),
+		newReadPEMTestCase("trailing blank line", block+"\n", nil, 1),
+		newReadPEMTestCase("trailing garbage",
+			block+"trailing text\n", nil, 1),
+		newReadPEMTestCase("two blocks", block+block, nil, 2),
+		newReadPEMTestCase("text between blocks",
+			block+"subject=test\n"+block, nil, 2),
+	)
+}
+
+func TestReadPEM(t *testing.T) {
+	core.RunTestCases(t, readPEMTestCases())
+}
+
+// readStringPEMTestCase feeds a string to ReadStringPEM and checks the
+// returned error and how many blocks reached the callback.
+type readStringPEMTestCase struct {
+	wantErr    error
+	name       string
+	input      string
+	wantBlocks int
+}
+
+func newReadStringPEMTestCase(name, input string, wantErr error,
+	wantBlocks int) readStringPEMTestCase {
+	return readStringPEMTestCase{
+		name:       name,
+		input:      input,
+		wantErr:    wantErr,
+		wantBlocks: wantBlocks,
+	}
+}
+
+func (tc readStringPEMTestCase) Name() string {
+	return tc.name
+}
+
+func (tc readStringPEMTestCase) Test(t *testing.T) {
+	t.Helper()
+
+	var got int
+	err := x509utils.ReadStringPEM(tc.input, newBlockCounter(t, &got))
+	checkReadPEMResult(t, tc.wantErr, err, tc.wantBlocks, got)
+}
+
+func readStringPEMTestCases(t *testing.T) []readStringPEMTestCase {
+	t.Helper()
+
+	block := string(pem.EncodeToMemory(&pem.Block{
+		Type:  "TEST BLOCK",
+		Bytes: []byte("test data"),
+	}))
+	missing := filepath.Join(t.TempDir(), "missing.pem")
+
+	return core.S(
+		newReadStringPEMTestCase("raw block", block, nil, 1),
+		newReadStringPEMTestCase("raw block trailing blank line",
+			block+"\n", nil, 1),
+		newReadStringPEMTestCase("missing path",
+			missing, fs.ErrNotExist, 0),
+		// exactly PATH_MAX: the boundary row — a path this long is
+		// impossible, so the guard must fire without a stat.
+		newReadStringPEMTestCase("overlong non-path",
+			strings.Repeat("#", 4096), fs.ErrInvalid, 0),
+		newReadStringPEMTestCase("NUL byte non-path",
+			"not\x00a-path", fs.ErrInvalid, 0),
+	)
+}
+
+func TestReadStringPEM(t *testing.T) {
+	core.RunTestCases(t, readStringPEMTestCases(t))
+}
+
+// TestReadStringPEMNotPathReasons pins the split between the two
+// not-a-possible-path guard errors; both satisfy fs.ErrInvalid
+// (asserted by the table above) but state different reasons.
+func TestReadStringPEMNotPathReasons(t *testing.T) {
+	err := x509utils.ReadStringPEM(strings.Repeat("#", 4096), nil)
+	core.AssertMustError(t, err, "overlong")
+	core.AssertContains(t, err.Error(), "path too long", "overlong reason")
+	// the blob is clamped, not echoed whole, into the path error.
+	pe := core.AssertMustTypeIs[*fs.PathError](t, err, "overlong path")
+	core.AssertContains(t, pe.Path, "… (4096 bytes)", "overlong clamped")
+	core.AssertTrue(t, len(pe.Path) < 4096, "overlong bounded")
+
+	err = x509utils.ReadStringPEM("not\x00a-path", nil)
+	core.AssertMustError(t, err, "NUL byte")
+	core.AssertContains(t, err.Error(), "NUL byte in path", "NUL reason")
+}
+
+// TestReadStringPEMDirsDisabled reaches readDirPEM's guard: a path that
+// stat resolves to a directory is rejected as invalid, rather than scanned,
+// when directory support is turned off.
+func TestReadStringPEMDirsDisabled(t *testing.T) {
+	fSys := fstest.MapFS{
+		"certs/leaf.pem": &fstest.MapFile{Data: []byte("data")},
+	}
+
+	err := x509utils.ReadStringPEM("certs", nil,
+		x509utils.ReadWithFS(fSys), x509utils.ReadWithoutDirs())
+
+	core.AssertMustError(t, err, "disabled")
+	core.AssertErrorIs(t, err, fs.ErrInvalid, "invalid")
+	core.AssertContains(t, err.Error(),
+		"directories support disabled", "reason")
+
+	// the op stays lowercase, matching fs.PathError convention.
+	pe := core.AssertMustTypeIs[*fs.PathError](t, err, "PathError")
+	core.AssertEqual(t, "read", pe.Op, "op")
+}
+
+// TestReadPEMAbort stops the walk when the callback returns false, leaving the
+// remaining blocks undelivered.
+func TestReadPEMAbort(t *testing.T) {
+	block := pem.EncodeToMemory(&pem.Block{
+		Type:  "TEST BLOCK",
+		Bytes: []byte("test data"),
+	})
+
+	var got int
+	cb := func(_ fs.FS, _ string, _ *pem.Block) bool {
+		got++
+		return false // abort after the first block
+	}
+
+	// two identical blocks; the callback must stop the walk at the first.
+	err := x509utils.ReadPEM(bytes.Repeat(block, 2), cb)
+	core.AssertNoError(t, err, "abort")
+	core.AssertEqual(t, 1, got, "blocks")
+}

--- a/tls/x509utils/pem_read_test.go
+++ b/tls/x509utils/pem_read_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"encoding/pem"
 	"io/fs"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"testing/fstest"
@@ -14,6 +16,9 @@ import (
 )
 
 var (
+	_ core.TestCase = nilOptionTestCase{}
+	_ core.TestCase = readDirPEMTestCase{}
+	_ core.TestCase = readFilePEMTestCase{}
 	_ core.TestCase = readPEMTestCase{}
 	_ core.TestCase = readStringPEMTestCase{}
 )
@@ -212,4 +217,286 @@ func TestReadPEMAbort(t *testing.T) {
 	err := x509utils.ReadPEM(bytes.Repeat(block, 2), cb)
 	core.AssertNoError(t, err, "abort")
 	core.AssertEqual(t, 1, got, "blocks")
+}
+
+// testPEM encodes a single test PEM block.
+func testPEM() []byte {
+	return pem.EncodeToMemory(&pem.Block{
+		Type:  "TEST BLOCK",
+		Bytes: []byte("test data"),
+	})
+}
+
+// pemGoodFS is a small tree of valid PEM files: three blocks in total, one at
+// the root and two in a sub-directory, so a recursive read must descend.
+func pemGoodFS() fstest.MapFS {
+	one := testPEM()
+	two := append(testPEM(), testPEM()...)
+	return fstest.MapFS{
+		"a.pem":       &fstest.MapFile{Data: one},
+		"sub/two.pem": &fstest.MapFile{Data: two},
+	}
+}
+
+// pemMixedFS adds a non-PEM file to the good tree, so a directory read reports
+// an error while still delivering the valid blocks.
+func pemMixedFS() fstest.MapFS {
+	fSys := pemGoodFS()
+	fSys["bad.txt"] = &fstest.MapFile{Data: []byte("not pem\n")}
+	return fSys
+}
+
+// pemBadSubdirFS places the non-PEM file inside the sub-directory, so the error
+// surfaces from the recursive descent rather than the top-level files.
+func pemBadSubdirFS() fstest.MapFS {
+	fSys := pemGoodFS()
+	fSys["sub/bad.txt"] = &fstest.MapFile{Data: []byte("not pem\n")}
+	return fSys
+}
+
+// failReadFS resolves like its embedded MapFS — so stat still reports a file —
+// but fails every ReadFile, to exercise the read-error path after a successful
+// stat.
+type failReadFS struct{ fstest.MapFS }
+
+func (failReadFS) ReadFile(string) ([]byte, error) {
+	return nil, fs.ErrPermission
+}
+
+// invalidStatFS reports every path as an invalid argument, to drive run's
+// normalisation of a stat "invalid" error down to the bare fs sentinel.
+type invalidStatFS struct{ fstest.MapFS }
+
+func (invalidStatFS) Stat(string) (fs.FileInfo, error) {
+	return nil, &fs.PathError{Op: "stat", Path: "x", Err: fs.ErrInvalid}
+}
+
+// invalidPlainFS reports an invalid-wrapping error that is not a PathError, so
+// run must leave it intact rather than collapse it to the bare sentinel.
+type invalidPlainFS struct{ fstest.MapFS }
+
+func (invalidPlainFS) Stat(string) (fs.FileInfo, error) {
+	return nil, core.Wrap(fs.ErrInvalid, "stat quirk")
+}
+
+// readFilePEMTestCase feeds a single file to ReadFilePEM and checks the
+// delivered block count and error.
+type readFilePEMTestCase struct {
+	wantErr    error
+	fSys       fs.FS
+	name       string
+	file       string
+	wantBlocks int
+}
+
+func newReadFilePEMTestCase(name string, fSys fs.FS, file string,
+	wantErr error, wantBlocks int) readFilePEMTestCase {
+	return readFilePEMTestCase{
+		name:       name,
+		fSys:       fSys,
+		file:       file,
+		wantErr:    wantErr,
+		wantBlocks: wantBlocks,
+	}
+}
+
+func (tc readFilePEMTestCase) Name() string { return tc.name }
+
+func (tc readFilePEMTestCase) Test(t *testing.T) {
+	t.Helper()
+
+	var got int
+	err := x509utils.ReadFilePEM(tc.fSys, tc.file, newBlockCounter(t, &got))
+	checkReadPEMResult(t, tc.wantErr, err, tc.wantBlocks, got)
+}
+
+func readFilePEMTestCases() []readFilePEMTestCase {
+	fSys := pemGoodFS()
+	return core.S(
+		newReadFilePEMTestCase("single block", fSys, "a.pem", nil, 1),
+		newReadFilePEMTestCase("two blocks", fSys, "sub/two.pem", nil, 2),
+		newReadFilePEMTestCase("non-PEM file", pemMixedFS(), "bad.txt",
+			core.ErrInvalid, 0),
+		newReadFilePEMTestCase("missing file", fSys, "missing.pem",
+			fs.ErrNotExist, 0),
+	)
+}
+
+func TestReadFilePEM(t *testing.T) {
+	core.RunTestCases(t, readFilePEMTestCases())
+}
+
+// TestReadFilePEMDecodeError pins the wrapper ReadFilePEM puts around a decode
+// failure: an fs.PathError tagged pem.Decode that still matches core.ErrInvalid.
+func TestReadFilePEMDecodeError(t *testing.T) {
+	err := x509utils.ReadFilePEM(pemMixedFS(), "bad.txt", nil)
+
+	pe := core.AssertMustTypeIs[*fs.PathError](t, err, "PathError")
+	core.AssertEqual(t, "pem.Decode", pe.Op, "op")
+	core.AssertErrorIs(t, err, core.ErrInvalid, "invalid")
+}
+
+// readDirPEMTestCase feeds a directory to ReadDirPEM and checks the total
+// blocks delivered across the tree and the aggregate error.
+type readDirPEMTestCase struct {
+	wantErr    error
+	fSys       fs.FS
+	name       string
+	dir        string
+	wantBlocks int
+}
+
+func newReadDirPEMTestCase(name string, fSys fs.FS, dir string,
+	wantErr error, wantBlocks int) readDirPEMTestCase {
+	return readDirPEMTestCase{
+		name:       name,
+		fSys:       fSys,
+		dir:        dir,
+		wantErr:    wantErr,
+		wantBlocks: wantBlocks,
+	}
+}
+
+func (tc readDirPEMTestCase) Name() string { return tc.name }
+
+func (tc readDirPEMTestCase) Test(t *testing.T) {
+	t.Helper()
+
+	var got int
+	err := x509utils.ReadDirPEM(tc.fSys, tc.dir, newBlockCounter(t, &got))
+	checkReadPEMResult(t, tc.wantErr, err, tc.wantBlocks, got)
+}
+
+func readDirPEMTestCases() []readDirPEMTestCase {
+	return core.S(
+		// descends into sub/ to reach the two blocks there.
+		newReadDirPEMTestCase("recursive", pemGoodFS(), ".", nil, 3),
+		// the non-PEM file fails, yet the valid blocks are still delivered.
+		newReadDirPEMTestCase("aggregates errors", pemMixedFS(), ".",
+			core.ErrInvalid, 3),
+		// same, but the failing file lives in the sub-directory, so the error
+		// bubbles up through the recursive descent.
+		newReadDirPEMTestCase("aggregates subdir errors", pemBadSubdirFS(), ".",
+			core.ErrInvalid, 3),
+		newReadDirPEMTestCase("missing dir", pemGoodFS(), "nope",
+			fs.ErrNotExist, 0),
+	)
+}
+
+func TestReadDirPEM(t *testing.T) {
+	core.RunTestCases(t, readDirPEMTestCases())
+}
+
+// TestReadDirPEMNilCallback covers the short-circuit: with no callback there is
+// nothing to run, so the walk is skipped without error.
+func TestReadDirPEMNilCallback(t *testing.T) {
+	err := x509utils.ReadDirPEM(pemGoodFS(), ".", nil)
+	core.AssertNoError(t, err, "nil cb")
+}
+
+// TestReadStringPEMFromFS covers the file and directory paths ReadStringPEM
+// resolves through a supplied fs.FS.
+func TestReadStringPEMFromFS(t *testing.T) {
+	fSys := pemGoodFS()
+
+	t.Run("file", func(t *testing.T) {
+		var got int
+		err := x509utils.ReadStringPEM("a.pem", newBlockCounter(t, &got),
+			x509utils.ReadWithFS(fSys))
+		core.AssertNoError(t, err, "read")
+		core.AssertEqual(t, 1, got, "blocks")
+	})
+
+	t.Run("directory", func(t *testing.T) {
+		var got int
+		err := x509utils.ReadStringPEM(".", newBlockCounter(t, &got),
+			x509utils.ReadWithFS(fSys), x509utils.ReadWithDirs())
+		core.AssertNoError(t, err, "read")
+		core.AssertEqual(t, 3, got, "blocks")
+	})
+}
+
+// TestReadStringPEMFromDisk covers the os-backed stat, read and directory paths
+// taken when no fs.FS is supplied.
+func TestReadStringPEMFromDisk(t *testing.T) {
+	dir := t.TempDir()
+	err := os.WriteFile(filepath.Join(dir, "leaf.pem"), testPEM(), 0o600)
+	core.AssertMustNoError(t, err, "write")
+
+	t.Run("file", func(t *testing.T) {
+		var got int
+		err := x509utils.ReadStringPEM(filepath.Join(dir, "leaf.pem"),
+			newBlockCounter(t, &got))
+		core.AssertNoError(t, err, "read")
+		core.AssertEqual(t, 1, got, "blocks")
+	})
+
+	t.Run("directory", func(t *testing.T) {
+		var got int
+		err := x509utils.ReadStringPEM(dir, newBlockCounter(t, &got))
+		core.AssertNoError(t, err, "read")
+		core.AssertEqual(t, 1, got, "blocks")
+	})
+}
+
+// TestReadStringPEMReadError covers the read-error path: stat resolves the
+// string to a file, but reading its contents fails.
+func TestReadStringPEMReadError(t *testing.T) {
+	fSys := failReadFS{pemGoodFS()}
+	err := x509utils.ReadStringPEM("a.pem", nil, x509utils.ReadWithFS(fSys))
+	core.AssertErrorIs(t, err, fs.ErrPermission, "read error")
+}
+
+// TestReadStringPEMInvalidStat covers run's normalisation: a stat PathError
+// that matches fs.ErrInvalid surfaces as the bare sentinel, not the wrapper.
+func TestReadStringPEMInvalidStat(t *testing.T) {
+	err := x509utils.ReadStringPEM("x", nil, x509utils.ReadWithFS(invalidStatFS{}))
+	core.AssertErrorIs(t, err, fs.ErrInvalid, "invalid")
+}
+
+// TestReadStringPEMInvalidNonPath pins the other side: a non-PathError error
+// wrapping fs.ErrInvalid is passed through intact, not collapsed.
+func TestReadStringPEMInvalidNonPath(t *testing.T) {
+	err := x509utils.ReadStringPEM("x", nil, x509utils.ReadWithFS(invalidPlainFS{}))
+	core.AssertErrorIs(t, err, fs.ErrInvalid, "invalid")
+	core.AssertContains(t, err.Error(), "stat quirk", "preserved")
+}
+
+// TestReadWithFSNil rejects a nil fs.FS: the option cannot resolve paths, so it
+// reports the misconfiguration as invalid.
+func TestReadWithFSNil(t *testing.T) {
+	err := x509utils.ReadStringPEM("whatever", nil, x509utils.ReadWithFS(nil))
+	core.AssertErrorIs(t, err, core.ErrInvalid, "nil fs")
+}
+
+// nilOptionTestCase applies a ReadOption to a nil *readOptions to reach the
+// shared nil-receiver guard, which is callable as Option()(nil) even though
+// ReadStringPEM only ever applies options to a live one.
+type nilOptionTestCase struct {
+	opt  x509utils.ReadOption
+	name string
+}
+
+func newNilOptionTestCase(name string,
+	opt x509utils.ReadOption) nilOptionTestCase {
+	return nilOptionTestCase{name: name, opt: opt}
+}
+
+func (tc nilOptionTestCase) Name() string { return tc.name }
+
+func (tc nilOptionTestCase) Test(t *testing.T) {
+	t.Helper()
+	core.AssertErrorIs(t, tc.opt(nil), core.ErrNilReceiver, "nil receiver")
+}
+
+func nilOptionTestCases() []nilOptionTestCase {
+	return core.S(
+		newNilOptionTestCase("ReadWithFS", x509utils.ReadWithFS(fstest.MapFS{})),
+		newNilOptionTestCase("ReadWithoutDirs", x509utils.ReadWithoutDirs()),
+		newNilOptionTestCase("ReadWithDirs", x509utils.ReadWithDirs()),
+	)
+}
+
+func TestReadOptionNilReceiver(t *testing.T) {
+	core.RunTestCases(t, nilOptionTestCases())
 }

--- a/tls/x509utils/pem_read_test.go
+++ b/tls/x509utils/pem_read_test.go
@@ -219,6 +219,15 @@ func TestReadPEMAbort(t *testing.T) {
 	core.AssertEqual(t, 1, got, "blocks")
 }
 
+// TestReadPEMNilCallback covers ReadPEM's nil-callback arm: with valid PEM and
+// no callback the decode loop runs every block to EOF and returns nil, rather
+// than invoking the absent callback (F70).
+func TestReadPEMNilCallback(t *testing.T) {
+	// two blocks, so the loop iterates with the callback skipped each time.
+	err := x509utils.ReadPEM(bytes.Repeat(testPEM(), 2), nil)
+	core.AssertNoError(t, err, "nil cb")
+}
+
 // testPEM encodes a single test PEM block.
 func testPEM() []byte {
 	return pem.EncodeToMemory(&pem.Block{

--- a/tls/x509utils/pem_write.go
+++ b/tls/x509utils/pem_write.go
@@ -35,25 +35,19 @@ func WriteCert(w io.Writer, cert *x509.Certificate) (int64, error) {
 
 	switch {
 	case cert == nil:
-		err := &ErrInvalidCert{Reason: "not provided"}
+		err := NewErrInvalidCert(nil, nil, "not provided")
 		return 0, err
 	case len(cert.Raw) == 0:
-		err := &ErrInvalidCert{Reason: "missing Raw DER certificate", Cert: cert}
+		err := NewErrInvalidCert(cert, nil, "missing Raw DER certificate")
 		return 0, err
 	}
 
-	err := pem.Encode(&buf, &pem.Block{
+	// cert.Raw is non-empty here and pem.Encode only fails when the writer
+	// does; a bytes.Buffer never does, so a non-nil error is unreachable.
+	core.MustNoError(pem.Encode(&buf, &pem.Block{
 		Type:  "CERTIFICATE",
 		Bytes: cert.Raw,
-	})
-	if err != nil {
-		err = &ErrInvalidCert{
-			Cert:   cert,
-			Err:    err,
-			Reason: "failed to encode certificate",
-		}
-		return 0, err
-	}
+	}))
 
 	return buf.WriteTo(w)
 }

--- a/tls/x509utils/pem_write.go
+++ b/tls/x509utils/pem_write.go
@@ -14,17 +14,15 @@ func WriteKey(w io.Writer, key PrivateKey) (int64, error) {
 	var buf bytes.Buffer
 
 	keyDER, err := x509.MarshalPKCS8PrivateKey(key)
-	if err == nil {
-		err = pem.Encode(&buf, &pem.Block{
-			Type:  "PRIVATE KEY",
-			Bytes: keyDER,
-		})
+	if err != nil {
+		return 0, core.Wrap(err, "failed to encode key")
 	}
 
-	if err != nil {
-		err = core.Wrap(err, "failed to encode key")
-		return 0, err
-	}
+	// pem.Encode to a bytes.Buffer cannot fail; only the writer can.
+	core.MustNoError(pem.Encode(&buf, &pem.Block{
+		Type:  "PRIVATE KEY",
+		Bytes: keyDER,
+	}))
 
 	return buf.WriteTo(w)
 }

--- a/tls/x509utils/pem_write_test.go
+++ b/tls/x509utils/pem_write_test.go
@@ -1,0 +1,98 @@
+package x509utils_test
+
+import (
+	"bytes"
+	"crypto/x509"
+	"errors"
+	"testing"
+
+	"darvaza.org/core"
+
+	"darvaza.org/x/tls/x509utils"
+)
+
+// errWrite is the failure a failing writer reports.
+var errWrite = errors.New("write failed")
+
+// errWriter fails every write, to drive WriteCert's flush-to-destination error
+// path after the certificate has already encoded.
+type errWriter struct{}
+
+func (errWriter) Write([]byte) (int, error) { return 0, errWrite }
+
+var _ core.TestCase = writeCertTestCase{}
+
+// writeCertTestCase exercises WriteCert: its two reachable rejection paths,
+// each an ErrInvalidCert built by NewErrInvalidCert, and the encoding path.
+type writeCertTestCase struct {
+	cert    *x509.Certificate
+	name    string
+	wantMsg string // empty => expect a PEM block, no error
+}
+
+func (tc writeCertTestCase) Name() string { return tc.name }
+
+func (tc writeCertTestCase) Test(t *testing.T) {
+	t.Helper()
+
+	var buf bytes.Buffer
+	n, err := x509utils.WriteCert(&buf, tc.cert)
+
+	if tc.wantMsg == "" {
+		core.AssertNoError(t, err, "error")
+		core.AssertEqual(t, int64(buf.Len()), n, "written")
+		core.AssertContains(t, buf.String(), "BEGIN CERTIFICATE", "pem")
+		return
+	}
+
+	core.AssertEqual(t, int64(0), n, "written")
+	if !core.AssertError(t, err, "error") {
+		return
+	}
+	core.AssertEqual(t, tc.wantMsg, err.Error(), "message")
+	// every WriteCert rejection defaults to core.ErrInvalid (F44).
+	core.AssertErrorIs(t, err, core.ErrInvalid, "invalid")
+
+	// the rejection threads the offending cert through unchanged.
+	ec := core.AssertMustTypeIs[*x509utils.ErrInvalidCert](t, err, "error")
+	core.AssertSame(t, tc.cert, ec.Cert, "cert")
+}
+
+func newWriteCertTestCase(name string, cert *x509.Certificate,
+	wantMsg string) writeCertTestCase {
+	return writeCertTestCase{
+		cert:    cert,
+		name:    name,
+		wantMsg: wantMsg,
+	}
+}
+
+func writeCertTestCases() []writeCertTestCase {
+	return core.S(
+		// nil cert: nothing to thread through, just a reason.
+		newWriteCertTestCase("nil", nil,
+			"invalid certificate: not provided"),
+		// a cert with no DER cannot be encoded; the cert is carried.
+		newWriteCertTestCase("empty raw", &x509.Certificate{},
+			"invalid certificate: missing Raw DER certificate"),
+		// pem.Encode wraps the Raw bytes verbatim; no parsing happens, so any
+		// non-empty Raw yields a PEM block.
+		newWriteCertTestCase("encodes raw",
+			&x509.Certificate{Raw: []byte("not real DER")}, ""),
+	)
+}
+
+func TestWriteCert(t *testing.T) {
+	core.RunTestCases(t, writeCertTestCases())
+}
+
+// TestWriteCertWriteError covers the writer-failure branch: the certificate
+// encodes into the buffer, but flushing it to the destination fails, so
+// WriteCert reports zero bytes written and the writer's error.
+func TestWriteCertWriteError(t *testing.T) {
+	cert := &x509.Certificate{Raw: []byte("not real DER")}
+
+	n, err := x509utils.WriteCert(errWriter{}, cert)
+	core.AssertEqual(t, int64(0), n, "written")
+	core.AssertErrorIs(t, err, errWrite, "error")
+}

--- a/tls/x509utils/pem_write_test.go
+++ b/tls/x509utils/pem_write_test.go
@@ -2,13 +2,22 @@ package x509utils_test
 
 import (
 	"bytes"
+	"crypto"
 	"crypto/x509"
+	"encoding/pem"
 	"errors"
+	"io"
 	"testing"
 
 	"darvaza.org/core"
 
 	"darvaza.org/x/tls/x509utils"
+)
+
+// Compile-time TestCase interface assertions, kept together as an index.
+var (
+	_ core.TestCase = writeCertTestCase{}
+	_ core.TestCase = writeKeyTestCase{}
 )
 
 // errWrite is the failure a failing writer reports.
@@ -19,8 +28,6 @@ var errWrite = errors.New("write failed")
 type errWriter struct{}
 
 func (errWriter) Write([]byte) (int, error) { return 0, errWrite }
-
-var _ core.TestCase = writeCertTestCase{}
 
 // writeCertTestCase exercises WriteCert: its two reachable rejection paths,
 // each an ErrInvalidCert built by NewErrInvalidCert, and the encoding path.
@@ -46,9 +53,7 @@ func (tc writeCertTestCase) Test(t *testing.T) {
 	}
 
 	core.AssertEqual(t, int64(0), n, "written")
-	if !core.AssertError(t, err, "error") {
-		return
-	}
+	core.AssertMustError(t, err, "error")
 	core.AssertEqual(t, tc.wantMsg, err.Error(), "message")
 	// every WriteCert rejection defaults to core.ErrInvalid (F44).
 	core.AssertErrorIs(t, err, core.ErrInvalid, "invalid")
@@ -93,6 +98,92 @@ func TestWriteCertWriteError(t *testing.T) {
 	cert := &x509.Certificate{Raw: []byte("not real DER")}
 
 	n, err := x509utils.WriteCert(errWriter{}, cert)
+	core.AssertEqual(t, int64(0), n, "written")
+	core.AssertErrorIs(t, err, errWrite, "error")
+}
+
+// unsupportedKey is a PrivateKey whose concrete type
+// x509.MarshalPKCS8PrivateKey does not recognise, driving WriteKey's
+// marshal-error arm.
+type unsupportedKey struct{}
+
+func (unsupportedKey) Public() crypto.PublicKey { return nil }
+
+func (unsupportedKey) Sign(io.Reader, []byte, crypto.SignerOpts) ([]byte, error) {
+	return nil, nil
+}
+
+func (unsupportedKey) Equal(crypto.PrivateKey) bool { return false }
+
+// writeKeyTestCase exercises WriteKey: the PKCS8 encode-and-round-trip path,
+// and the marshal-error arm reached by a nil key or a key type PKCS8
+// marshalling rejects.
+type writeKeyTestCase struct {
+	key     x509utils.PrivateKey
+	name    string
+	wantErr bool
+}
+
+func (tc writeKeyTestCase) Name() string { return tc.name }
+
+func (tc writeKeyTestCase) Test(t *testing.T) {
+	t.Helper()
+
+	var buf bytes.Buffer
+	n, err := x509utils.WriteKey(&buf, tc.key)
+
+	if tc.wantErr {
+		core.AssertEqual(t, int64(0), n, "written")
+		core.AssertMustError(t, err, "error")
+		core.AssertContains(t, err.Error(), "failed to encode key", "message")
+		return
+	}
+
+	core.AssertMustNoError(t, err, "error")
+	core.AssertEqual(t, int64(buf.Len()), n, "written")
+
+	// the written block decodes back to the original key.
+	block, _ := pem.Decode(buf.Bytes())
+	core.AssertMustNotNil(t, block, "block")
+	core.AssertEqual(t, "PRIVATE KEY", block.Type, "type")
+
+	got, err := x509utils.BlockToPrivateKey(block)
+	core.AssertMustNoError(t, err, "parse")
+	core.AssertMustNotNil(t, got, "key")
+	core.AssertTrue(t, got.Equal(tc.key), "key round-trip")
+}
+
+func newWriteKeyTestCase(name string, key x509utils.PrivateKey,
+	wantErr bool) writeKeyTestCase {
+	return writeKeyTestCase{
+		key:     key,
+		name:    name,
+		wantErr: wantErr,
+	}
+}
+
+func writeKeyTestCases(t *testing.T) []writeKeyTestCase {
+	t.Helper()
+
+	return core.S(
+		// a real key round-trips through PKCS8; WriteKey is type-agnostic,
+		// so one key type covers the encode-and-flush path.
+		newWriteKeyTestCase("ECDSA", mkKey(t), false),
+		// a nil key and an unrecognised key type both fail PKCS8 marshalling.
+		newWriteKeyTestCase("nil key", nil, true),
+		newWriteKeyTestCase("unsupported key", unsupportedKey{}, true),
+	)
+}
+
+func TestWriteKey(t *testing.T) {
+	core.RunTestCases(t, writeKeyTestCases(t))
+}
+
+// TestWriteKeyWriteError covers the writer-failure branch: the key encodes
+// into the buffer, but flushing it to the destination fails, so WriteKey
+// reports zero bytes written and the writer's error.
+func TestWriteKeyWriteError(t *testing.T) {
+	n, err := x509utils.WriteKey(errWriter{}, mkKey(t))
 	core.AssertEqual(t, int64(0), n, "written")
 	core.AssertErrorIs(t, err, errWrite, "error")
 }

--- a/tls/x509utils/spki.go
+++ b/tls/x509utils/spki.go
@@ -58,11 +58,10 @@ func SubjectPublicKeyBytes(pub crypto.PublicKey) ([]byte, error) {
 		SubjectPublicKey asn1.BitString
 	}
 
+	// MarshalPKIXPublicKey emits complete, well-formed SPKI DER and spki
+	// mirrors that structure exactly, so decoding it back cannot fail.
 	_, err = asn1.Unmarshal(spkiASN1, &spki)
-	if err != nil {
-		err = core.Wrap(err, "failed to decode public key")
-		return nil, err
-	}
+	core.MustNoError(err)
 
 	return spki.SubjectPublicKey.Bytes, nil
 }

--- a/tls/x509utils/spki_test.go
+++ b/tls/x509utils/spki_test.go
@@ -1,0 +1,169 @@
+package x509utils_test
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/rsa"
+	"crypto/sha1"
+	"crypto/sha256"
+	"crypto/x509"
+	"testing"
+
+	"darvaza.org/core"
+
+	"darvaza.org/x/tls/x509utils"
+)
+
+var (
+	_ core.TestCase = subjectPublicKeyBytesTestCase{}
+	_ core.TestCase = subjectPublicKeyHashTestCase{}
+)
+
+// spkiBytes returns the SubjectPublicKey bit-string bytes for pub by an
+// independent stdlib path, so the expected value never re-derives through
+// SubjectPublicKeyBytes (the function under test). Each key type has its own
+// encoding: an EC key marshals to the uncompressed point, RSA to the PKCS1
+// SEQUENCE, Ed25519 to the raw 32-byte key.
+func spkiBytes(t *testing.T, pub crypto.PublicKey) []byte {
+	t.Helper()
+	switch k := pub.(type) {
+	case *ecdsa.PublicKey:
+		ecdhPub, err := k.ECDH()
+		core.AssertMustNoError(t, err, "ecdh")
+		return ecdhPub.Bytes()
+	case *rsa.PublicKey:
+		return x509.MarshalPKCS1PublicKey(k)
+	case ed25519.PublicKey:
+		return []byte(k)
+	default:
+		core.AssertMustNil(t, pub, "unhandled public key type")
+		return nil
+	}
+}
+
+// subjectPublicKeyBytesTestCase exercises SubjectPublicKeyBytes: a supported
+// key marshals to its raw SubjectPublicKey bytes, stripping the algorithm
+// identifier, whereas one that cannot be encoded surfaces the error instead.
+type subjectPublicKeyBytesTestCase struct {
+	pub     crypto.PublicKey
+	name    string
+	wantErr string
+	want    []byte
+}
+
+func (tc subjectPublicKeyBytesTestCase) Name() string { return tc.name }
+
+func (tc subjectPublicKeyBytesTestCase) Test(t *testing.T) {
+	t.Helper()
+	got, err := x509utils.SubjectPublicKeyBytes(tc.pub)
+	if tc.wantErr != "" {
+		core.AssertError(t, err, "error")
+		core.AssertContains(t, err.Error(), tc.wantErr, "error")
+		core.AssertNil(t, got, "bytes")
+		return
+	}
+	core.AssertMustNoError(t, err, "encode")
+	core.AssertSliceEqual(t, tc.want, got, "spki bytes")
+}
+
+func newSubjectPublicKeyBytesTestCase(name string, pub crypto.PublicKey,
+	want []byte, wantErr string) subjectPublicKeyBytesTestCase {
+	return subjectPublicKeyBytesTestCase{
+		pub:     pub,
+		want:    want,
+		name:    name,
+		wantErr: wantErr,
+	}
+}
+
+func subjectPublicKeyBytesTestCases(t *testing.T) []subjectPublicKeyBytesTestCase {
+	t.Helper()
+
+	ecPub := mkKey(t).Public()
+	rsaPub := mkRSAKey(t).Public()
+	edPub := mkEd25519Key(t).Public()
+
+	// SubjectPublicKeyBytes asserts the asn1.Unmarshal cannot fail via
+	// core.MustNoError: MarshalPKIXPublicKey always emits well-formed SPKI, so
+	// re-decoding it never errors. Only the encode arm is reachable here: nil
+	// and an unsupported type both fail MarshalPKIXPublicKey.
+	return core.S(
+		newSubjectPublicKeyBytesTestCase("ECDSA P-256", ecPub,
+			spkiBytes(t, ecPub), ""),
+		newSubjectPublicKeyBytesTestCase("RSA", rsaPub,
+			spkiBytes(t, rsaPub), ""),
+		newSubjectPublicKeyBytesTestCase("Ed25519", edPub,
+			spkiBytes(t, edPub), ""),
+		newSubjectPublicKeyBytesTestCase("nil public key", nil, nil,
+			"failed to encode public key"),
+		newSubjectPublicKeyBytesTestCase("unsupported type", struct{}{}, nil,
+			"failed to encode public key"),
+	)
+}
+
+func TestSubjectPublicKeyBytes(t *testing.T) {
+	core.RunTestCases(t, subjectPublicKeyBytesTestCases(t))
+}
+
+// subjectPublicKeyHashTestCase exercises the SHA1/SHA224/SHA256 SubjectPublicKey
+// hashers together: each hashes the same SubjectPublicKey bytes, so one row
+// pins all three against an independently derived digest and their shared
+// error-propagation arm.
+type subjectPublicKeyHashTestCase struct {
+	pub     crypto.PublicKey
+	name    string
+	spki    []byte
+	wantErr bool
+}
+
+func (tc subjectPublicKeyHashTestCase) Name() string { return tc.name }
+
+func (tc subjectPublicKeyHashTestCase) Test(t *testing.T) {
+	t.Helper()
+
+	h1, err1 := x509utils.SubjectPublicKeySHA1(tc.pub)
+	h224, err224 := x509utils.SubjectPublicKeySHA224(tc.pub)
+	h256, err256 := x509utils.SubjectPublicKeySHA256(tc.pub)
+
+	if tc.wantErr {
+		core.AssertError(t, err1, "sha1 error")
+		core.AssertError(t, err224, "sha224 error")
+		core.AssertError(t, err256, "sha256 error")
+		return
+	}
+
+	core.AssertMustNoError(t, err1, "sha1")
+	core.AssertMustNoError(t, err224, "sha224")
+	core.AssertMustNoError(t, err256, "sha256")
+	core.AssertEqual(t, sha1.Sum(tc.spki), h1, "sha1")
+	core.AssertEqual(t, sha256.Sum224(tc.spki), h224, "sha224")
+	core.AssertEqual(t, sha256.Sum256(tc.spki), h256, "sha256")
+}
+
+func newSubjectPublicKeyHashTestCase(name string, pub crypto.PublicKey,
+	spki []byte, wantErr bool) subjectPublicKeyHashTestCase {
+	return subjectPublicKeyHashTestCase{
+		pub:     pub,
+		spki:    spki,
+		name:    name,
+		wantErr: wantErr,
+	}
+}
+
+func subjectPublicKeyHashTestCases(t *testing.T) []subjectPublicKeyHashTestCase {
+	t.Helper()
+
+	ecPub := mkKey(t).Public()
+
+	return core.S(
+		newSubjectPublicKeyHashTestCase("ECDSA P-256", ecPub,
+			spkiBytes(t, ecPub), false),
+		newSubjectPublicKeyHashTestCase("unsupported type", struct{}{}, nil,
+			true),
+	)
+}
+
+func TestSubjectPublicKeyHashes(t *testing.T) {
+	core.RunTestCases(t, subjectPublicKeyHashTestCases(t))
+}

--- a/tls/x509utils/testutils_test.go
+++ b/tls/x509utils/testutils_test.go
@@ -1,0 +1,71 @@
+package x509utils_test
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"net"
+	"testing"
+	"time"
+
+	"darvaza.org/core"
+)
+
+// testCert holds a minted, parsed certificate.
+type testCert struct {
+	cert *x509.Certificate
+}
+
+// certSpec describes a self-signed certificate to mint, valid for a one-hour
+// window around now.
+type certSpec struct {
+	cn  string
+	dns []string
+	ips []net.IP
+}
+
+// mkSerial returns a random 128-bit serial number.
+func mkSerial(t *testing.T) *big.Int {
+	t.Helper()
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	core.AssertMustNoError(t, err, "serial")
+	return serial
+}
+
+// build mints and parses the certificate described by the spec.
+func (spec certSpec) build(t *testing.T) testCert {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	core.AssertMustNoError(t, err, "generate key")
+
+	tmpl := spec.template(t)
+
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl,
+		key.Public(), key)
+	core.AssertMustNoError(t, err, "create certificate")
+
+	cert, err := x509.ParseCertificate(der)
+	core.AssertMustNoError(t, err, "parse certificate")
+	return testCert{cert: cert}
+}
+
+// template builds the x509 template with a one-hour validity window
+// around now.
+func (spec certSpec) template(t *testing.T) *x509.Certificate {
+	t.Helper()
+
+	now := time.Now()
+	return &x509.Certificate{
+		SerialNumber: mkSerial(t),
+		Subject:      pkix.Name{CommonName: spec.cn},
+		NotBefore:    now.Add(-time.Hour),
+		NotAfter:     now.Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		DNSNames:     spec.dns,
+		IPAddresses:  spec.ips,
+	}
+}

--- a/tls/x509utils/testutils_test.go
+++ b/tls/x509utils/testutils_test.go
@@ -1,6 +1,7 @@
 package x509utils_test
 
 import (
+	"crypto"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -14,17 +15,24 @@ import (
 	"darvaza.org/core"
 )
 
-// testCert holds a minted, parsed certificate.
+// testCert bundles a parsed certificate with the key that owns it, so it can
+// sign children.
 type testCert struct {
 	cert *x509.Certificate
+	key  *ecdsa.PrivateKey
 }
 
-// certSpec describes a self-signed certificate to mint, valid for a one-hour
-// window around now.
+// certSpec describes a certificate to mint. A nil parent yields a self-signed
+// certificate; otherwise parent signs it. Zero validity fields fall back to a
+// one-hour window around now.
 type certSpec struct {
-	cn  string
-	dns []string
-	ips []net.IP
+	notBefore time.Time
+	notAfter  time.Time
+	parent    *testCert
+	cn        string
+	dns       []string
+	ips       []net.IP
+	isCA      bool
 }
 
 // mkSerial returns a random 128-bit serial number.
@@ -43,29 +51,50 @@ func (spec certSpec) build(t *testing.T) testCert {
 	core.AssertMustNoError(t, err, "generate key")
 
 	tmpl := spec.template(t)
+	signerCert, signerKey := tmpl, crypto.Signer(key)
+	if spec.parent != nil {
+		signerCert, signerKey = spec.parent.cert, spec.parent.key
+	}
 
-	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl,
-		key.Public(), key)
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, signerCert,
+		key.Public(), signerKey)
 	core.AssertMustNoError(t, err, "create certificate")
 
 	cert, err := x509.ParseCertificate(der)
 	core.AssertMustNoError(t, err, "parse certificate")
-	return testCert{cert: cert}
+	return testCert{cert: cert, key: key}
 }
 
-// template builds the x509 template with a one-hour validity window
-// around now.
+// template builds the x509 template, filling sensible validity defaults and
+// the CA flags when requested.
 func (spec certSpec) template(t *testing.T) *x509.Certificate {
 	t.Helper()
 
 	now := time.Now()
-	return &x509.Certificate{
+	notBefore := core.Coalesce(spec.notBefore, now.Add(-time.Hour))
+	notAfter := core.Coalesce(spec.notAfter, now.Add(time.Hour))
+
+	tmpl := &x509.Certificate{
 		SerialNumber: mkSerial(t),
 		Subject:      pkix.Name{CommonName: spec.cn},
-		NotBefore:    now.Add(-time.Hour),
-		NotAfter:     now.Add(time.Hour),
+		NotBefore:    notBefore,
+		NotAfter:     notAfter,
 		KeyUsage:     x509.KeyUsageDigitalSignature,
 		DNSNames:     spec.dns,
 		IPAddresses:  spec.ips,
 	}
+	if spec.isCA {
+		tmpl.IsCA = true
+		tmpl.BasicConstraintsValid = true
+		tmpl.KeyUsage |= x509.KeyUsageCertSign
+	}
+	return tmpl
+}
+
+// mkKey generates a fresh ECDSA key for equality tests.
+func mkKey(t *testing.T) *ecdsa.PrivateKey {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	core.AssertMustNoError(t, err, "generate key")
+	return key
 }

--- a/tls/x509utils/utils_test.go
+++ b/tls/x509utils/utils_test.go
@@ -1,0 +1,135 @@
+package x509utils_test
+
+import (
+	"crypto"
+	"crypto/x509"
+	"io"
+	"testing"
+
+	"darvaza.org/core"
+
+	"darvaza.org/x/tls/x509utils"
+)
+
+var (
+	_ core.TestCase = publicKeyFromCertificateTestCase{}
+	_ core.TestCase = publicKeyFromPrivateKeyTestCase{}
+)
+
+// notPublicKey is a value without an Equal(crypto.PublicKey) bool method, so it
+// fails the x509utils.PublicKey assertion. It stands in for a public key the
+// helpers must reject.
+type notPublicKey struct{}
+
+// fakeSigner satisfies x509utils.PrivateKey (crypto.Signer plus Equal) yet its
+// Public returns a notPublicKey, driving the arm where the private key is
+// well-typed but its public half is not an x509utils.PublicKey.
+type fakeSigner struct{}
+
+func (fakeSigner) Public() crypto.PublicKey { return notPublicKey{} }
+
+func (fakeSigner) Sign(io.Reader, []byte, crypto.SignerOpts) ([]byte, error) {
+	return nil, nil
+}
+
+func (fakeSigner) Equal(crypto.PrivateKey) bool { return false }
+
+// publicKeyFromPrivateKeyTestCase exercises PublicKeyFromPrivateKey: a
+// well-typed key yields its public half; every other operand yields nil.
+type publicKeyFromPrivateKeyTestCase struct {
+	key  crypto.PrivateKey
+	want crypto.PublicKey
+	name string
+}
+
+func (tc publicKeyFromPrivateKeyTestCase) Name() string { return tc.name }
+
+func (tc publicKeyFromPrivateKeyTestCase) Test(t *testing.T) {
+	t.Helper()
+	got := x509utils.PublicKeyFromPrivateKey(tc.key)
+	if tc.want == nil {
+		core.AssertNil(t, got, "public key")
+		return
+	}
+	core.AssertMustNotNil(t, got, "public key")
+	core.AssertTrue(t, got.Equal(tc.want), "public key")
+}
+
+func newPublicKeyFromPrivateKeyTestCase(name string, key crypto.PrivateKey,
+	want crypto.PublicKey) publicKeyFromPrivateKeyTestCase {
+	return publicKeyFromPrivateKeyTestCase{key: key, want: want, name: name}
+}
+
+func publicKeyFromPrivateKeyTestCases(
+	t *testing.T,
+) []publicKeyFromPrivateKeyTestCase {
+	t.Helper()
+
+	key := mkKey(t)
+
+	return core.S(
+		newPublicKeyFromPrivateKeyTestCase("ECDSA key", key, key.Public()),
+		newPublicKeyFromPrivateKeyTestCase("nil", nil, nil),
+		// a value that is not an x509utils.PrivateKey fails the first assertion.
+		newPublicKeyFromPrivateKeyTestCase("non-key value", "not a key", nil),
+		// a well-typed key whose Public is not an x509utils.PublicKey fails the
+		// second assertion.
+		newPublicKeyFromPrivateKeyTestCase("public not a key", fakeSigner{},
+			nil),
+	)
+}
+
+func TestPublicKeyFromPrivateKey(t *testing.T) {
+	core.RunTestCases(t, publicKeyFromPrivateKeyTestCases(t))
+}
+
+// publicKeyFromCertificateTestCase exercises PublicKeyFromCertificate: a
+// certificate carrying a well-typed public key yields it; a nil certificate,
+// a nil public key, or a public key of the wrong shape yields nil.
+type publicKeyFromCertificateTestCase struct {
+	cert *x509.Certificate
+	want crypto.PublicKey
+	name string
+}
+
+func (tc publicKeyFromCertificateTestCase) Name() string { return tc.name }
+
+func (tc publicKeyFromCertificateTestCase) Test(t *testing.T) {
+	t.Helper()
+	got := x509utils.PublicKeyFromCertificate(tc.cert)
+	if tc.want == nil {
+		core.AssertNil(t, got, "public key")
+		return
+	}
+	core.AssertMustNotNil(t, got, "public key")
+	core.AssertTrue(t, got.Equal(tc.want), "public key")
+}
+
+func newPublicKeyFromCertificateTestCase(name string, cert *x509.Certificate,
+	want crypto.PublicKey) publicKeyFromCertificateTestCase {
+	return publicKeyFromCertificateTestCase{cert: cert, want: want, name: name}
+}
+
+func publicKeyFromCertificateTestCases(
+	t *testing.T,
+) []publicKeyFromCertificateTestCase {
+	t.Helper()
+
+	leaf := certSpec{cn: "utils.example.com",
+		dns: core.S("utils.example.com")}.build(t)
+
+	return core.S(
+		newPublicKeyFromCertificateTestCase("ECDSA cert", leaf.cert,
+			leaf.cert.PublicKey),
+		newPublicKeyFromCertificateTestCase("nil cert", nil, nil),
+		newPublicKeyFromCertificateTestCase("nil public key",
+			&x509.Certificate{}, nil),
+		// a public key without Equal fails the assertion.
+		newPublicKeyFromCertificateTestCase("public not a key",
+			&x509.Certificate{PublicKey: notPublicKey{}}, nil),
+	)
+}
+
+func TestPublicKeyFromCertificate(t *testing.T) {
+	core.RunTestCases(t, publicKeyFromCertificateTestCases(t))
+}


### PR DESCRIPTION
## tls/x509utils: fix latent defects and expand test coverage

Hardens the `x509utils` helpers the TLS store stack (`basic`, `buffer`,
`config`) leans on, and backs each fix with the test that found it. The
package moved from thin coverage to black-box suites over every
store-facing entry point; the bugs below all surfaced while writing them.

### Behaviour fixes

- **Nil-guard Names** — a nil `*x509.Certificate` panicked; it now returns
  no names.
- **Nil-guard the PEM block parsers** — `BlockToPrivateKey` and
  `BlockToCertificate` dereferenced a nil `*pem.Block` and panicked; they
  now return `core.ErrInvalid`.
- **Parse SEC1 EC private keys** — an `EC PRIVATE KEY` block (the SEC1
  form common generators emit, and the buffer store ingests) was rejected
  despite the doc promising ecdsa keys. A SEC1 fallback now sits between
  the PKCS1 and PKCS8 attempts.
- **Accept trailing content after the last PEM block** — a trailing blank
  line or non-PEM bytes (editor-saved and concatenated bundles) failed the
  whole read even though every block had already been delivered. `ReadPEM`
  now decodes first and only rejects input with no PEM block at all;
  `ReadStringPEM` also stops handing an over-long or NUL-bearing candidate
  to `stat`.
- **Canonicalise IP-SAN name keys** — an IPv4-mapped IPv6 SAN was stored as
  `[::ffff:1.2.3.4]` while the lookup paths produced `[1.2.3.4]`, leaving
  the certificate unretrievable; `NameAsIP` also left the scope zone on the
  key. Storage and both lookup helpers now settle on one unmapped,
  zone-stripped form.
- **Empty CertPool is not a CA pool** — `IsCA` reported true for a pool
  with no entries; it now requires at least one entry, all of them CAs.
- **Make IsSelfSigned structural** — it built a one-cert pool and ran
  `Verify`, so an expired or non-server self-signed root was reported as
  not self-signed and mis-sorted from intermediates. It now tests
  subject/issuer match and a self-signature via `CheckSignatureFrom`, with
  time validity explicitly out of scope.

### API and refactor

- **Add NewErrInvalidCert constructor** — the single way to build an
  `ErrInvalidCert`, defaulting the cause to `core.ErrInvalid` so every
  constructed error satisfies `errors.Is(err, core.ErrInvalid)` and
  `tls.IsInvalid`, without changing the message text. Verify's rejections
  and `WriteCert` route through it; `WriteCert`'s unreachable
  encode-failure arm now asserts the impossible path with
  `core.MustNoError` rather than returning a cause no caller can observe.
- **Align WriteKey error handling with WriteCert** — the two now share one
  encode-then-flush shape, so a writer failure is reported the same way for
  keys as for certificates.
- **Remove unreachable removeZone** — the non-IP scope-zone strip in
  `doSanitizeName` could never fire (idna's STD3 rules reject `%` before
  the name reaches it); IP zones are handled on the IP branch by
  `WithZone("")`.

### Tests

Black-box (`_test` package) suites over the store-facing surface:
`Names`/`Hostname` and the name-matching helpers, `pair.go`
(`IsSelfSigned`/`ValidCertKeyPair`/`PublicKeyEqual`/`PrivateKeyEqual`/
`ValidKeyPair`), `BlockToPrivateKey`, PEM block encoding, `ReadPEM`/
`ReadStringPEM` and directory reading, `WriteCert`/`WriteKey`, SPKI hashing
and public-key extraction, the `NewErrInvalidCert` behaviour, and the
certpool lookup, write and import surface — with nil and non-key operands
throughout. The name-lookup tests moved from white-box loops to `TestCase`
tables, and the certpool test assertions were tidied (`AssertMustTypeIs`,
real system-pool checks). A cert-minting `testutils_test.go` underpins the
suites.

### Verification

`make all race coverage-tls` green across the repo.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `NewErrInvalidCert` for consistent invalid-certificate errors and cause handling.

* **Bug Fixes**
  * Improved `Verify` invalid-certificate validation failures with consistent error formatting.
  * Fixed certificate pool `IsCA` behavior for empty pools.
  * Refined certificate name/IP sanitization and self-signed detection.
  * Strengthened PEM read/write handling: better nil/invalid-path guards, improved key/cert parsing, and clearer error normalization.

* **Tests**
  * Expanded coverage across PEM, naming/IP, pairing, SPKI, certpool operations, and verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
