### PR TITLE
feat(sync/workgroup): add GoShutdown task/shutdown pairing

### DIFF
--- a/sync/README.md
+++ b/sync/README.md
@@ -475,7 +475,7 @@ cancellation propagation and lifecycle management of concurrent operations.
 
 * Context integration for propagating cancellation signals.
 * Coordinated lifecycle management for concurrent tasks.
-* Graceful shutdown of operations.
+* Graceful shutdown via `Close`: cancels the Group and drains all tasks.
 * Error tracking and propagation.
 * Concurrent safety for multi-goroutine use.
 
@@ -521,7 +521,11 @@ if err := wg.Wait(); err != nil {
 
 * Propagates cancellation signals from parent contexts to all tasks.
 * Provides an `OnCancel` hook that fires on cancellation from any source —
-  an explicit `Cancel`/`Close` or the parent context.
+  an explicit `Cancel`/`Close` or the parent context. The handler receives
+  the cancellation cause and a live context detached from the Group's
+  cancellation (via `context.WithoutCancel`): it retains the Group context's
+  values but is not itself cancelled, so cleanup work can pass it along or
+  build its own deadline on top.
 * Safe for concurrent use from multiple goroutines.
 * Supports reuse after completion if not cancelled.
 * Error tracking distinguishes between normal cancellation and error causes.

--- a/sync/README.md
+++ b/sync/README.md
@@ -493,6 +493,11 @@ cancellation propagation and lifecycle management of concurrent operations.
 * `GoCatch(func(context.Context) error, func(context.Context, error) error)
   error`: Spawns a goroutine with error handling and error-triggered
   cancellation.
+* `GoShutdown(func(context.Context) error, func(context.Context),
+  time.Duration) error`: Spawns a supervised task paired with a shutdown
+  handler that signals it to end when the Group is cancelled while it is
+  still running — the `http.Server` `ListenAndServe`/`Shutdown` pattern
+  for workers that cannot act on the Group's context.
 
 ### Group Example usage
 
@@ -526,6 +531,18 @@ if err := wg.Wait(); err != nil {
   cancellation (via `context.WithoutCancel`): it retains the Group context's
   values but is not itself cancelled, so cleanup work can pass it along or
   build its own deadline on top.
+* `GoShutdown` pairs a task with a shutdown handler in a single tracked
+  unit. The handler's one job is to tell a worker that cannot act on the
+  Group's context to end: it runs at most once, only when the Group is
+  cancelled while the task is still running, and receives a live, detached
+  context bounded by the grace period (unbounded when the grace period is
+  zero or less). A task that ends on its own needs no signal — an error
+  still cancels the Group, but the handler is not invoked. With a nil
+  task the handler is enrolled alone as a watcher: the per-resource
+  counterpart to the per-Group `OnCancel` hook — one enrolled for each
+  resource to release on cancellation, grace-bounded, without the cause.
+  Like the `OnCancel` handler, a panic in the shutdown handler is
+  recovered and discarded.
 * Safe for concurrent use from multiple goroutines.
 * Supports reuse after completion if not cancelled.
 * Error tracking distinguishes between normal cancellation and error causes.

--- a/sync/workgroup/workgroup.go
+++ b/sync/workgroup/workgroup.go
@@ -16,6 +16,7 @@ import (
 	"context"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"darvaza.org/core"
 	"darvaza.org/x/sync/cond"
@@ -523,6 +524,76 @@ func (wg *Group) GoCatch(fn func(context.Context) error, catch func(context.Cont
 	}
 }
 
+// GoShutdown enrols a task paired with a shutdown handler that signals
+// it to end when the Group is cancelled — the http.Server
+// ListenAndServe/Shutdown pattern, for workers that cannot act on the
+// Group's context.
+//
+// fn is supervised exactly like a GoCatch task with no catch handler:
+// a panic becomes a core.PanicError and a non-nil return cancels the
+// whole Group with that error. It receives the Group's context but,
+// unlike an ordinary task, is not expected to act on its cancellation;
+// delivering that signal is what shutdown is for.
+//
+// shutdown's one job is to tell fn to end. It is invoked at most once,
+// only when the Group is cancelled — by an explicit Cancel or Close,
+// cancellation of the parent, or another task's failure — while fn is
+// still running. A worker that ends on its own needs no signal: if fn
+// returns nil the pair simply ends, like any other task, and if fn
+// returns an error the Group is cancelled with it, but the worker is
+// already gone, so its own shutdown is not invoked. When cancellation
+// and fn's return coincide, shutdown may still be invoked as fn ends;
+// like http.Server.Shutdown, it must tolerate the worker being gone
+// already.
+//
+// shutdown receives a live context detached from the Group's
+// cancellation via context.WithoutCancel: not itself cancelled, yet
+// retaining the Group context's values, so a logger or trace
+// identifiers carry through. The context is bounded by gracePeriod; a
+// gracePeriod of zero or less leaves it unbounded (see
+// core.WithTimeout). No cancellation cause is passed — mirroring
+// http.Server.Shutdown — and [Group.Err] answers when the cause
+// matters. A panic in shutdown is recovered and discarded, as in the
+// OnCancel handler: there is no catch hook to receive it, and the
+// Group is already cancelled, leaving no cause for it to become.
+//
+// The pair is enrolled as a single task: Wait, Done, and Close block
+// until both fn and shutdown have returned. Per-task cleanup belongs
+// in fn itself; Group-wide cancellation cleanup belongs in OnCancel.
+//
+// With a nil fn, shutdown is enrolled alone as a watcher task that
+// holds the Group open until cancellation signals it. A watcher is
+// per-resource where OnCancel is per-Group: enrol one for each
+// resource to release on cancellation, each with its own grace
+// period and no cause passed; OnCancel is the Group's single
+// transition hook and receives the cancellation cause.
+//
+// With a nil shutdown, fn is enrolled alone, equivalent to GoCatch
+// with no catch handler. When a handler is enrolled, GoShutdown
+// returns ErrClosed if the Group is already cancelled and nothing is
+// started; with both handlers nil there is nothing to enrol and it
+// returns nil.
+func (wg *Group) GoShutdown(
+	fn func(context.Context) error,
+	shutdown func(context.Context),
+	gracePeriod time.Duration,
+) error {
+	if err := wg.lazyInit(); err != nil {
+		return err
+	}
+
+	switch {
+	case fn == nil && shutdown == nil:
+		return nil
+	case shutdown == nil:
+		return wg.doGoRun(fn, nil)
+	case fn == nil:
+		return wg.doGo(wg.newShutdownWatcher(shutdown, gracePeriod))
+	default:
+		return wg.doGo(wg.newShutdownTask(fn, shutdown, gracePeriod))
+	}
+}
+
 // doGoRun enrols fn as a supervised task and runs it, the shared path behind
 // GoCatch.
 func (wg *Group) doGoRun(fn func(context.Context) error, catch func(context.Context, error) error) error {
@@ -531,10 +602,85 @@ func (wg *Group) doGoRun(fn func(context.Context) error, catch func(context.Cont
 	})
 }
 
-// run executes fn under core.Catch, routes the result through catch when set,
-// and cancels the Group if the surviving error is non-nil. fn and catch receive
-// wg.ctx, not the enrolment closure's context argument.
+// newShutdownTask pairs fn with its shutdown handler in a single
+// counted task: fn runs supervised on an inner goroutine while the
+// outer body waits for cancellation or fn's return. shutdown exists to
+// signal a worker that cannot act on the Group's context, so it is
+// invoked only when the Group is cancelled while fn is still running;
+// a worker that ended on its own — cleanly, or with the error that
+// cancels the Group — has nobody left to signal.
+func (wg *Group) newShutdownTask(
+	fn func(context.Context) error,
+	shutdown func(context.Context),
+	gracePeriod time.Duration,
+) func(context.Context) {
+	return func(ctx context.Context) {
+		errCh := make(chan error, 1)
+		go func() {
+			// supervised like GoCatch: a panic becomes a PanicError.
+			errCh <- wg.runErr(fn, nil)
+		}()
+
+		select {
+		case err := <-errCh:
+			// fn ended on its own; nothing to signal. Its error, if
+			// any, cancels the Group here — before the pair is
+			// released — so a concurrent Wait observes the cause.
+			if err != nil {
+				wg.Cancel(err)
+			}
+		case <-ctx.Done():
+			wg.runShutdown(shutdown, gracePeriod)
+			// hold the task open until fn has wound down too. Its
+			// error arrives after cancellation, so it can no longer
+			// become the cause and is discarded like any other.
+			<-errCh
+		}
+	}
+}
+
+// newShutdownWatcher builds a shutdown-only task: it blocks until the
+// Group's context is cancelled and then invokes the shutdown handler,
+// holding the Group open until cancellation.
+func (wg *Group) newShutdownWatcher(
+	shutdown func(context.Context),
+	gracePeriod time.Duration,
+) func(context.Context) {
+	return func(ctx context.Context) {
+		// hold until the Group is cancelled; that signal starts the handler.
+		<-ctx.Done()
+		wg.runShutdown(shutdown, gracePeriod)
+	}
+}
+
+// runShutdown invokes the shutdown handler on a live context detached
+// from the Group's cancellation (context.WithoutCancel) and bounded by
+// gracePeriod.
+func (wg *Group) runShutdown(shutdown func(context.Context), gracePeriod time.Duration) {
+	ctx, cancel := core.WithTimeout(context.WithoutCancel(wg.ctx), gracePeriod)
+	defer cancel()
+	// Contain a panicking handler. GoShutdown offers no catch hook and
+	// the Group is already cancelled when shutdown runs, so the
+	// recovered error has nowhere to go — the same rule as the
+	// OnCancel handler.
+	_ = core.Catch(func() error {
+		shutdown(ctx)
+		return nil
+	})
+}
+
+// run executes fn via runErr and cancels the Group if the surviving
+// error is non-nil.
 func (wg *Group) run(fn func(context.Context) error, catch func(context.Context, error) error) {
+	if err := wg.runErr(fn, catch); err != nil {
+		wg.Cancel(err)
+	}
+}
+
+// runErr executes fn under core.Catch and routes the result through catch
+// when set, returning the surviving error without acting on it. fn and catch
+// receive wg.ctx, not the enrolment closure's context argument.
+func (wg *Group) runErr(fn func(context.Context) error, catch func(context.Context, error) error) error {
 	err := core.Catch(func() error {
 		// execute the function
 		return fn(wg.ctx)
@@ -547,10 +693,7 @@ func (wg *Group) run(fn func(context.Context) error, catch func(context.Context,
 		})
 	}
 
-	// cancel the group if the resulting error is non-nil
-	if err != nil {
-		wg.Cancel(err)
-	}
+	return err
 }
 
 // waitTasks blocks until the tasks counter has stably reached zero across

--- a/sync/workgroup/workgroup.go
+++ b/sync/workgroup/workgroup.go
@@ -64,12 +64,15 @@ type Group struct {
 	// after the Group's context is already done is not guaranteed to
 	// run, as the cancellation watcher may have fired already.
 	//
-	// When the handler runs, the Group's context is already
-	// cancelled — ctx.Err() is non-nil and context.Cause(ctx)
-	// returns the cancellation cause. For cleanup work that needs
-	// a live context, derive from wg.Parent or detach via
-	// context.WithoutCancel(ctx); contexts derived from ctx are
-	// born cancelled.
+	// The handler receives a live context, detached from the Group's
+	// cancellation via context.WithoutCancel: it is not itself cancelled
+	// and carries no deadline, so the handler can pass it to cleanup
+	// operations — or build its own deadline or cancellation on top —
+	// without their being torn down by the cancellation that triggered
+	// the handler. It retains the Group context's values, so a logger,
+	// trace identifiers, and other request-scoped data carry through.
+	// The cancellation cause arrives through the cause argument, not
+	// context.Cause(ctx).
 	//
 	// cause carries the error passed to Cancel (context.Canceled for a
 	// nil cause), or context.Cause(parent) when the parent context is
@@ -364,16 +367,21 @@ func (wg *Group) spawnCancelHandler(cause error) chan struct{} {
 	go func() {
 		defer wg.tasks.Dec()
 		close(ready)
-		// Contain a panicking handler. Without this, a panic unwinds
-		// the detached goroutine with nothing to recover it: it crashes
-		// the process while Wait blocks forever on the tasks counter.
-		// run() wraps ordinary tasks the same way. The caught error is
-		// deliberately dropped: the group is already cancelled, so
-		// routing it back through Cancel would be a no-op. Surfacing it
-		// instead would require threading a cancellation cause out of
-		// the handler, which the Group does not yet support.
+		// The handler runs after wg.ctx is cancelled, so hand it a
+		// context detached from that cancellation: WithoutCancel strips
+		// the cancellation and deadline while retaining the values, so
+		// cleanup work gets a live context that still carries the group's
+		// logger or trace identifiers. The cause travels through the
+		// cause argument instead of context.Cause(ctx).
+		ctx := context.WithoutCancel(wg.ctx)
+		// Contain a panicking handler: user code invoked by the Group
+		// must not escape a panic and kill the process. The recovered
+		// error is discarded — OnCancel offers no catch hook and the
+		// Group is already cancelled, so it has nowhere to go; the
+		// same rule as any handler the Group invokes after
+		// cancellation.
 		_ = core.Catch(func() error {
-			fn(wg.ctx, cause)
+			fn(ctx, cause)
 			return nil
 		})
 	}()

--- a/sync/workgroup/workgroup.go
+++ b/sync/workgroup/workgroup.go
@@ -511,12 +511,21 @@ func (wg *Group) GoCatch(fn func(context.Context) error, catch func(context.Cont
 	case fn == nil:
 		return nil
 	default:
-		return wg.doGo(func(_ context.Context) {
-			wg.run(fn, catch)
-		})
+		return wg.doGoRun(fn, catch)
 	}
 }
 
+// doGoRun enrols fn as a supervised task and runs it, the shared path behind
+// GoCatch.
+func (wg *Group) doGoRun(fn func(context.Context) error, catch func(context.Context, error) error) error {
+	return wg.doGo(func(_ context.Context) {
+		wg.run(fn, catch)
+	})
+}
+
+// run executes fn under core.Catch, routes the result through catch when set,
+// and cancels the Group if the surviving error is non-nil. fn and catch receive
+// wg.ctx, not the enrolment closure's context argument.
 func (wg *Group) run(fn func(context.Context) error, catch func(context.Context, error) error) {
 	err := core.Catch(func() error {
 		// execute the function

--- a/sync/workgroup/workgroup_test.go
+++ b/sync/workgroup/workgroup_test.go
@@ -386,8 +386,8 @@ func runTestCancelPropagatesCustom(t *testing.T) {
 // TestGroup_OnCancel tests the OnCancel handler.
 func TestGroup_OnCancel(t *testing.T) {
 	t.Run("HandlerFiresOnCancel", runTestOnCancelHandlerFires)
-	t.Run("HandlerReceivesGroupContext", runTestOnCancelReceivesContext)
-	t.Run("HandlerSeesCancelledContext", runTestOnCancelSeesCancelledContext)
+	t.Run("HandlerReceivesLiveContext", runTestOnCancelReceivesLiveContext)
+	t.Run("HandlerContextRetainsValues", runTestOnCancelContextRetainsValues)
 	t.Run("HandlerReceivesCustomCause", runTestOnCancelReceivesCause)
 	t.Run("HandlerReceivesContextCanceledForNilCause",
 		runTestOnCancelReceivesContextCanceledForNilCause)
@@ -415,45 +415,52 @@ func runTestOnCancelHandlerFires(t *testing.T) {
 	core.AssertNoError(t, wg.Wait(), "wait")
 }
 
-func runTestOnCancelReceivesContext(t *testing.T) {
-	t.Helper()
-	var received context.Context
-	receivedCh := make(chan struct{})
-
-	wg := workgroup.New(context.Background())
-	expected := wg.Context()
-	wg.OnCancel = func(ctx context.Context, _ error) {
-		received = ctx
-		close(receivedCh)
-	}
-
-	wg.Cancel(nil)
-	synctesting.AssertMustClosed(t, receivedCh, 100*time.Millisecond,
-		"handler ran")
-	core.AssertSame(t, expected, received, "context identity")
-	core.AssertNoError(t, wg.Wait(), "wait")
-}
-
-func runTestOnCancelSeesCancelledContext(t *testing.T) {
+// runTestOnCancelReceivesLiveContext pins that the handler's context is
+// detached from the Group's cancellation: it is live (ctx.Err() is nil)
+// rather than the already-cancelled group context.
+func runTestOnCancelReceivesLiveContext(t *testing.T) {
 	t.Helper()
 	var observedErr error
-	var observedCause error
 	receivedCh := make(chan struct{})
 
 	wg := workgroup.New(context.Background())
 	wg.OnCancel = func(ctx context.Context, _ error) {
 		observedErr = ctx.Err()
-		observedCause = context.Cause(ctx)
 		close(receivedCh)
 	}
 
 	wg.Cancel(nil)
 	synctesting.AssertMustClosed(t, receivedCh, 100*time.Millisecond,
 		"handler ran")
-	core.AssertErrorIs(t, observedErr, context.Canceled,
-		"ctx.Err() inside handler")
-	core.AssertErrorIs(t, observedCause, context.Canceled,
-		"context.Cause(ctx) inside handler")
+	core.AssertNoError(t, observedErr, "ctx.Err() inside handler")
+	core.AssertNoError(t, wg.Wait(), "wait")
+}
+
+// runTestOnCancelContextRetainsValues pins that detaching the handler's
+// context preserves the Group context's values, so cleanup work keeps any
+// logger or trace identifiers carried through it.
+func runTestOnCancelContextRetainsValues(t *testing.T) {
+	t.Helper()
+	type key string
+	testKey := key("trace-id")
+	testVal := "abc123"
+
+	var received any
+	receivedCh := make(chan struct{})
+
+	parent := context.WithValue(context.Background(), testKey, testVal)
+	wg := workgroup.New(parent)
+	wg.OnCancel = func(ctx context.Context, _ error) {
+		received = ctx.Value(testKey)
+		close(receivedCh)
+	}
+
+	wg.Cancel(nil)
+	synctesting.AssertMustClosed(t, receivedCh, 100*time.Millisecond,
+		"handler ran")
+	if got, ok := core.AssertTypeIs[string](t, received, "value type"); ok {
+		core.AssertEqual(t, testVal, got, "value carried into handler")
+	}
 	core.AssertNoError(t, wg.Wait(), "wait")
 }
 

--- a/sync/workgroup/workgroup_test.go
+++ b/sync/workgroup/workgroup_test.go
@@ -1414,6 +1414,11 @@ func TestGroup_NilReceiver(t *testing.T) {
 					func(_ context.Context, e error) error { return e },
 				)
 			}),
+		newNilReceiverErrorCase("GoShutdown",
+			func(wg *workgroup.Group) error {
+				return wg.GoShutdown(
+					func(_ context.Context) error { return nil }, nil, 0)
+			}),
 	})
 
 	core.RunTestCases(t, []nilReceiverPanicCase{
@@ -1665,6 +1670,386 @@ func runTestGoCatchHandlerReceivesContext(t *testing.T) {
 	_ = wg.Wait()
 	core.AssertEqual(t, wg.Context(), taskCtx, "task ctx")
 	core.AssertEqual(t, wg.Context(), catchCtx, "catch ctx")
+}
+
+// TestGroup_GoShutdown tests the GoShutdown method: an fn paired with a
+// shutdown handler that signals it to end when the Group is cancelled
+// while fn is still running.
+func TestGroup_GoShutdown(t *testing.T) {
+	t.Run("ServerPattern", runTestGoShutdownServerPattern)
+	t.Run("CloseSignalsShutdown", runTestGoShutdownCloseSignals)
+	t.Run("CleanReturnSkipsShutdown", runTestGoShutdownCleanReturnSkipsShutdown)
+	t.Run("FnErrorSkipsShutdown", runTestGoShutdownFnErrorSkipsShutdown)
+	t.Run("FnPanicSkipsShutdown", runTestGoShutdownFnPanicSkipsShutdown)
+	t.Run("FnErrorSignalsPeer", runTestGoShutdownFnErrorSignalsPeer)
+	t.Run("ShutdownContextBounded", runTestGoShutdownContextBounded)
+	t.Run("ShutdownContextUnbounded", runTestGoShutdownContextUnbounded)
+	t.Run("ShutdownPanicContained", runTestGoShutdownPanicContained)
+	t.Run("WatcherMode", runTestGoShutdownWatcherMode)
+	t.Run("NilShutdownRunsFn", runTestGoShutdownNilShutdownSuccess)
+	t.Run("NilShutdownSupervisesFn", runTestGoShutdownNilShutdownError)
+	t.Run("BothNilNoop", runTestGoShutdownBothNil)
+	t.Run("EnrolmentWhenCancelled", runTestGoShutdownEnrolmentWhenCancelled)
+}
+
+// runTestGoShutdownServerPattern models the http.Server pattern: fn ignores
+// the context and runs until the shutdown handler stops it. On cancellation
+// the handler closes the server, fn returns, and the paired task releases
+// the Group.
+func runTestGoShutdownServerPattern(t *testing.T) {
+	t.Helper()
+	serverStop := make(chan struct{})
+	var served atomic.Bool
+
+	wg := workgroup.New(context.Background())
+	core.AssertNoError(t, wg.GoShutdown(
+		func(_ context.Context) error {
+			served.Store(true)
+			<-serverStop // ListenAndServe: runs until Shutdown stops it
+			return nil
+		},
+		func(_ context.Context) { close(serverStop) }, // Shutdown
+		time.Second,
+	), "GoShutdown")
+
+	synctesting.AssertMustEventually(t, served.Load, 100*time.Millisecond,
+		"server started")
+	wg.Cancel(nil)
+	core.AssertNoError(t, wg.Wait(), "wait after shutdown stopped fn")
+	core.AssertTrue(t, served.Load(), "served")
+}
+
+// runTestGoShutdownCloseSignals pins the defer wg.Close() idiom: Close
+// cancels the Group, so it signals the running worker and waits for the
+// pair to end before returning.
+func runTestGoShutdownCloseSignals(t *testing.T) {
+	t.Helper()
+	serverStop := make(chan struct{})
+	var shutdownRan atomic.Bool
+	wg := workgroup.New(context.Background())
+
+	core.AssertNoError(t, wg.GoShutdown(
+		func(_ context.Context) error { <-serverStop; return nil },
+		func(_ context.Context) {
+			shutdownRan.Store(true)
+			close(serverStop)
+		},
+		time.Second,
+	), "GoShutdown")
+
+	core.AssertNoError(t, wg.Close(), "close")
+	core.AssertTrue(t, shutdownRan.Load(), "shutdown fired by Close")
+}
+
+// runTestGoShutdownCleanReturnSkipsShutdown pins that an fn returning
+// without the Group being cancelled ends the pair; there is nobody to
+// signal, so the shutdown handler never runs.
+func runTestGoShutdownCleanReturnSkipsShutdown(t *testing.T) {
+	t.Helper()
+	var shutdownRan atomic.Bool
+	wg := workgroup.New(context.Background())
+
+	core.AssertNoError(t, wg.GoShutdown(
+		func(_ context.Context) error { return nil },
+		func(_ context.Context) { shutdownRan.Store(true) },
+		time.Second,
+	), "GoShutdown")
+
+	core.AssertNoError(t, wg.Wait(), "wait")
+	core.AssertFalse(t, shutdownRan.Load(), "shutdown skipped on clean return")
+}
+
+// runTestGoShutdownFnErrorSkipsShutdown pins that fn's own error cancels
+// the Group but does not invoke its own shutdown handler: the worker has
+// already ended, so there is nobody left to signal.
+func runTestGoShutdownFnErrorSkipsShutdown(t *testing.T) {
+	t.Helper()
+	testErr := errors.New("fn failed")
+	var shutdownRan atomic.Bool
+	wg := workgroup.New(context.Background())
+
+	core.AssertNoError(t, wg.GoShutdown(
+		func(_ context.Context) error { return testErr },
+		func(_ context.Context) { shutdownRan.Store(true) },
+		time.Second,
+	), "GoShutdown")
+
+	core.AssertErrorIs(t, wg.Wait(), testErr, "wait err")
+	core.AssertFalse(t, shutdownRan.Load(), "shutdown skipped on fn error")
+}
+
+// runTestGoShutdownFnPanicSkipsShutdown pins that fn's panic is supervised
+// into a PanicError cause without invoking its own shutdown handler.
+func runTestGoShutdownFnPanicSkipsShutdown(t *testing.T) {
+	t.Helper()
+	var shutdownRan atomic.Bool
+	wg := workgroup.New(context.Background())
+
+	core.AssertNoError(t, wg.GoShutdown(
+		func(_ context.Context) error { panic("boom in fn") },
+		func(_ context.Context) { shutdownRan.Store(true) },
+		time.Second,
+	), "GoShutdown")
+
+	err := wg.Wait()
+	core.AssertFalse(t, shutdownRan.Load(), "shutdown skipped on fn panic")
+	if panicErr, ok := core.AssertTypeIs[*core.PanicError](t, err,
+		"panic type"); ok {
+		core.AssertContains(t, panicErr.Error(), "boom in fn", "panic msg")
+	}
+}
+
+// runTestGoShutdownFnErrorSignalsPeer pins both sides of the rule at once:
+// a failing worker cancels the Group without its own shutdown running,
+// while the still-running peer is signalled to end. Wait returning at all
+// proves the peer's shutdown fired, as nothing else unblocks it.
+func runTestGoShutdownFnErrorSignalsPeer(t *testing.T) {
+	t.Helper()
+	testErr := errors.New("fn failed")
+	peerStop := make(chan struct{})
+	var ownShutdown atomic.Bool
+	wg := workgroup.New(context.Background())
+
+	core.AssertNoError(t, wg.GoShutdown(
+		func(_ context.Context) error { <-peerStop; return nil },
+		func(_ context.Context) { close(peerStop) },
+		time.Second,
+	), "peer GoShutdown")
+	core.AssertNoError(t, wg.GoShutdown(
+		func(_ context.Context) error { return testErr },
+		func(_ context.Context) { ownShutdown.Store(true) },
+		time.Second,
+	), "failing GoShutdown")
+
+	core.AssertErrorIs(t, wg.Wait(), testErr, "wait err")
+	core.AssertFalse(t, ownShutdown.Load(), "own shutdown skipped")
+}
+
+// shutdownObservation captures what the shutdown handler observes about the
+// context it receives, so a caller can assert its detachment, deadline, and
+// values.
+type shutdownObservation struct {
+	err         error
+	value       string
+	hasDeadline bool
+}
+
+// shutdownCtxKey / shutdownCtxValue seed a value into the parent context so
+// the shutdown handler can prove the detached context still carries it.
+var shutdownCtxKey = core.NewContextKey[string]("workgroup-test-trace")
+
+const shutdownCtxValue = "trace-xyz"
+
+// observeShutdownContext enrols a server-pattern GoShutdown with the given
+// grace period, cancels the Group, and returns what the shutdown handler saw
+// of its context. Wait returning proves the handler ran: nothing else
+// unblocks fn.
+func observeShutdownContext(t *testing.T, grace time.Duration) shutdownObservation {
+	t.Helper()
+	var obs shutdownObservation
+	stop := make(chan struct{})
+	parent := shutdownCtxKey.WithValue(context.Background(), shutdownCtxValue)
+
+	wg := workgroup.New(parent)
+	core.AssertNoError(t, wg.GoShutdown(
+		func(_ context.Context) error { <-stop; return nil },
+		func(ctx context.Context) {
+			obs.err = ctx.Err()
+			_, obs.hasDeadline = ctx.Deadline()
+			if v, ok := ctx.Value(shutdownCtxKey).(string); ok {
+				obs.value = v
+			}
+			close(stop)
+		},
+		grace,
+	), "GoShutdown")
+
+	wg.Cancel(nil)
+	core.AssertNoError(t, wg.Wait(), "wait")
+	return obs
+}
+
+// runTestGoShutdownContextBounded pins that a positive grace period hands
+// the shutdown handler a live, value-bearing context with a deadline.
+func runTestGoShutdownContextBounded(t *testing.T) {
+	t.Helper()
+	obs := observeShutdownContext(t, time.Minute)
+	core.AssertNoError(t, obs.err, "shutdown context live")
+	core.AssertTrue(t, obs.hasDeadline, "deadline present")
+	core.AssertEqual(t, shutdownCtxValue, obs.value, "value retained")
+}
+
+// runTestGoShutdownContextUnbounded pins that a non-positive grace period
+// leaves the shutdown context unbounded — live and value-bearing, no
+// deadline.
+func runTestGoShutdownContextUnbounded(t *testing.T) {
+	t.Helper()
+	obs := observeShutdownContext(t, 0)
+	core.AssertNoError(t, obs.err, "shutdown context live")
+	core.AssertFalse(t, obs.hasDeadline, "no deadline when unbounded")
+	core.AssertEqual(t, shutdownCtxValue, obs.value, "value retained")
+}
+
+// runTestGoShutdownPanicContained pins that a panicking shutdown handler is
+// recovered and discarded, so the signal still lands and Wait returns. The
+// handler stops the server before panicking; Wait returning proves both.
+func runTestGoShutdownPanicContained(t *testing.T) {
+	t.Helper()
+	stop := make(chan struct{})
+	wg := workgroup.New(context.Background())
+
+	core.AssertNoError(t, wg.GoShutdown(
+		func(_ context.Context) error { <-stop; return nil },
+		func(_ context.Context) {
+			close(stop)
+			panic("boom in shutdown")
+		},
+		time.Second,
+	), "GoShutdown")
+
+	wg.Cancel(nil)
+	core.AssertNoError(t, wg.Wait(), "wait returns after contained panic")
+}
+
+// runTestGoShutdownWatcherMode pins the nil-fn form: the shutdown handler is
+// enrolled alone as a watcher that holds the Group open until cancellation
+// signals it.
+func runTestGoShutdownWatcherMode(t *testing.T) {
+	t.Helper()
+	shutdownRan := make(chan struct{})
+	wg := workgroup.New(context.Background())
+
+	core.AssertNoError(t, wg.GoShutdown(nil,
+		func(_ context.Context) { close(shutdownRan) }, time.Second),
+		"GoShutdown")
+
+	synctesting.AssertMustOpen(t, shutdownRan, 50*time.Millisecond,
+		"shutdown waits for cancellation")
+	wg.Cancel(nil)
+	synctesting.AssertMustClosed(t, shutdownRan, 100*time.Millisecond,
+		"shutdown ran on cancel")
+	core.AssertNoError(t, wg.Wait(), "wait")
+}
+
+// runTestGoShutdownNilShutdownSuccess pins that a nil shutdown degrades to a
+// plain supervised task that runs fn to completion.
+func runTestGoShutdownNilShutdownSuccess(t *testing.T) {
+	t.Helper()
+	var executed atomic.Bool
+	wg := workgroup.New(context.Background())
+
+	core.AssertNoError(t, wg.GoShutdown(
+		func(_ context.Context) error { executed.Store(true); return nil },
+		nil, time.Second,
+	), "GoShutdown")
+
+	core.AssertNoError(t, wg.Wait(), "wait")
+	core.AssertTrue(t, executed.Load(), "fn executed")
+}
+
+// runTestGoShutdownNilShutdownError pins that the nil-shutdown degrade still
+// supervises fn: its error cancels the Group, as with GoCatch.
+func runTestGoShutdownNilShutdownError(t *testing.T) {
+	t.Helper()
+	testErr := errors.New("fn failed")
+	wg := workgroup.New(context.Background())
+
+	core.AssertNoError(t, wg.GoShutdown(
+		func(_ context.Context) error { return testErr }, nil, time.Second,
+	), "GoShutdown")
+
+	core.AssertErrorIs(t, wg.Wait(), testErr, "wait err")
+}
+
+// runTestGoShutdownBothNil pins that a nil fn and nil shutdown enrol nothing
+// and Wait returns at once.
+func runTestGoShutdownBothNil(t *testing.T) {
+	t.Helper()
+	wg := workgroup.New(context.Background())
+	core.AssertNoError(t, wg.GoShutdown(nil, nil, time.Second), "both nil")
+
+	done := make(chan struct{})
+	go func() { _ = wg.Wait(); close(done) }()
+	synctesting.AssertClosed(t, done, 100*time.Millisecond, "wait immediate")
+}
+
+// goShutdownCancelledCase exercises one GoShutdown enrolment arm against
+// an already cancelled Group: an arm with a handler to enrol refuses with
+// ErrClosed, while the both-nil form has nothing to enrol and returns nil.
+type goShutdownCancelledCase struct {
+	wantErr      error
+	name         string
+	withFn       bool
+	withShutdown bool
+}
+
+func (tc goShutdownCancelledCase) Name() string { return tc.name }
+
+func (tc goShutdownCancelledCase) Test(t *testing.T) {
+	t.Helper()
+	var fnRan, shutdownRan atomic.Bool
+	wg := workgroup.New(context.Background())
+	wg.Cancel(nil)
+
+	err := wg.GoShutdown(tc.fn(&fnRan), tc.shutdown(&shutdownRan), time.Second)
+	if tc.wantErr == nil {
+		core.AssertNoError(t, err, "enrol")
+	} else {
+		core.AssertErrorIs(t, err, tc.wantErr, "enrol")
+	}
+	core.AssertNoError(t, wg.Wait(), "wait")
+	core.AssertFalse(t, fnRan.Load(), "fn not enrolled")
+	core.AssertFalse(t, shutdownRan.Load(), "shutdown not enrolled")
+}
+
+// fn builds the arm's worker handler, nil when the arm leaves fn unset.
+func (tc goShutdownCancelledCase) fn(
+	ran *atomic.Bool,
+) func(context.Context) error {
+	if !tc.withFn {
+		return nil
+	}
+	return func(_ context.Context) error {
+		ran.Store(true)
+		return nil
+	}
+}
+
+// shutdown builds the arm's shutdown handler, nil when the arm leaves
+// shutdown unset.
+func (tc goShutdownCancelledCase) shutdown(
+	ran *atomic.Bool,
+) func(context.Context) {
+	if !tc.withShutdown {
+		return nil
+	}
+	return func(_ context.Context) {
+		ran.Store(true)
+	}
+}
+
+var _ core.TestCase = goShutdownCancelledCase{}
+
+func newGoShutdownCancelledCase(name string, withFn, withShutdown bool,
+	wantErr error) goShutdownCancelledCase {
+	return goShutdownCancelledCase{
+		wantErr:      wantErr,
+		name:         name,
+		withFn:       withFn,
+		withShutdown: withShutdown,
+	}
+}
+
+// runTestGoShutdownEnrolmentWhenCancelled pins each enrolment arm against
+// an already cancelled Group.
+func runTestGoShutdownEnrolmentWhenCancelled(t *testing.T) {
+	t.Helper()
+	core.RunTestCases(t, core.S(
+		newGoShutdownCancelledCase("BothHandlers", true, true, errors.ErrClosed),
+		newGoShutdownCancelledCase("NilShutdown", true, false, errors.ErrClosed),
+		newGoShutdownCancelledCase("Watcher", false, true, errors.ErrClosed),
+		newGoShutdownCancelledCase("BothNil", false, false, nil),
+	))
 }
 
 // BenchmarkWorkgroup measures workgroup operation performance.


### PR DESCRIPTION
## Summary

Adds `Group.GoShutdown` to `sync/workgroup` — a way to enrol a worker that
cannot observe the Group's context (the `http.Server` `ListenAndServe`/
`Shutdown` shape) alongside a handler whose only job is to end it on
cancellation. Along the way, `OnCancel` now hands its handler a live,
detached context rather than the already-cancelled one, which is a
behavioural change for existing `OnCancel` users.

## `GoShutdown` — pairing a worker with its shutdown

Some workers block until told to stop and never look at a context:
`http.Server.ListenAndServe` returns only once `Shutdown` or `Close` is
called. `GoShutdown` enrols such a worker as a single counted task, paired
with a shutdown handler:

```go
func (wg *Group) GoShutdown(
    fn func(context.Context) error,
    shutdown func(context.Context),
    gracePeriod time.Duration,
) error
```

- `fn` runs supervised on an inner goroutine: a panic becomes a
  `core.PanicError`, a non-nil return cancels the Group.
- `shutdown` is invoked **at most once, only when the Group is cancelled
  while `fn` is still running**. It is never a reaction to the worker's own
  end — a clean return simply ends the pair, and an error cancels the Group
  before the pair is released (so a concurrent `Wait` observes the cause),
  but there is nobody left to signal.
- The handler receives a live context detached from the Group's
  cancellation via `context.WithoutCancel`, keeping the Group context's
  values and bounded by `gracePeriod` (unbounded when zero or less). No
  cause is passed, mirroring `http.Server.Shutdown`; `Group.Err` answers
  when it matters. A panic in the handler is recovered and discarded, the
  same rule as `OnCancel`.

Two degenerate pairings are meaningful:

- **nil `fn`** — the handler is enrolled alone as a *watcher*: it holds the
  Group open until cancellation signals it. This is the per-resource
  counterpart to the per-Group `OnCancel` hook — enrol one for each resource
  to release, each with its own grace period and no cause.
- **nil `shutdown`** — `fn` degrades to a plain supervised task, equivalent
  to `GoCatch` with no catch handler.

With both handlers set, enrolling on an already-cancelled Group returns
`ErrClosed`; with both nil there is nothing to enrol and it returns nil.

## `OnCancel` now receives a live, detached context (behavioural change)

`OnCancel` previously received `wg.ctx`, already cancelled by the time the
handler ran. That context was unusable for the handler's own work: a
deadline derived from it was born cancelled, and passing it to a cleanup
call aborted that call at once.

The handler now receives `context.WithoutCancel(wg.ctx)` — the Group
context's values (logger, trace identifiers, request-scoped data) without
its cancellation — so cleanup work can pass it along or build its own grace
deadline on top. The cancellation cause is still delivered through the
`cause` argument.

**Upgrade note:** handlers that read cancellation state off the context
(`ctx.Err`, `ctx.Done`, `context.Cause(ctx)`) now observe a live context
and must take the cause from the `cause` argument instead.

## Internal refactor

`refactor(sync/workgroup): extract doGoRun enrolment helper` pulls
`GoCatch`'s inline supervised-run wrapper into a `doGoRun` helper and splits
`runErr` out of `run`, so the shutdown pair can reuse the supervised path
without its embedded `Cancel`. No behavioural change.

## Tests

The `GoShutdown` dispatcher suite covers the `http.Server` pattern, the
`Close`-as-signal idiom, and the enrolment arms on a cancelled Group
(both-handlers / nil-shutdown / watcher → `ErrClosed`, both-nil → nil).
`OnCancel` gains rows pinning the live context and value retention.

Whole-repo `make all race coverage-sync` passes; CI (Build, Test, Race
Detection, Codecov) is green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added coordinated shutdown support for long-running tasks, helping them stop gracefully when the group is closed.

* **Bug Fixes**
  * Improved cancellation handling so cleanup callbacks run with a live context and keep parent values available.
  * Added safer shutdown behavior with timeout handling and panic containment.

* **Documentation**
  * Clarified how group shutdown and cancellation callbacks behave, including graceful task draining.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->