### PR TITLE
Cross-platform compile checks for windows and darwin

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,10 @@ on:
       - '**-wip'
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   make:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,3 +30,26 @@ jobs:
         cache-dependency-path: '**/go.sum'
     - name: Build
       run: make
+
+  vet:
+    name: vet (${{ matrix.goos }})
+    runs-on: ubuntu-latest
+    if: (github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository)
+    strategy:
+      fail-fast: false
+      matrix:
+        goos: [linux, windows, darwin]
+    steps:
+    - uses: actions/checkout@v7
+    - uses: actions/setup-go@v6
+      with:
+        go-version: '1.26'
+        cache: true
+        cache-dependency-path: '**/go.sum'
+    # make vet compiles every module's packages and tests for the target
+    # GOOS via `go vet`, without running them — a compile check that,
+    # for a non-host GOOS, is the only cross-platform gate we have.
+    - name: make vet
+      env:
+        GOOS: ${{ matrix.goos }}
+      run: make vet

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   make:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     # Pull requests from the same repository won't trigger this checks as they were already triggered by the push
     if: (github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository)
     strategy:
@@ -33,7 +33,7 @@ jobs:
 
   vet:
     name: vet (${{ matrix.goos }})
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     if: (github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository)
     strategy:
       fail-fast: false

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -10,7 +10,7 @@ jobs:
       github.actor != 'renovate[bot]' &&
       !github.event.pull_request.draft &&
       github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -20,7 +20,7 @@ jobs:
         (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && github.event.pull_request.head.repo.full_name == github.repository) ||
         (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
       )
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -9,6 +9,10 @@ on:
       - '**-wip'
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     # Pull requests from the same repository won't trigger this checks as they were already triggered by the push
     if: (github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository)
     steps:

--- a/.github/workflows/race.yml
+++ b/.github/workflows/race.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   race:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     # Pull requests from the same repository won't trigger this checks as they were already triggered by the push
     if: (github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository)
     steps:

--- a/.github/workflows/race.yml
+++ b/.github/workflows/race.yml
@@ -9,6 +9,10 @@ on:
       - '**-wip'
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   race:
     runs-on: ubuntu-latest

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   renovate-config-validator:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     if: (github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository)
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,10 @@ on:
       - '**-wip'
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     # Pull requests from the same repository won't trigger this checks as they were already triggered by the push
     if: (github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository)
     strategy:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -183,8 +183,12 @@ Automated dual coverage reporting across all modules:
 
 GitHub Actions workflows split for better performance:
 
-- **Build workflow** (`.github/workflows/build.yml`): Focuses on compilation
-  only.
+- **Build workflow** (`.github/workflows/build.yml`): Compilation, plus a
+  cross-platform vet gate.
+  - `vet` job runs `make vet` across a `GOOS` matrix (linux, windows,
+    darwin). Because `go vet` compiles every package and its tests without
+    running them, it is the only compile check for the platforms CI cannot
+    execute natively.
 - **Test workflow** (`.github/workflows/test.yml`): Dedicated testing
   pipeline.
   - Race condition detection job with Go 1.26.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -267,6 +267,39 @@ This provides a clean interface for passing arbitrary test flags without
 modifying the Makefile, making it easy to run tests with different
 configurations for debugging, coverage analysis, or CI/CD pipelines.
 
+## Vetting with GOVET_FLAGS
+
+The `GOVET_FLAGS` environment variable allows flexible `go vet`
+execution by passing additional flags. This variable is defined in the
+Makefile with a `-v` default and is used when running vet through the
+generated rules.
+
+### Vet Usage Examples
+
+```bash
+# Run vet quietly (drop the default -v)
+make vet GOVET_FLAGS=
+
+# Vet a single module
+make vet-sync
+
+# Cross-compile and vet every module for another platform
+GOOS=windows make vet
+GOOS=darwin make vet
+```
+
+### How GOVET_FLAGS Works
+
+1. The Makefile defines `GOVET_FLAGS ?= -v`.
+2. The generated rules use it in the vet target:
+   `$(GO) vet $(GOVET_FLAGS) ./...`.
+3. Any flags passed via `GOVET_FLAGS` are forwarded directly to
+   `go vet`.
+
+Because `go vet` compiles each package and its tests for the target
+`GOOS` without running them, `make vet` doubles as a cross-platform
+compile check.
+
 ## Important Notes
 
 - Go 1.25 is the minimum required version.

--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,10 @@ GO ?= go
 GOFMT ?= gofmt
 GOFMT_FLAGS = -w -l -s
 GOGENERATE_FLAGS = -v
+GOTEST_FLAGS ?=
 GOUP_FLAGS ?= -v
 GOUP_PACKAGES ?= ./...
-GOTEST_FLAGS ?=
+GOVET_FLAGS ?= -v
 JQ ?= jq
 
 TOOLSDIR := $(CURDIR)/internal/build

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ endif
 MARKDOWNLINT_FLAGS ?= --fix --config $(TOOLSDIR)/markdownlint.json
 
 ifndef LANGUAGETOOL
-ifeq ($(shell $(DLX) @twilio-labs/languagetool-cli --version 2>&1 | grep -qE '^(unknown|[0-9])' && echo yes),yes)
+ifeq ($(shell $(DLX) @twilio-labs/languagetool-cli --version < /dev/null | grep -qE '^(unknown|[0-9])' && echo yes),yes)
 LANGUAGETOOL = $(DLX) @twilio-labs/languagetool-cli
 else
 LANGUAGETOOL = true
@@ -81,7 +81,7 @@ endif
 LANGUAGETOOL_FLAGS ?= --config $(TOOLSDIR)/languagetool.cfg --custom-dict-file $(TMPDIR)/languagetool-dict.txt
 
 ifndef CSPELL
-ifeq ($(shell $(DLX) cspell --version 2>&1 | grep -q '^[0-9]' && echo yes),yes)
+ifeq ($(shell $(DLX) cspell --version < /dev/null | grep -q '^[0-9]' && echo yes),yes)
 CSPELL = $(DLX) cspell
 else
 CSPELL = true
@@ -90,7 +90,7 @@ endif
 CSPELL_FLAGS ?= --no-progress --dot --config $(TOOLSDIR)/cspell.json
 
 ifndef SHELLCHECK
-ifeq ($(shell $(DLX) shellcheck --version 2>&1 | grep -q '^ShellCheck' && echo yes),yes)
+ifeq ($(shell $(DLX) shellcheck --version < /dev/null | grep -q '^ShellCheck' && echo yes),yes)
 SHELLCHECK = $(DLX) shellcheck
 else
 SHELLCHECK = true

--- a/config/AGENTS.md
+++ b/config/AGENTS.md
@@ -36,9 +36,13 @@ For detailed API documentation and usage examples, see [README.md](README.md).
   logic.
 - `const_unix.go`: the unix `Prefix` constants (`PrefixUser` and the
   FHS prefixes) plus the `isWellKnown` membership check (`!windows`).
+- `const_windows.go`: the Windows `Prefix` constants (`PrefixUser`
+  `@user` and `PrefixSystem` `%ProgramData%`) plus the `isWellKnown`
+  membership check (`windows`).
 - `appdir_xdg.go`: XDG Base Directory Specification implementation
   (`!windows`).
 - `appdir_fhs.go`: Filesystem Hierarchy Standard support (`!windows`).
+- `appdir_windows.go`: stubbed Windows resolvers.
 - `utils.go`: path-composition helpers (`Join` and friends).
 
 ## Architecture Notes

--- a/config/AGENTS.md
+++ b/config/AGENTS.md
@@ -34,6 +34,8 @@ For detailed API documentation and usage examples, see [README.md](README.md).
 
 - `appdir.go`: `Prefix` type, user-mode helpers, and core resolution
   logic.
+- `const_unix.go`: the unix `Prefix` constants (`PrefixUser` and the
+  FHS prefixes) plus the `isWellKnown` membership check (`!windows`).
 - `appdir_xdg.go`: XDG Base Directory Specification implementation
   (`!windows`).
 - `appdir_fhs.go`: Filesystem Hierarchy Standard support (`!windows`).

--- a/config/appdir/appdir.go
+++ b/config/appdir/appdir.go
@@ -24,10 +24,6 @@ import (
 // error.
 type Prefix string
 
-// PrefixUser is the Prefix indicating user mode, where the
-// FooDir methods return the same as UserFooDir().
-const PrefixUser Prefix = "~"
-
 // prefix is the default Prefix used by the top-level
 // SysFooDir functions.
 var prefix = PrefixUser
@@ -59,12 +55,11 @@ func NewPrefix(dir string) (Prefix, error) {
 // which carries no root — fails with [fs.ErrInvalid], the stat
 // error, or [syscall.ENOTDIR].
 func (p Prefix) Validate() error {
-	switch p {
-	case PrefixUser, PrefixSystem, PrefixLocal, PrefixOptional:
+	if p.isWellKnown() {
 		return nil
-	default:
-		return p.validateDir()
 	}
+
+	return p.validateDir()
 }
 
 // validateDir requires the Prefix to be an absolute path to an

--- a/config/appdir/appdir.go
+++ b/config/appdir/appdir.go
@@ -28,12 +28,17 @@ type Prefix string
 // SysFooDir functions.
 var prefix = PrefixUser
 
-// NewPrefix returns a Prefix for the given directory, resolved
-// to an absolute path and validated via [Prefix.Validate]. The
-// special value "~" returns [PrefixUser] instead.
+// NewPrefix returns a Prefix for the given directory. A
+// well-known hint — [PrefixUser] or one of the system
+// prefixes [PrefixSystem], [PrefixLocal] and [PrefixOptional] —
+// is symbolic, expanded by the per-OS resolver at composition
+// time, so it is returned unchanged. Any other value is treated
+// as a path: resolved to absolute and validated via
+// [Prefix.Validate].
 func NewPrefix(dir string) (Prefix, error) {
-	if Prefix(dir) == PrefixUser {
-		return PrefixUser, nil
+	p := Prefix(dir)
+	if p.isWellKnown() {
+		return p, nil
 	}
 
 	s, err := filepath.Abs(dir)
@@ -41,7 +46,7 @@ func NewPrefix(dir string) (Prefix, error) {
 		return "", err
 	}
 
-	p := Prefix(s)
+	p = Prefix(s)
 	if err := p.Validate(); err != nil {
 		return "", err
 	}

--- a/config/appdir/appdir.go
+++ b/config/appdir/appdir.go
@@ -48,7 +48,7 @@ func loadPrefix() Prefix {
 // as a path: resolved to absolute and validated via
 // [Prefix.Validate]. The empty string is rejected rather than
 // silently resolving to the working directory.
-func NewPrefix(dir string) (Prefix, error) {
+func NewPrefix[T string | Prefix](dir T) (Prefix, error) {
 	p := Prefix(dir)
 	if p.isWellKnown() {
 		return p, nil
@@ -61,7 +61,7 @@ func NewPrefix(dir string) (Prefix, error) {
 		return "", p.Validate()
 	}
 
-	s, err := filepath.Abs(dir)
+	s, err := filepath.Abs(string(dir))
 	if err != nil {
 		return "", err
 	}
@@ -114,8 +114,8 @@ func (p Prefix) validateDir() error {
 // when generating SysFooDir() strings. The well-known
 // [PrefixUser] selects user mode, the default. It is safe to
 // call concurrently with the SysFooDir readers.
-func SetSysPrefix(dir string) error {
-	p, err := NewPrefix(dir)
+func SetSysPrefix[T string | Prefix](dir T) error {
+	p, err := NewPrefix(string(dir))
 	if err != nil {
 		return err
 	}

--- a/config/appdir/appdir.go
+++ b/config/appdir/appdir.go
@@ -9,6 +9,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"syscall"
 
 	"darvaza.org/core"
@@ -24,9 +25,20 @@ import (
 // error.
 type Prefix string
 
-// prefix is the default Prefix used by the top-level
-// SysFooDir functions.
-var prefix = PrefixUser
+// prefix is the default Prefix used by the top-level SysFooDir
+// functions. It is stored atomically so [SetSysPrefix] is safe
+// against concurrent readers, and initialised to [PrefixUser].
+var prefix atomic.Pointer[Prefix]
+
+func init() {
+	u := PrefixUser
+	prefix.Store(&u)
+}
+
+// loadPrefix returns the current default Prefix.
+func loadPrefix() Prefix {
+	return *prefix.Load()
+}
 
 // NewPrefix returns a Prefix for the given directory. A
 // well-known hint — [PrefixUser] or one of the system
@@ -91,22 +103,23 @@ func (p Prefix) validateDir() error {
 }
 
 // SetSysPrefix specifies what filesystem prefix to use
-// when generating SysFooDir() strings. The special value "~"
-// selects user mode ([PrefixUser]), the default.
+// when generating SysFooDir() strings. The well-known
+// [PrefixUser] selects user mode, the default. It is safe to
+// call concurrently with the SysFooDir readers.
 func SetSysPrefix(dir string) error {
 	p, err := NewPrefix(dir)
 	if err != nil {
 		return err
 	}
 
-	prefix = p
+	prefix.Store(&p)
 	return nil
 }
 
 // SysPrefix returns the default Prefix used by the top-level
 // SysFooDir functions.
 func SysPrefix() Prefix {
-	return prefix
+	return loadPrefix()
 }
 
 // UserCacheDir returns where to store application cache
@@ -195,25 +208,25 @@ func (p Prefix) RuntimeDir(sub ...string) (string, error) {
 // SysCacheDir returns where to store application cache,
 // when run in system mode.
 func SysCacheDir(sub ...string) (string, error) {
-	return prefix.CacheDir(sub...)
+	return loadPrefix().CacheDir(sub...)
 }
 
 // SysConfigDir returns where to store application configuration
 // data, when run in system mode.
 func SysConfigDir(sub ...string) (string, error) {
-	return prefix.ConfigDir(sub...)
+	return loadPrefix().ConfigDir(sub...)
 }
 
 // SysDataDir returns where to store application persistent
 // data, when run in system mode.
 func SysDataDir(sub ...string) (string, error) {
-	return prefix.DataDir(sub...)
+	return loadPrefix().DataDir(sub...)
 }
 
 // SysRuntimeDir returns where to store application run-time
 // variable data, when run in system mode.
 func SysRuntimeDir(sub ...string) (string, error) {
-	return prefix.RuntimeDir(sub...)
+	return loadPrefix().RuntimeDir(sub...)
 }
 
 // AllConfigDir returns a slice containing the application
@@ -253,5 +266,5 @@ func (p Prefix) AllConfigDir(sub ...string) []string {
 // configuration path on the current working directory, user mode,
 // and system mode.
 func AllConfigDir(sub ...string) []string {
-	return prefix.AllConfigDir(sub...)
+	return loadPrefix().AllConfigDir(sub...)
 }

--- a/config/appdir/appdir.go
+++ b/config/appdir/appdir.go
@@ -46,11 +46,19 @@ func loadPrefix() Prefix {
 // is symbolic, expanded by the per-OS resolver at composition
 // time, so it is returned unchanged. Any other value is treated
 // as a path: resolved to absolute and validated via
-// [Prefix.Validate].
+// [Prefix.Validate]. The empty string is rejected rather than
+// silently resolving to the working directory.
 func NewPrefix(dir string) (Prefix, error) {
 	p := Prefix(dir)
 	if p.isWellKnown() {
 		return p, nil
+	}
+
+	if dir == "" {
+		// filepath.Abs("") resolves to the working directory,
+		// which would anchor the system tree at cwd; reject it
+		// as the zero value Validate already does.
+		return "", p.Validate()
 	}
 
 	s, err := filepath.Abs(dir)

--- a/config/appdir/appdir_fhs.go
+++ b/config/appdir/appdir_fhs.go
@@ -10,20 +10,6 @@ import (
 	"darvaza.org/core"
 )
 
-const (
-	// PrefixLocal represents services installed outside
-	// the scope of the package manager.
-	PrefixLocal Prefix = "/usr/local"
-	// PrefixSystem represents services installed by
-	// the package manager.
-	PrefixSystem Prefix = "/"
-	// PrefixOptional represents services installed outside
-	// the scope of the package manager but requiring
-	// a complex hierarchy, usually installed by extracting
-	// an archive file.
-	PrefixOptional Prefix = "/opt"
-)
-
 func (p Prefix) sysCacheDir(sub ...string) (string, error) {
 	return p.sysDir("/var/cache", sub...)
 }

--- a/config/appdir/appdir_test.go
+++ b/config/appdir/appdir_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package appdir_test
 
 import (
@@ -18,7 +20,6 @@ var _ core.TestCase = userDirTestCase{}
 var _ core.TestCase = userDirErrTestCase{}
 var _ core.TestCase = sysDirTestCase{}
 var _ core.TestCase = sysUserModeTestCase{}
-var _ core.TestCase = newPrefixTestCase{}
 var _ core.TestCase = setSysPrefixTestCase{}
 
 // userDirTestCase tests the UserFooDir functions honouring their
@@ -388,79 +389,6 @@ func TestSysDirUserMode(t *testing.T) {
 	core.RunTestCases(t, testCases)
 }
 
-// newPrefixTestCase tests [appdir.NewPrefix] validation and
-// path resolution.
-type newPrefixTestCase struct {
-	wantErrIs error
-	dir       string
-	name      string
-	want      appdir.Prefix
-}
-
-func (tc newPrefixTestCase) Name() string {
-	return tc.name
-}
-
-func (tc newPrefixTestCase) Test(t *testing.T) {
-	t.Helper()
-
-	got, err := appdir.NewPrefix(tc.dir)
-	if tc.wantErrIs != nil {
-		core.AssertErrorIs(t, err, tc.wantErrIs, "new prefix")
-		return
-	}
-
-	core.AssertMustNoError(t, err, "new prefix")
-	core.AssertEqual(t, tc.want, got, "prefix")
-}
-
-// newNewPrefixTestCase declares a row expected to succeed, with
-// want holding the resulting Prefix value.
-func newNewPrefixTestCase(name, dir string,
-	want appdir.Prefix) newPrefixTestCase {
-	return newPrefixTestCase{
-		dir:  dir,
-		name: name,
-		want: want,
-	}
-}
-
-// newNewPrefixTestCaseErr declares a row expected to fail.
-func newNewPrefixTestCaseErr(name, dir string,
-	wantErrIs error) newPrefixTestCase {
-	return newPrefixTestCase{
-		wantErrIs: wantErrIs,
-		dir:       dir,
-		name:      name,
-	}
-}
-
-func newPrefixTestCases(tmp, file, cwd string) []newPrefixTestCase {
-	return core.S(
-		newNewPrefixTestCase("user mode", "~", appdir.PrefixUser),
-		newNewPrefixTestCase("existing dir", tmp,
-			appdir.Prefix(tmp)),
-		newNewPrefixTestCase("relative path", ".",
-			appdir.Prefix(cwd)),
-		newNewPrefixTestCaseErr("missing path",
-			filepath.Join(tmp, "missing"), fs.ErrNotExist),
-		newNewPrefixTestCaseErr("regular file", file,
-			syscall.ENOTDIR),
-	)
-}
-
-func TestNewPrefix(t *testing.T) {
-	tmp := t.TempDir()
-	file := filepath.Join(tmp, "file")
-	err := os.WriteFile(file, []byte("x"), 0o600)
-	core.AssertMustNoError(t, err, "write file")
-
-	cwd, err := os.Getwd()
-	core.AssertMustNoError(t, err, "getwd")
-
-	core.RunTestCases(t, newPrefixTestCases(tmp, file, cwd))
-}
-
 // TestNewPrefixAbsError pins [appdir.NewPrefix] propagating the
 // filepath.Abs failure resolving a relative argument when the
 // working directory no longer exists.
@@ -551,17 +479,6 @@ func TestSetSysPrefix(t *testing.T) {
 	core.AssertMustNoError(t, err, "getwd")
 
 	core.RunTestCases(t, setSysPrefixTestCases(tmp, file, cwd))
-}
-
-// TestSysPrefix pins the getter reflecting the current default
-// Prefix.
-func TestSysPrefix(t *testing.T) {
-	core.AssertEqual(t, appdir.PrefixUser, appdir.SysPrefix(),
-		"default")
-
-	t.Cleanup(appdir.StubSysPrefix(appdir.PrefixSystem))
-	core.AssertEqual(t, appdir.PrefixSystem, appdir.SysPrefix(),
-		"stubbed")
 }
 
 // TestSetSysPrefixUserMode pins "~" returning the package to user

--- a/config/appdir/appdir_windows.go
+++ b/config/appdir/appdir_windows.go
@@ -1,0 +1,32 @@
+package appdir
+
+import "darvaza.org/core"
+
+// The native Windows resolvers are not implemented yet: each
+// entry point reports [core.ErrNotImplemented] so the package
+// builds and vets on Windows. The real implementation lands with
+// the Windows support work, replacing this file in place.
+
+func getUserDataDir() (string, error) {
+	return "", core.ErrNotImplemented
+}
+
+func getUserRuntimeDir() (string, error) {
+	return "", core.ErrNotImplemented
+}
+
+func (Prefix) sysCacheDir(...string) (string, error) {
+	return "", core.ErrNotImplemented
+}
+
+func (Prefix) sysConfigDir(...string) (string, error) {
+	return "", core.ErrNotImplemented
+}
+
+func (Prefix) sysDataDir(...string) (string, error) {
+	return "", core.ErrNotImplemented
+}
+
+func (Prefix) sysRuntimeDir(...string) (string, error) {
+	return "", core.ErrNotImplemented
+}

--- a/config/appdir/const_unix.go
+++ b/config/appdir/const_unix.go
@@ -1,0 +1,31 @@
+//go:build !windows
+
+package appdir
+
+const (
+	// PrefixUser is the Prefix indicating user mode, where the
+	// FooDir methods return the same as UserFooDir().
+	PrefixUser Prefix = "~"
+	// PrefixLocal represents services installed outside
+	// the scope of the package manager.
+	PrefixLocal Prefix = "/usr/local"
+	// PrefixSystem represents services installed by
+	// the package manager.
+	PrefixSystem Prefix = "/"
+	// PrefixOptional represents services installed outside
+	// the scope of the package manager but requiring
+	// a complex hierarchy, usually installed by extracting
+	// an archive file.
+	PrefixOptional Prefix = "/opt"
+)
+
+// isWellKnown reports whether p is one of the predefined
+// prefixes.
+func (p Prefix) isWellKnown() bool {
+	switch p {
+	case PrefixUser, PrefixSystem, PrefixLocal, PrefixOptional:
+		return true
+	default:
+		return false
+	}
+}

--- a/config/appdir/const_windows.go
+++ b/config/appdir/const_windows.go
@@ -1,0 +1,23 @@
+package appdir
+
+const (
+	// PrefixUser is the Prefix indicating user mode, where the
+	// FooDir methods return the same as UserFooDir(). Windows
+	// has no home-relative "~"; its symbolic token is "@user".
+	PrefixUser Prefix = "@user"
+	// PrefixSystem composes the system-mode directories under
+	// the machine-wide application data directory,
+	// %ProgramData%, resolved when composing.
+	PrefixSystem Prefix = `%ProgramData%`
+)
+
+// isWellKnown reports whether p is one of the predefined
+// prefixes.
+func (p Prefix) isWellKnown() bool {
+	switch p {
+	case PrefixUser, PrefixSystem:
+		return true
+	default:
+		return false
+	}
+}

--- a/config/appdir/prefix_test.go
+++ b/config/appdir/prefix_test.go
@@ -15,6 +15,7 @@ import (
 // Compile-time verification that test case types implement TestCase interface
 var _ core.TestCase = prefixValidateTestCase{}
 var _ core.TestCase = prefixUserModeTestCase{}
+var _ core.TestCase = newPrefixTestCase{}
 
 // prefixValidateTestCase tests [appdir.Prefix.Validate] pinning the
 // usability contract — a well-known prefix or an absolute path to
@@ -129,4 +130,88 @@ func TestPrefixUserMode(t *testing.T) {
 	)
 
 	core.RunTestCases(t, testCases)
+}
+
+// newPrefixTestCase tests [appdir.NewPrefix] validation and
+// path resolution.
+type newPrefixTestCase struct {
+	wantErrIs error
+	dir       string
+	name      string
+	want      appdir.Prefix
+}
+
+func (tc newPrefixTestCase) Name() string {
+	return tc.name
+}
+
+func (tc newPrefixTestCase) Test(t *testing.T) {
+	t.Helper()
+
+	got, err := appdir.NewPrefix(tc.dir)
+	if tc.wantErrIs != nil {
+		core.AssertErrorIs(t, err, tc.wantErrIs, "new prefix")
+		return
+	}
+
+	core.AssertMustNoError(t, err, "new prefix")
+	core.AssertEqual(t, tc.want, got, "prefix")
+}
+
+// newNewPrefixTestCase declares a row expected to succeed, with
+// want holding the resulting Prefix value.
+func newNewPrefixTestCase(name, dir string,
+	want appdir.Prefix) newPrefixTestCase {
+	return newPrefixTestCase{
+		dir:  dir,
+		name: name,
+		want: want,
+	}
+}
+
+// newNewPrefixTestCaseErr declares a row expected to fail.
+func newNewPrefixTestCaseErr(name, dir string,
+	wantErrIs error) newPrefixTestCase {
+	return newPrefixTestCase{
+		wantErrIs: wantErrIs,
+		dir:       dir,
+		name:      name,
+	}
+}
+
+func newPrefixTestCases(tmp, file, cwd string) []newPrefixTestCase {
+	return core.S(
+		newNewPrefixTestCase("user mode", "~", appdir.PrefixUser),
+		newNewPrefixTestCase("existing dir", tmp,
+			appdir.Prefix(tmp)),
+		newNewPrefixTestCase("relative path", ".",
+			appdir.Prefix(cwd)),
+		newNewPrefixTestCaseErr("missing path",
+			filepath.Join(tmp, "missing"), fs.ErrNotExist),
+		newNewPrefixTestCaseErr("regular file", file,
+			syscall.ENOTDIR),
+	)
+}
+
+func TestNewPrefix(t *testing.T) {
+	tmp := t.TempDir()
+	file := filepath.Join(tmp, "file")
+	err := os.WriteFile(file, []byte("x"), 0o600)
+	core.AssertMustNoError(t, err, "write file")
+
+	cwd, err := os.Getwd()
+	core.AssertMustNoError(t, err, "getwd")
+
+	core.RunTestCases(t, newPrefixTestCases(tmp, file, cwd))
+}
+
+// TestSysPrefix pins the getter reflecting the current default
+// Prefix.
+func TestSysPrefix(t *testing.T) {
+	core.AssertEqual(t, appdir.PrefixUser, appdir.SysPrefix(),
+		"default")
+
+	t.Cleanup(appdir.StubSysPrefix(appdir.PrefixSystem))
+	core.AssertEqual(t, appdir.PrefixSystem, appdir.SysPrefix(),
+		"stubbed")
 }

--- a/config/appdir/prefix_test.go
+++ b/config/appdir/prefix_test.go
@@ -190,6 +190,7 @@ func newPrefixTestCases(tmp, file, cwd string) []newPrefixTestCase {
 			appdir.Prefix(tmp)),
 		newNewPrefixTestCase("relative path", ".",
 			appdir.Prefix(cwd)),
+		newNewPrefixTestCaseErr("empty", "", fs.ErrInvalid),
 		newNewPrefixTestCaseErr("missing path",
 			filepath.Join(tmp, "missing"), fs.ErrNotExist),
 		newNewPrefixTestCaseErr("regular file", file,

--- a/config/appdir/prefix_test.go
+++ b/config/appdir/prefix_test.go
@@ -180,8 +180,11 @@ func newNewPrefixTestCaseErr(name, dir string,
 }
 
 func newPrefixTestCases(tmp, file, cwd string) []newPrefixTestCase {
-	return core.S(
-		newNewPrefixTestCase("user mode", "~", appdir.PrefixUser),
+	cases := core.S(
+		newNewPrefixTestCase("user mode",
+			string(appdir.PrefixUser), appdir.PrefixUser),
+		newNewPrefixTestCase("system prefix",
+			string(appdir.PrefixSystem), appdir.PrefixSystem),
 		newNewPrefixTestCase("existing dir", tmp,
 			appdir.Prefix(tmp)),
 		newNewPrefixTestCase("relative path", ".",
@@ -191,6 +194,7 @@ func newPrefixTestCases(tmp, file, cwd string) []newPrefixTestCase {
 		newNewPrefixTestCaseErr("regular file", file,
 			syscall.ENOTDIR),
 	)
+	return append(cases, osNewPrefixTestCases()...)
 }
 
 func TestNewPrefix(t *testing.T) {

--- a/config/appdir/prefix_test.go
+++ b/config/appdir/prefix_test.go
@@ -228,7 +228,7 @@ func TestSysPrefix(t *testing.T) {
 func TestSysPrefixConcurrent(t *testing.T) {
 	t.Cleanup(appdir.StubSysPrefix(appdir.PrefixUser))
 
-	dirs := core.S(string(appdir.PrefixUser), string(appdir.PrefixSystem))
+	dirs := core.S(appdir.PrefixUser, appdir.PrefixSystem)
 
 	var wg sync.WaitGroup
 	for i := range 16 {

--- a/config/appdir/prefix_test.go
+++ b/config/appdir/prefix_test.go
@@ -4,6 +4,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"sync"
 	"syscall"
 	"testing"
 
@@ -218,4 +219,25 @@ func TestSysPrefix(t *testing.T) {
 	t.Cleanup(appdir.StubSysPrefix(appdir.PrefixSystem))
 	core.AssertEqual(t, appdir.PrefixSystem, appdir.SysPrefix(),
 		"stubbed")
+}
+
+// TestSysPrefixConcurrent exercises the atomic default under
+// concurrent writers and readers. Run with -race it guards
+// against a data race on the package-level prefix.
+func TestSysPrefixConcurrent(t *testing.T) {
+	t.Cleanup(appdir.StubSysPrefix(appdir.PrefixUser))
+
+	dirs := core.S(string(appdir.PrefixUser), string(appdir.PrefixSystem))
+
+	var wg sync.WaitGroup
+	for i := range 16 {
+		dir := dirs[i%len(dirs)]
+		wg.Go(func() {
+			_ = appdir.SetSysPrefix(dir)
+		})
+		wg.Go(func() {
+			_, _ = appdir.SysCacheDir("app")
+		})
+	}
+	wg.Wait()
 }

--- a/config/appdir/prefix_unix_test.go
+++ b/config/appdir/prefix_unix_test.go
@@ -1,0 +1,23 @@
+//go:build !windows
+
+package appdir_test
+
+import (
+	"darvaza.org/core"
+
+	"darvaza.org/x/config/appdir"
+)
+
+// osNewPrefixTestCases supplies the platform-specific well-known
+// prefixes exercised by [appdir.NewPrefix]. On unix the FHS
+// prefixes [appdir.PrefixLocal] and [appdir.PrefixOptional]
+// extend the portable [appdir.PrefixUser] and
+// [appdir.PrefixSystem] set.
+func osNewPrefixTestCases() []newPrefixTestCase {
+	return core.S(
+		newNewPrefixTestCase("local prefix",
+			string(appdir.PrefixLocal), appdir.PrefixLocal),
+		newNewPrefixTestCase("optional prefix",
+			string(appdir.PrefixOptional), appdir.PrefixOptional),
+	)
+}

--- a/config/appdir/prefix_windows_test.go
+++ b/config/appdir/prefix_windows_test.go
@@ -1,0 +1,11 @@
+//go:build windows
+
+package appdir_test
+
+// osNewPrefixTestCases supplies the platform-specific well-known
+// prefixes exercised by [appdir.NewPrefix]. Windows recognises no
+// FHS-style prefixes beyond the portable [appdir.PrefixUser] and
+// [appdir.PrefixSystem], so it contributes none.
+func osNewPrefixTestCases() []newPrefixTestCase {
+	return nil
+}

--- a/config/appdir/testutils_internal_test.go
+++ b/config/appdir/testutils_internal_test.go
@@ -4,9 +4,9 @@ package appdir
 // filesystem validation performed by [SetSysPrefix], and returns a
 // function restoring the previous value, keeping tests isolated.
 func StubSysPrefix(p Prefix) func() {
-	prev := prefix
-	prefix = p
+	prev := prefix.Load()
+	prefix.Store(&p)
 	return func() {
-		prefix = prev
+		prefix.Store(prev)
 	}
 }

--- a/fs/AGENTS.md
+++ b/fs/AGENTS.md
@@ -44,7 +44,7 @@ The package follows several design principles:
 Key patterns:
 
 - Interfaces follow os package naming conventions (e.g., ChmodFS for Chmod).
-- Platform-specific code uses build tags (_linux.go_, _windows.go).
+- Platform-specific code uses build tags (_unix.go,_windows.go).
 - Glob patterns support `**` for recursive matching.
 
 ## Development Commands

--- a/fs/README.md
+++ b/fs/README.md
@@ -126,7 +126,7 @@ through platform-specific syscalls.
 
 The implementation uses native APIs on each platform:
 
-* **Linux**: Uses `flock()` syscalls with `LOCK_EX` and `LOCK_NB` flags.
+* **Unix**: Uses `flock()` syscalls with `LOCK_EX` and `LOCK_NB` flags.
 * **Windows**: Uses `LockFileEx()` and `UnlockFileEx()` Win32 APIs.
 
 All platforms return `syscall.EBUSY` when `TryLockEx` cannot acquire a lock

--- a/fs/fssyscall/syscall_unix.go
+++ b/fs/fssyscall/syscall_unix.go
@@ -1,4 +1,4 @@
-//go:build linux
+//go:build unix
 
 package fssyscall
 

--- a/internal/build/cspell.json
+++ b/internal/build/cspell.json
@@ -48,6 +48,7 @@
     "fsys",
     "gobwas",
     "golangci",
+    "GOOS",
     "GOPATH",
     "goroutines",
     "Gosched",

--- a/internal/build/gen_mk.sh
+++ b/internal/build/gen_mk.sh
@@ -6,7 +6,7 @@ set -eu
 INDEX="$1"
 
 PROJECTS="$(cut -d':' -f1 "$INDEX")"
-COMMANDS="tidy get build test coverage race up"
+COMMANDS="tidy get build test vet coverage race up"
 
 TAB=$(printf "\t")
 
@@ -142,6 +142,9 @@ gen_make_targets() {
 		;;
 	race)
 		call="env CGO_ENABLED=1 \$(GO) test -race -count=1 \$(GOTEST_FLAGS) ./..."
+		;;
+	vet)
+		call="\$(GO) vet \$(GOVET_FLAGS) ./..."
 		;;
 	*)
 		call="\$(GO) $cmd -v ./..."


### PR DESCRIPTION
## Cross-platform compile checks for windows and darwin

CI built and tested `x` only on its Linux host, so a package that
failed to compile for another `GOOS` went unnoticed until someone
built it there — and these are libraries meant to be imported well
beyond Linux. This branch adds a cross-platform compile gate and
makes the whole monorepo pass it with **no per-module exclusions**.

### The gate

- **`build: generate a make vet target`** — the build system emitted
  `tidy`/`build`/`test`/`race` but no `vet`, so there was no single
  command to type-check every module. The generator now emits an
  aggregate `vet` target and a `vet-<module>` per module, each running
  `go vet $(GOVET_FLAGS) ./...` and honouring `GOOS`. A new
  `GOVET_FLAGS` (default `-v`) mirrors how `GOTEST_FLAGS` threads into
  `test`/`race`. Because `go vet` compiles each package **and its
  tests** without running them, `GOOS=<os> make vet` is a
  cross-platform compile check.
- **`ci: vet every module across a GOOS matrix`** — a `vet` job in
  `build.yml` runs `make vet` across `linux`, `windows` and `darwin`.
  The non-host rows are the only compile check for platforms the
  runners cannot execute; the linux row vets natively.

### Making the tree pass

- **`build(config/appdir): compile on Windows with stubbed
  resolvers`** — the portable `appdir.go` referenced six resolvers
  that only the unix files defined, so the package built on unix-like
  systems alone. `const_windows.go` lands with the Windows `Prefix`
  set — `PrefixUser` as `@user` and `PrefixSystem` as `%ProgramData%`,
  with no FHS prefixes; `appdir_windows.go` stubs the six symbols, each
  returning
  `core.ErrNotImplemented`, at its final filename so the native
  resolvers replace the body in place when they land. The package now
  links and vets on Windows — it does **not** yet resolve native
  Windows directories.
- **`build(fs/fssyscall): share the advisory-lock implementation
  across unix`** — `fssyscall` carried a Linux-only lock file, so it
  did not compile on darwin. The Linux code is nothing but the BSD
  `flock(2)` interface, identical on darwin and the BSDs, so
  `syscall_linux.go` is renamed to `syscall_unix.go` with its tag
  widened from `linux` to `unix`; one file now serves every unix
  platform.
- **`refactor(config/appdir): gather the Prefix type into its own
  files`** — preparatory, no behaviour change: it gathers the scattered
  `Prefix` constants and tests into `const_unix.go` and
  `prefix_test.go`, so the type is self-contained and its per-platform
  variants (above) have a clear home.

### appdir hardening

- **`fix(config/appdir): guard the default prefix with an atomic`** —
  the package-level default `prefix` becomes an
  `atomic.Pointer[Prefix]`, so `SetSysPrefix` is safe against concurrent
  `SysFooDir` readers; a `-race` regression test pins it.
- **`fix(config/appdir): reject the empty prefix in NewPrefix`** —
  `filepath.Abs("")` resolves to the working directory, so
  `NewPrefix("")` silently anchored the system tree at cwd. It is now
  rejected through `Validate`, matching `Prefix("").Validate()`.
- **`refactor(config/appdir): accept Prefix in NewPrefix and
  SetSysPrefix`** — both take a `string | Prefix` type parameter, so the
  well-known constants pass straight through — `SetSysPrefix(PrefixUser)`
  — without a `string()` cast. Non-breaking; plain string callers keep
  compiling.

### CI and build hygiene

- **`ci: cancel superseded workflow runs per ref`** — each workflow
  gains a `concurrency` group keyed on the ref with
  `cancel-in-progress`, so a fresh push cancels the in-flight run on the
  same branch instead of burning runners on stale results.
- **`ci: run workflows on Depot runners`** — every job moves from
  `ubuntu-latest` to `depot-ubuntu-latest`.
- **`build: feed tool-detection probes EOF on stdin`** — the
  languagetool, cspell and shellcheck availability probes redirect stdin
  from `/dev/null`, so a tool that reads stdin can no longer block the
  `$(shell …)` expansion.

### Verification

`make vet` passes whole-repo on the host and under `GOOS=windows` /
`GOOS=darwin`; `make tidy` and `make all race` are green. On CI, the
Build workflow's `vet (linux)`, `vet (windows)` and `vet (darwin)`
jobs all pass alongside the existing `make`, Test, Race and Codecov
runs.

### Follow-up

The native Windows resolvers in `config/appdir` remain stubbed
(`core.ErrNotImplemented`); implementing them is separate work. Porting
the `vet` target and its docs to `core` and `core/BUILDING.md` is
likewise deferred.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cross-platform app directory prefix support, including Windows token-based prefixes.
  * Introduced configurable `go vet` checks with cross-platform compile-only validation.
* **Bug Fixes**
  * Improved concurrency safety for updating and reading the system directory prefix.
  * Refined Unix advisory file locking documentation.
* **Documentation**
  * Updated CI vet responsibilities and added guidance for `GOVET_FLAGS`.
  * Corrected platform/build-tag notes in docs.
* **Chores**
  * CI workflows now use concurrency cancellation and updated runner images; expanded generated `vet` Make target.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
