### PR TITLE
feat(net/reconnect): session-state predicates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ FIX_WHITESPACE_EXCLUDE ?= $(FIX_WHITESPACE_EXCLUDE_GO) $(FIX_WHITESPACE_EXCLUDE_
 FIX_WHITESPACE_ARGS ?= . \! \( $(FIX_WHITESPACE_EXCLUDE) \)
 
 ifndef DLX
-ifeq ($(shell pnpm --version 2>&1 | grep -q '^[0-9]' && echo yes),yes)
+ifeq ($(shell pnpm --version < /dev/null 2> /dev/null | grep -q '^[0-9]' && echo yes),yes)
 DLX = pnpm dlx
 else
 DLX = true
@@ -63,7 +63,7 @@ FIND_FILES_GO_ARGS ?= $(FIND_FILES_PRUNE_ARGS) -o -name '*.go'
 FIND_FILES_MARKDOWN_ARGS ?= $(FIND_FILES_PRUNE_ARGS) -o -name '*.md'
 
 ifndef MARKDOWNLINT
-ifeq ($(shell $(DLX) markdownlint-cli --version 2>&1 | grep -q '^[0-9]' && echo yes),yes)
+ifeq ($(shell $(DLX) markdownlint-cli --version < /dev/null | grep -q '^[0-9]' && echo yes),yes)
 MARKDOWNLINT = $(DLX) markdownlint-cli
 else
 MARKDOWNLINT = true
@@ -72,7 +72,7 @@ endif
 MARKDOWNLINT_FLAGS ?= --fix --config $(TOOLSDIR)/markdownlint.json
 
 ifndef LANGUAGETOOL
-ifeq ($(shell $(DLX) @twilio-labs/languagetool-cli --version 2>&1 | grep -qE '^(unknown|[0-9])' && echo yes),yes)
+ifeq ($(shell $(DLX) @twilio-labs/languagetool-cli --version < /dev/null | grep -qE '^(unknown|[0-9])' && echo yes),yes)
 LANGUAGETOOL = $(DLX) @twilio-labs/languagetool-cli
 else
 LANGUAGETOOL = true
@@ -81,7 +81,7 @@ endif
 LANGUAGETOOL_FLAGS ?= --config $(TOOLSDIR)/languagetool.cfg --custom-dict-file $(TMPDIR)/languagetool-dict.txt
 
 ifndef CSPELL
-ifeq ($(shell $(DLX) cspell --version 2>&1 | grep -q '^[0-9]' && echo yes),yes)
+ifeq ($(shell $(DLX) cspell --version < /dev/null | grep -q '^[0-9]' && echo yes),yes)
 CSPELL = $(DLX) cspell
 else
 CSPELL = true
@@ -90,7 +90,7 @@ endif
 CSPELL_FLAGS ?= --no-progress --dot --config $(TOOLSDIR)/cspell.json
 
 ifndef SHELLCHECK
-ifeq ($(shell $(DLX) shellcheck --version 2>&1 | grep -q '^ShellCheck' && echo yes),yes)
+ifeq ($(shell $(DLX) shellcheck --version < /dev/null | grep -q '^ShellCheck' && echo yes),yes)
 SHELLCHECK = $(DLX) shellcheck
 else
 SHELLCHECK = true

--- a/net/reconnect/errors.go
+++ b/net/reconnect/errors.go
@@ -33,17 +33,25 @@ var (
 	// across the lifecycle stack.
 	ErrClosed = core.QuietWrap(errors.ErrClosed, "already closed")
 
-	// ErrNameEmpty indicates a name is empty
-	ErrNameEmpty = errors.New("name missing")
+	// ErrNameEmpty indicates a name is empty. It wraps [core.ErrInvalid]
+	// so a caller matching the invalid-argument family with errors.Is
+	// catches it.
+	ErrNameEmpty = core.QuietWrap(core.ErrInvalid, "name missing")
 
-	// ErrNameTooLong indicates a name exceeds maximum length
-	ErrNameTooLong = errors.New("name too long")
+	// ErrNameTooLong indicates a name exceeds maximum length. It wraps
+	// [core.ErrInvalid] for the same reason.
+	ErrNameTooLong = core.QuietWrap(core.ErrInvalid, "name too long")
 )
 
 // IsFatal tells if the error means the connection
 // should be closed and not retried.
 // Only [ErrDoNotReconnect], possibly wrapped, is considered
 // fatal; anything else is treated as recoverable.
+//
+// IsFatal classifies connection errors seen inside the reconnect loop.
+// Caller-misuse errors are reported at setup time and never reach that
+// decision; they extend [core.ErrInvalid], so match them with errors.Is
+// against that sentinel instead.
 func IsFatal(err error) bool {
 	if err != nil {
 		is, _ := core.IsErrorFn2(checkIsFatal, err)
@@ -117,4 +125,22 @@ func checkIsNonError(err error) (is, certainly bool) {
 	default:
 		return false, false
 	}
+}
+
+// IsNotConnected reports whether err indicates the [Client] had no session
+// when a request was attempted, matching [ErrNotConnected] anywhere in the
+// chain. A fully shut-down client surfaces [ErrClosed] without
+// ErrNotConnected wrapping it; match [ErrClosed] instead to cover both the
+// closed and not-connected cases with a single target.
+func IsNotConnected(err error) bool {
+	return errors.Is(err, ErrNotConnected)
+}
+
+// IsClosed reports whether err indicates the [Client] has been shut down,
+// matching [ErrClosed] anywhere in the chain. Because [ErrNotConnected]
+// wraps [ErrClosed], IsClosed is the broad companion to [IsNotConnected]:
+// it is true for both a fully closed client and the transient
+// not-connected window, whereas IsNotConnected matches only the latter.
+func IsClosed(err error) bool {
+	return errors.Is(err, ErrClosed)
 }

--- a/net/reconnect/errors_test.go
+++ b/net/reconnect/errors_test.go
@@ -1,0 +1,243 @@
+package reconnect_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"darvaza.org/core"
+
+	"darvaza.org/x/net/reconnect"
+)
+
+// Compile-time verification that test case types implement TestCase interface
+var _ core.TestCase = isNotConnectedTestCase{}
+
+// isNotConnectedTestCase tests the IsNotConnected predicate.
+type isNotConnectedTestCase struct {
+	err  error
+	name string
+	want bool
+}
+
+func newIsNotConnectedTestCase(name string, err error, want bool) isNotConnectedTestCase {
+	return isNotConnectedTestCase{
+		err:  err,
+		name: name,
+		want: want,
+	}
+}
+
+func (tc isNotConnectedTestCase) Name() string {
+	return tc.name
+}
+
+func (tc isNotConnectedTestCase) Test(t *testing.T) {
+	t.Helper()
+
+	got := reconnect.IsNotConnected(tc.err)
+	core.AssertEqual(t, tc.want, got, "IsNotConnected")
+}
+
+func makeIsNotConnectedTestCases() []core.TestCase {
+	return []core.TestCase{
+		newIsNotConnectedTestCase("nil", nil, false),
+		newIsNotConnectedTestCase("not connected", reconnect.ErrNotConnected, true),
+		newIsNotConnectedTestCase("wrapped not connected",
+			core.Wrap(reconnect.ErrNotConnected, "getSession"), true),
+		// ErrNotConnected wraps ErrClosed, not the reverse: a bare closed
+		// client must not report as not-connected.
+		newIsNotConnectedTestCase("closed only", reconnect.ErrClosed, false),
+		newIsNotConnectedTestCase("unrelated", core.ErrInvalid, false),
+	}
+}
+
+func TestIsNotConnected(t *testing.T) {
+	core.RunTestCases(t, makeIsNotConnectedTestCases())
+}
+
+// Compile-time verification that test case types implement TestCase interface
+var _ core.TestCase = isClosedTestCase{}
+
+// isClosedTestCase tests the IsClosed predicate.
+type isClosedTestCase struct {
+	err  error
+	name string
+	want bool
+}
+
+func newIsClosedTestCase(name string, err error, want bool) isClosedTestCase {
+	return isClosedTestCase{
+		err:  err,
+		name: name,
+		want: want,
+	}
+}
+
+func (tc isClosedTestCase) Name() string {
+	return tc.name
+}
+
+func (tc isClosedTestCase) Test(t *testing.T) {
+	t.Helper()
+
+	got := reconnect.IsClosed(tc.err)
+	core.AssertEqual(t, tc.want, got, "IsClosed")
+}
+
+func makeIsClosedTestCases() []core.TestCase {
+	return []core.TestCase{
+		newIsClosedTestCase("nil", nil, false),
+		newIsClosedTestCase("closed", reconnect.ErrClosed, true),
+		// ErrNotConnected wraps ErrClosed, so IsClosed covers it too.
+		newIsClosedTestCase("not connected", reconnect.ErrNotConnected, true),
+		newIsClosedTestCase("wrapped closed",
+			core.Wrap(reconnect.ErrClosed, "shutdown"), true),
+		// ErrRunning wraps EBUSY, not ErrClosed: a running client is not closed.
+		newIsClosedTestCase("running", reconnect.ErrRunning, false),
+		newIsClosedTestCase("unrelated", core.ErrInvalid, false),
+	}
+}
+
+func TestIsClosed(t *testing.T) {
+	core.RunTestCases(t, makeIsClosedTestCases())
+}
+
+// Compile-time verification that test case types implement TestCase interface
+var _ core.TestCase = invalidFamilyTestCase{}
+
+// invalidFamilyTestCase pins which sentinels extend core.ErrInvalid, so a
+// consumer matching the invalid-argument family with errors.Is keeps
+// catching them.
+type invalidFamilyTestCase struct {
+	err  error
+	name string
+	want bool
+}
+
+func newInvalidFamilyTestCase(name string, err error, want bool) invalidFamilyTestCase {
+	return invalidFamilyTestCase{
+		err:  err,
+		name: name,
+		want: want,
+	}
+}
+
+func (tc invalidFamilyTestCase) Name() string {
+	return tc.name
+}
+
+func (tc invalidFamilyTestCase) Test(t *testing.T) {
+	t.Helper()
+
+	got := errors.Is(tc.err, core.ErrInvalid)
+	core.AssertEqual(t, tc.want, got, "extends core.ErrInvalid")
+}
+
+func makeInvalidFamilyTestCases() []core.TestCase {
+	return []core.TestCase{
+		newInvalidFamilyTestCase("name empty", reconnect.ErrNameEmpty, true),
+		newInvalidFamilyTestCase("name too long", reconnect.ErrNameTooLong, true),
+		// Connection and control errors stay out of the invalid family.
+		newInvalidFamilyTestCase("not connected", reconnect.ErrNotConnected, false),
+		newInvalidFamilyTestCase("do not reconnect", reconnect.ErrDoNotReconnect, false),
+	}
+}
+
+func TestInvalidFamily(t *testing.T) {
+	core.RunTestCases(t, makeInvalidFamilyTestCases())
+}
+
+// Compile-time verification that test case types implement TestCase interface
+var _ core.TestCase = isFatalTestCase{}
+
+// isFatalTestCase tests the IsFatal predicate.
+type isFatalTestCase struct {
+	err  error
+	name string
+	want bool
+}
+
+func newIsFatalTestCase(name string, err error, want bool) isFatalTestCase {
+	return isFatalTestCase{
+		err:  err,
+		name: name,
+		want: want,
+	}
+}
+
+func (tc isFatalTestCase) Name() string {
+	return tc.name
+}
+
+func (tc isFatalTestCase) Test(t *testing.T) {
+	t.Helper()
+
+	got := reconnect.IsFatal(tc.err)
+	core.AssertEqual(t, tc.want, got, "IsFatal")
+}
+
+func makeIsFatalTestCases() []core.TestCase {
+	return []core.TestCase{
+		// nil never reaches the loop's classifier, but the public
+		// entry point must still report it as non-fatal.
+		newIsFatalTestCase("nil", nil, false),
+		newIsFatalTestCase("do not reconnect", reconnect.ErrDoNotReconnect, true),
+		newIsFatalTestCase("wrapped do not reconnect",
+			core.Wrap(reconnect.ErrDoNotReconnect, "waiter"), true),
+		// Connection errors are recoverable, so the loop retries them.
+		newIsFatalTestCase("not connected", reconnect.ErrNotConnected, false),
+		newIsFatalTestCase("unrelated", core.ErrInvalid, false),
+	}
+}
+
+func TestIsFatal(t *testing.T) {
+	core.RunTestCases(t, makeIsFatalTestCases())
+}
+
+// Compile-time verification that test case types implement TestCase interface
+var _ core.TestCase = isNonErrorTestCase{}
+
+// isNonErrorTestCase tests the IsNonError predicate.
+type isNonErrorTestCase struct {
+	err  error
+	name string
+	want bool
+}
+
+func newIsNonErrorTestCase(name string, err error, want bool) isNonErrorTestCase {
+	return isNonErrorTestCase{
+		err:  err,
+		name: name,
+		want: want,
+	}
+}
+
+func (tc isNonErrorTestCase) Name() string {
+	return tc.name
+}
+
+func (tc isNonErrorTestCase) Test(t *testing.T) {
+	t.Helper()
+
+	got := reconnect.IsNonError(tc.err)
+	core.AssertEqual(t, tc.want, got, "IsNonError")
+}
+
+func makeIsNonErrorTestCases() []core.TestCase {
+	return []core.TestCase{
+		// filterNonError only ever passes a non-nil error, so the
+		// nil short-circuit is reachable solely through the public API.
+		newIsNonErrorTestCase("nil", nil, true),
+		newIsNonErrorTestCase("canceled", context.Canceled, true),
+		newIsNonErrorTestCase("do not reconnect", reconnect.ErrDoNotReconnect, true),
+		newIsNonErrorTestCase("wrapped canceled",
+			core.Wrap(context.Canceled, "shutdown"), true),
+		// A genuine failure must not be filtered out as a clean stop.
+		newIsNonErrorTestCase("real error", reconnect.ErrNotConnected, false),
+	}
+}
+
+func TestIsNonError(t *testing.T) {
+	core.RunTestCases(t, makeIsNonErrorTestCases())
+}


### PR DESCRIPTION
## Summary

Adds an error-classification surface to `net/reconnect` so consumers can
tell a client's session state apart with `errors.Is`-backed predicates
instead of matching sentinels by hand, and unblocks the build when
corepack turns interactive.

## net/reconnect — session-state predicates

Two predicates, from narrow to broad:

- `IsNotConnected(err)` matches `ErrNotConnected` — the transient window
  where the client has no session yet.
- `IsClosed(err)` matches `ErrClosed`. Because `ErrNotConnected` wraps
  `ErrClosed`, this is the broad companion: true for both a fully
  shut-down client and the not-connected window, so a single target
  covers both cases.

A consumer mapping errors to status can now split the two (e.g. 503 for
a closed client, 502 for a not-connected blip) rather than reaching for
the sentinels directly.

While here, the commit *add IsNotConnected and IsClosed predicates* also
closes a consistency gap: `ErrNameEmpty` and `ErrNameTooLong` were plain
`errors.New` values, so they sat outside the invalid-argument family the
rest of the package already reports (`validateUNIXName` returns
`core.ErrInvalid` for a null byte). They now wrap `core.ErrInvalid`, so
`errors.Is(err, core.ErrInvalid)` catches every name-validation failure.
Their `Error()` text is unchanged.

## build — unblock corepack

The commit *stop corepack blocking tool detection* feeds `/dev/null` on
stdin to the tool-detection probes so corepack cannot stall a `make`
invocation on an interactive prompt, and lets the markdownlint,
languagetool, cspell and shellcheck probes send stderr to the terminal.
That last part matters because a failed probe resolves the tool to a
no-op and `tidy` then drops the check from its prerequisites silently —
the probe's own stderr is the only place the failure shows.

## Tests

- Table tests for `IsNotConnected`, `IsClosed`, `IsFatal` and
  `IsNonError`, plus an invalid-family test pinning the name sentinels
  into `core.ErrInvalid` so the fix can't silently revert.
- `errors.go` is now at full statement coverage; package coverage
  82.2% → 82.5%.
- `make build-net`, `tidy-net` and `race-net` clean; all CI workflows
  green on the branch.
