### PR TITLE
ci: cross-build vet, depot runners, and self-hosted OCR review

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,10 @@ on:
       - '**-wip'
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   make:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   make:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04
     # Pull requests from the same repository won't trigger this checks as they were already triggered by the push
     if: (github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository)
     strategy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,3 +30,26 @@ jobs:
         cache-dependency-path: '**/go.sum'
     - name: Build
       run: make
+
+  vet:
+    name: vet (${{ matrix.goos }})
+    runs-on: ubuntu-latest
+    if: (github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository)
+    strategy:
+      fail-fast: false
+      matrix:
+        goos: [linux, windows, darwin]
+    steps:
+    - uses: actions/checkout@v7
+    - uses: actions/setup-go@v6
+      with:
+        go-version: '1.26'
+        cache: true
+        cache-dependency-path: '**/go.sum'
+    # make vet compiles every module's packages and tests for the target
+    # GOOS via `go vet`, without running them — a compile check that,
+    # for a non-host GOOS, is the only cross-platform gate we have.
+    - name: make vet
+      env:
+        GOOS: ${{ matrix.goos }}
+      run: make vet

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -10,7 +10,7 @@ jobs:
       github.actor != 'renovate[bot]' &&
       !github.event.pull_request.draft &&
       github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -20,7 +20,7 @@ jobs:
         (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && github.event.pull_request.head.repo.full_name == github.repository) ||
         (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
       )
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -9,6 +9,10 @@ on:
       - '**-wip'
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04
     # Pull requests from the same repository won't trigger this checks as they were already triggered by the push
     if: (github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository)
     steps:

--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -1,0 +1,29 @@
+name: OCR Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+
+concurrency:
+  group: ocr-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  ocr-review:
+    if: |
+      github.actor != 'renovate[bot]' &&
+      !github.event.pull_request.draft &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: [self-hosted, linux, x64, runner1]
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Review against compute3 (Ollama, OpenAI-compatible)
+        uses: alibaba/open-code-review@v1.7.8
+        with:
+          llm_url: http://compute3.lan:11434/v1
+          llm_model: qwen3-coder:30b
+          llm_auth_token: ollama
+          llm_use_anthropic: 'false'

--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -20,10 +20,4 @@ jobs:
       pull-requests: write
 
     steps:
-      - name: Review against compute3 (Ollama, OpenAI-compatible)
-        uses: alibaba/open-code-review@v1.7.8
-        with:
-          llm_url: http://compute3.lan:11434/v1
-          llm_model: qwen3-coder:30b
-          llm_auth_token: ollama
-          llm_use_anthropic: 'false'
+      - uses: apptly-dev/mnggal-mnggal-reviewer@v1

--- a/.github/workflows/race.yml
+++ b/.github/workflows/race.yml
@@ -9,6 +9,10 @@ on:
       - '**-wip'
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   race:
     runs-on: ubuntu-latest

--- a/.github/workflows/race.yml
+++ b/.github/workflows/race.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   race:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04
     # Pull requests from the same repository won't trigger this checks as they were already triggered by the push
     if: (github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository)
     steps:

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   renovate-config-validator:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04
     if: (github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository)
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,10 @@ on:
       - '**-wip'
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04
     # Pull requests from the same repository won't trigger this checks as they were already triggered by the push
     if: (github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository)
     strategy:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -183,8 +183,12 @@ Automated dual coverage reporting across all modules:
 
 GitHub Actions workflows split for better performance:
 
-- **Build workflow** (`.github/workflows/build.yml`): Focuses on compilation
-  only.
+- **Build workflow** (`.github/workflows/build.yml`): Compilation, plus a
+  cross-platform vet gate.
+  - `vet` job runs `make vet` across a `GOOS` matrix (linux, windows,
+    darwin). Because `go vet` compiles every package and its tests without
+    running them, it is the only compile check for the platforms CI cannot
+    execute natively.
 - **Test workflow** (`.github/workflows/test.yml`): Dedicated testing
   pipeline.
   - Race condition detection job with Go 1.26.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -267,6 +267,39 @@ This provides a clean interface for passing arbitrary test flags without
 modifying the Makefile, making it easy to run tests with different
 configurations for debugging, coverage analysis, or CI/CD pipelines.
 
+## Vetting with GOVET_FLAGS
+
+The `GOVET_FLAGS` environment variable allows flexible `go vet`
+execution by passing additional flags. This variable is defined in the
+Makefile with a `-v` default and is used when running vet through the
+generated rules.
+
+### Vet Usage Examples
+
+```bash
+# Run vet quietly (drop the default -v)
+make vet GOVET_FLAGS=
+
+# Vet a single module
+make vet-sync
+
+# Cross-compile and vet every module for another platform
+GOOS=windows make vet
+GOOS=darwin make vet
+```
+
+### How GOVET_FLAGS Works
+
+1. The Makefile defines `GOVET_FLAGS ?= -v`.
+2. The generated rules use it in the vet target:
+   `$(GO) vet $(GOVET_FLAGS) ./...`.
+3. Any flags passed via `GOVET_FLAGS` are forwarded directly to
+   `go vet`.
+
+Because `go vet` compiles each package and its tests for the target
+`GOOS` without running them, `make vet` doubles as a cross-platform
+compile check.
+
 ## Important Notes
 
 - Go 1.25 is the minimum required version.

--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,10 @@ GO ?= go
 GOFMT ?= gofmt
 GOFMT_FLAGS = -w -l -s
 GOGENERATE_FLAGS = -v
+GOTEST_FLAGS ?=
 GOUP_FLAGS ?= -v
 GOUP_PACKAGES ?= ./...
-GOTEST_FLAGS ?=
+GOVET_FLAGS ?= -v
 JQ ?= jq
 
 TOOLSDIR := $(CURDIR)/internal/build

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ FIND_FILES_GO_ARGS ?= $(FIND_FILES_PRUNE_ARGS) -o -name '*.go'
 FIND_FILES_MARKDOWN_ARGS ?= $(FIND_FILES_PRUNE_ARGS) -o -name '*.md'
 
 ifndef MARKDOWNLINT
-ifeq ($(shell $(DLX) markdownlint-cli --version 2>&1 | grep -q '^[0-9]' && echo yes),yes)
+ifeq ($(shell $(DLX) markdownlint-cli --version < /dev/null | grep -q '^[0-9]' && echo yes),yes)
 MARKDOWNLINT = $(DLX) markdownlint-cli
 else
 MARKDOWNLINT = true
@@ -73,7 +73,7 @@ endif
 MARKDOWNLINT_FLAGS ?= --fix --config $(TOOLSDIR)/markdownlint.json
 
 ifndef LANGUAGETOOL
-ifeq ($(shell $(DLX) @twilio-labs/languagetool-cli --version 2>&1 | grep -qE '^(unknown|[0-9])' && echo yes),yes)
+ifeq ($(shell $(DLX) @twilio-labs/languagetool-cli --version < /dev/null | grep -qE '^(unknown|[0-9])' && echo yes),yes)
 LANGUAGETOOL = $(DLX) @twilio-labs/languagetool-cli
 else
 LANGUAGETOOL = true
@@ -82,7 +82,7 @@ endif
 LANGUAGETOOL_FLAGS ?= --config $(TOOLSDIR)/languagetool.cfg --custom-dict-file $(TMPDIR)/languagetool-dict.txt
 
 ifndef CSPELL
-ifeq ($(shell $(DLX) cspell --version 2>&1 | grep -q '^[0-9]' && echo yes),yes)
+ifeq ($(shell $(DLX) cspell --version < /dev/null | grep -q '^[0-9]' && echo yes),yes)
 CSPELL = $(DLX) cspell
 else
 CSPELL = true
@@ -91,7 +91,7 @@ endif
 CSPELL_FLAGS ?= --no-progress --dot --config $(TOOLSDIR)/cspell.json
 
 ifndef SHELLCHECK
-ifeq ($(shell $(DLX) shellcheck --version 2>&1 | grep -q '^ShellCheck' && echo yes),yes)
+ifeq ($(shell $(DLX) shellcheck --version < /dev/null | grep -q '^ShellCheck' && echo yes),yes)
 SHELLCHECK = $(DLX) shellcheck
 else
 SHELLCHECK = true

--- a/config/AGENTS.md
+++ b/config/AGENTS.md
@@ -34,6 +34,8 @@ For detailed API documentation and usage examples, see [README.md](README.md).
 
 - `appdir.go`: `Prefix` type, user-mode helpers, and core resolution
   logic.
+- `const.go`: the portable `PrefixUser` constant.
+- `const_unix.go`: FHS prefix constants (`!windows`).
 - `appdir_xdg.go`: XDG Base Directory Specification implementation
   (`!windows`).
 - `appdir_fhs.go`: Filesystem Hierarchy Standard support (`!windows`).

--- a/config/AGENTS.md
+++ b/config/AGENTS.md
@@ -36,9 +36,12 @@ For detailed API documentation and usage examples, see [README.md](README.md).
   logic.
 - `const.go`: the portable `PrefixUser` constant.
 - `const_unix.go`: FHS prefix constants (`!windows`).
+- `const_windows.go`: prefix constants aliasing `%ProgramData%`
+  (Windows).
 - `appdir_xdg.go`: XDG Base Directory Specification implementation
   (`!windows`).
 - `appdir_fhs.go`: Filesystem Hierarchy Standard support (`!windows`).
+- `appdir_windows.go`: stubbed Windows resolvers.
 - `utils.go`: path-composition helpers (`Join` and friends).
 
 ## Architecture Notes

--- a/config/appdir/appdir.go
+++ b/config/appdir/appdir.go
@@ -24,10 +24,6 @@ import (
 // error.
 type Prefix string
 
-// PrefixUser is the Prefix indicating user mode, where the
-// FooDir methods return the same as UserFooDir().
-const PrefixUser Prefix = "~"
-
 // prefix is the default Prefix used by the top-level
 // SysFooDir functions.
 var prefix = PrefixUser
@@ -59,12 +55,11 @@ func NewPrefix(dir string) (Prefix, error) {
 // which carries no root — fails with [fs.ErrInvalid], the stat
 // error, or [syscall.ENOTDIR].
 func (p Prefix) Validate() error {
-	switch p {
-	case PrefixUser, PrefixSystem, PrefixLocal, PrefixOptional:
+	if p.isWellKnown() {
 		return nil
-	default:
-		return p.validateDir()
 	}
+
+	return p.validateDir()
 }
 
 // validateDir requires the Prefix to be an absolute path to an

--- a/config/appdir/appdir_fhs.go
+++ b/config/appdir/appdir_fhs.go
@@ -10,20 +10,6 @@ import (
 	"darvaza.org/core"
 )
 
-const (
-	// PrefixLocal represents services installed outside
-	// the scope of the package manager.
-	PrefixLocal Prefix = "/usr/local"
-	// PrefixSystem represents services installed by
-	// the package manager.
-	PrefixSystem Prefix = "/"
-	// PrefixOptional represents services installed outside
-	// the scope of the package manager but requiring
-	// a complex hierarchy, usually installed by extracting
-	// an archive file.
-	PrefixOptional Prefix = "/opt"
-)
-
 func (p Prefix) sysCacheDir(sub ...string) (string, error) {
 	return p.sysDir("/var/cache", sub...)
 }

--- a/config/appdir/appdir_test.go
+++ b/config/appdir/appdir_test.go
@@ -18,7 +18,6 @@ var _ core.TestCase = userDirTestCase{}
 var _ core.TestCase = userDirErrTestCase{}
 var _ core.TestCase = sysDirTestCase{}
 var _ core.TestCase = sysUserModeTestCase{}
-var _ core.TestCase = newPrefixTestCase{}
 var _ core.TestCase = setSysPrefixTestCase{}
 
 // userDirTestCase tests the UserFooDir functions honouring their
@@ -388,79 +387,6 @@ func TestSysDirUserMode(t *testing.T) {
 	core.RunTestCases(t, testCases)
 }
 
-// newPrefixTestCase tests [appdir.NewPrefix] validation and
-// path resolution.
-type newPrefixTestCase struct {
-	wantErrIs error
-	dir       string
-	name      string
-	want      appdir.Prefix
-}
-
-func (tc newPrefixTestCase) Name() string {
-	return tc.name
-}
-
-func (tc newPrefixTestCase) Test(t *testing.T) {
-	t.Helper()
-
-	got, err := appdir.NewPrefix(tc.dir)
-	if tc.wantErrIs != nil {
-		core.AssertErrorIs(t, err, tc.wantErrIs, "new prefix")
-		return
-	}
-
-	core.AssertMustNoError(t, err, "new prefix")
-	core.AssertEqual(t, tc.want, got, "prefix")
-}
-
-// newNewPrefixTestCase declares a row expected to succeed, with
-// want holding the resulting Prefix value.
-func newNewPrefixTestCase(name, dir string,
-	want appdir.Prefix) newPrefixTestCase {
-	return newPrefixTestCase{
-		dir:  dir,
-		name: name,
-		want: want,
-	}
-}
-
-// newNewPrefixTestCaseErr declares a row expected to fail.
-func newNewPrefixTestCaseErr(name, dir string,
-	wantErrIs error) newPrefixTestCase {
-	return newPrefixTestCase{
-		wantErrIs: wantErrIs,
-		dir:       dir,
-		name:      name,
-	}
-}
-
-func newPrefixTestCases(tmp, file, cwd string) []newPrefixTestCase {
-	return core.S(
-		newNewPrefixTestCase("user mode", "~", appdir.PrefixUser),
-		newNewPrefixTestCase("existing dir", tmp,
-			appdir.Prefix(tmp)),
-		newNewPrefixTestCase("relative path", ".",
-			appdir.Prefix(cwd)),
-		newNewPrefixTestCaseErr("missing path",
-			filepath.Join(tmp, "missing"), fs.ErrNotExist),
-		newNewPrefixTestCaseErr("regular file", file,
-			syscall.ENOTDIR),
-	)
-}
-
-func TestNewPrefix(t *testing.T) {
-	tmp := t.TempDir()
-	file := filepath.Join(tmp, "file")
-	err := os.WriteFile(file, []byte("x"), 0o600)
-	core.AssertMustNoError(t, err, "write file")
-
-	cwd, err := os.Getwd()
-	core.AssertMustNoError(t, err, "getwd")
-
-	core.RunTestCases(t, newPrefixTestCases(tmp, file, cwd))
-}
-
 // TestNewPrefixAbsError pins [appdir.NewPrefix] propagating the
 // filepath.Abs failure resolving a relative argument when the
 // working directory no longer exists.
@@ -551,17 +477,6 @@ func TestSetSysPrefix(t *testing.T) {
 	core.AssertMustNoError(t, err, "getwd")
 
 	core.RunTestCases(t, setSysPrefixTestCases(tmp, file, cwd))
-}
-
-// TestSysPrefix pins the getter reflecting the current default
-// Prefix.
-func TestSysPrefix(t *testing.T) {
-	core.AssertEqual(t, appdir.PrefixUser, appdir.SysPrefix(),
-		"default")
-
-	t.Cleanup(appdir.StubSysPrefix(appdir.PrefixSystem))
-	core.AssertEqual(t, appdir.PrefixSystem, appdir.SysPrefix(),
-		"stubbed")
 }
 
 // TestSetSysPrefixUserMode pins "~" returning the package to user

--- a/config/appdir/appdir_windows.go
+++ b/config/appdir/appdir_windows.go
@@ -1,0 +1,32 @@
+package appdir
+
+import "darvaza.org/core"
+
+// The native Windows resolvers are not implemented yet: each
+// entry point reports [core.ErrNotImplemented] so the package
+// builds and vets on Windows. The real implementation lands with
+// the Windows support work, replacing this file in place.
+
+func getUserDataDir() (string, error) {
+	return "", core.ErrNotImplemented
+}
+
+func getUserRuntimeDir() (string, error) {
+	return "", core.ErrNotImplemented
+}
+
+func (Prefix) sysCacheDir(...string) (string, error) {
+	return "", core.ErrNotImplemented
+}
+
+func (Prefix) sysConfigDir(...string) (string, error) {
+	return "", core.ErrNotImplemented
+}
+
+func (Prefix) sysDataDir(...string) (string, error) {
+	return "", core.ErrNotImplemented
+}
+
+func (Prefix) sysRuntimeDir(...string) (string, error) {
+	return "", core.ErrNotImplemented
+}

--- a/config/appdir/const.go
+++ b/config/appdir/const.go
@@ -1,0 +1,5 @@
+package appdir
+
+// PrefixUser is the Prefix indicating user mode, where the
+// FooDir methods return the same as UserFooDir().
+const PrefixUser Prefix = "~"

--- a/config/appdir/const_unix.go
+++ b/config/appdir/const_unix.go
@@ -1,0 +1,28 @@
+//go:build !windows
+
+package appdir
+
+const (
+	// PrefixLocal represents services installed outside
+	// the scope of the package manager.
+	PrefixLocal Prefix = "/usr/local"
+	// PrefixSystem represents services installed by
+	// the package manager.
+	PrefixSystem Prefix = "/"
+	// PrefixOptional represents services installed outside
+	// the scope of the package manager but requiring
+	// a complex hierarchy, usually installed by extracting
+	// an archive file.
+	PrefixOptional Prefix = "/opt"
+)
+
+// isWellKnown reports whether p is one of the predefined
+// prefixes.
+func (p Prefix) isWellKnown() bool {
+	switch p {
+	case PrefixUser, PrefixSystem, PrefixLocal, PrefixOptional:
+		return true
+	default:
+		return false
+	}
+}

--- a/config/appdir/const_windows.go
+++ b/config/appdir/const_windows.go
@@ -1,0 +1,24 @@
+package appdir
+
+const (
+	// PrefixSystem composes the system-mode directories under
+	// the machine-wide application data directory,
+	// %ProgramData%, resolved when composing.
+	PrefixSystem Prefix = `%ProgramData%`
+	// PrefixLocal is equivalent to [PrefixSystem] on Windows.
+	PrefixLocal = PrefixSystem
+	// PrefixOptional is equivalent to [PrefixSystem] on Windows.
+	PrefixOptional = PrefixSystem
+)
+
+// isWellKnown reports whether p is one of the predefined
+// prefixes. [PrefixLocal] and [PrefixOptional] alias
+// [PrefixSystem], so matching it covers all three.
+func (p Prefix) isWellKnown() bool {
+	switch p {
+	case PrefixUser, PrefixSystem:
+		return true
+	default:
+		return false
+	}
+}

--- a/config/appdir/prefix_test.go
+++ b/config/appdir/prefix_test.go
@@ -15,6 +15,7 @@ import (
 // Compile-time verification that test case types implement TestCase interface
 var _ core.TestCase = prefixValidateTestCase{}
 var _ core.TestCase = prefixUserModeTestCase{}
+var _ core.TestCase = newPrefixTestCase{}
 
 // prefixValidateTestCase tests [appdir.Prefix.Validate] pinning the
 // usability contract — a well-known prefix or an absolute path to
@@ -129,4 +130,88 @@ func TestPrefixUserMode(t *testing.T) {
 	)
 
 	core.RunTestCases(t, testCases)
+}
+
+// newPrefixTestCase tests [appdir.NewPrefix] validation and
+// path resolution.
+type newPrefixTestCase struct {
+	wantErrIs error
+	dir       string
+	name      string
+	want      appdir.Prefix
+}
+
+func (tc newPrefixTestCase) Name() string {
+	return tc.name
+}
+
+func (tc newPrefixTestCase) Test(t *testing.T) {
+	t.Helper()
+
+	got, err := appdir.NewPrefix(tc.dir)
+	if tc.wantErrIs != nil {
+		core.AssertErrorIs(t, err, tc.wantErrIs, "new prefix")
+		return
+	}
+
+	core.AssertMustNoError(t, err, "new prefix")
+	core.AssertEqual(t, tc.want, got, "prefix")
+}
+
+// newNewPrefixTestCase declares a row expected to succeed, with
+// want holding the resulting Prefix value.
+func newNewPrefixTestCase(name, dir string,
+	want appdir.Prefix) newPrefixTestCase {
+	return newPrefixTestCase{
+		dir:  dir,
+		name: name,
+		want: want,
+	}
+}
+
+// newNewPrefixTestCaseErr declares a row expected to fail.
+func newNewPrefixTestCaseErr(name, dir string,
+	wantErrIs error) newPrefixTestCase {
+	return newPrefixTestCase{
+		wantErrIs: wantErrIs,
+		dir:       dir,
+		name:      name,
+	}
+}
+
+func newPrefixTestCases(tmp, file, cwd string) []newPrefixTestCase {
+	return core.S(
+		newNewPrefixTestCase("user mode", "~", appdir.PrefixUser),
+		newNewPrefixTestCase("existing dir", tmp,
+			appdir.Prefix(tmp)),
+		newNewPrefixTestCase("relative path", ".",
+			appdir.Prefix(cwd)),
+		newNewPrefixTestCaseErr("missing path",
+			filepath.Join(tmp, "missing"), fs.ErrNotExist),
+		newNewPrefixTestCaseErr("regular file", file,
+			syscall.ENOTDIR),
+	)
+}
+
+func TestNewPrefix(t *testing.T) {
+	tmp := t.TempDir()
+	file := filepath.Join(tmp, "file")
+	err := os.WriteFile(file, []byte("x"), 0o600)
+	core.AssertMustNoError(t, err, "write file")
+
+	cwd, err := os.Getwd()
+	core.AssertMustNoError(t, err, "getwd")
+
+	core.RunTestCases(t, newPrefixTestCases(tmp, file, cwd))
+}
+
+// TestSysPrefix pins the getter reflecting the current default
+// Prefix.
+func TestSysPrefix(t *testing.T) {
+	core.AssertEqual(t, appdir.PrefixUser, appdir.SysPrefix(),
+		"default")
+
+	t.Cleanup(appdir.StubSysPrefix(appdir.PrefixSystem))
+	core.AssertEqual(t, appdir.PrefixSystem, appdir.SysPrefix(),
+		"stubbed")
 }

--- a/fs/AGENTS.md
+++ b/fs/AGENTS.md
@@ -44,7 +44,7 @@ The package follows several design principles:
 Key patterns:
 
 - Interfaces follow os package naming conventions (e.g., ChmodFS for Chmod).
-- Platform-specific code uses build tags (_linux.go_, _windows.go).
+- Platform-specific code uses build tags (_unix.go,_windows.go).
 - Glob patterns support `**` for recursive matching.
 
 ## Development Commands

--- a/fs/README.md
+++ b/fs/README.md
@@ -126,7 +126,7 @@ through platform-specific syscalls.
 
 The implementation uses native APIs on each platform:
 
-* **Linux**: Uses `flock()` syscalls with `LOCK_EX` and `LOCK_NB` flags.
+* **Unix**: Uses `flock()` syscalls with `LOCK_EX` and `LOCK_NB` flags.
 * **Windows**: Uses `LockFileEx()` and `UnlockFileEx()` Win32 APIs.
 
 All platforms return `syscall.EBUSY` when `TryLockEx` cannot acquire a lock

--- a/fs/fssyscall/syscall_unix.go
+++ b/fs/fssyscall/syscall_unix.go
@@ -1,4 +1,4 @@
-//go:build linux
+//go:build unix
 
 package fssyscall
 

--- a/internal/build/cspell.json
+++ b/internal/build/cspell.json
@@ -48,6 +48,7 @@
     "fsys",
     "gobwas",
     "golangci",
+    "GOOS",
     "GOPATH",
     "goroutines",
     "Gosched",

--- a/internal/build/gen_mk.sh
+++ b/internal/build/gen_mk.sh
@@ -6,7 +6,7 @@ set -eu
 INDEX="$1"
 
 PROJECTS="$(cut -d':' -f1 "$INDEX")"
-COMMANDS="tidy get build test coverage race up"
+COMMANDS="tidy get build test vet coverage race up"
 
 TAB=$(printf "\t")
 
@@ -142,6 +142,9 @@ gen_make_targets() {
 		;;
 	race)
 		call="env CGO_ENABLED=1 \$(GO) test -race -count=1 \$(GOTEST_FLAGS) ./..."
+		;;
+	vet)
+		call="\$(GO) vet \$(GOVET_FLAGS) ./..."
 		;;
 	*)
 		call="\$(GO) $cmd -v ./..."


### PR DESCRIPTION
Branch carries the CI/runner work: cross-platform `go vet` matrix, depot-hosted runners, the corepack-interactivity fix, and the self-hosted OCR reviewer (runner1 → compute3).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cross-platform application-directory support, including Windows-compatible prefix definitions and build coverage.
  * Added a cross-platform vetting check for Linux, Windows, and macOS targets.

* **Bug Fixes**
  * Improved Unix platform detection for file-locking functionality.
  * Updated directory-prefix validation to consistently recognize supported system prefixes.

* **Documentation**
  * Clarified application-directory behavior, vetting commands, platform support, and Unix file-locking behavior.

* **Chores**
  * Improved CI run cancellation and standardized build environments for faster, more efficient checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->