### PR TITLE
fix(tls): resolve SplitClientHelloInfo fallback to the typed local address

### DIFF
--- a/tls/store.go
+++ b/tls/store.go
@@ -198,17 +198,21 @@ func NewConfig(store Store) (*tls.Config, error) {
 }
 
 // SplitClientHelloInfo takes the context and server name out of a [tls.ClientHelloInfo].
-// If no ServerName is provided, the server's IP address will be used.
+// If no ServerName is provided, the server's local IP address is used when the
+// connection exposes a resolvable address; otherwise the server name is empty.
 func SplitClientHelloInfo(chi *tls.ClientHelloInfo) (ctx context.Context, serverName string, err error) {
 	if chi == nil {
 		return ctx, "", core.ErrInvalid
 	}
 	ctx = chi.Context()
 	serverName = chi.ServerName
-	if serverName == "" {
-		host, _, _ := core.SplitHostPort(chi.Conn.LocalAddr().String())
-		if host != "" {
-			serverName = fmt.Sprintf("[%s]", host)
+	if serverName == "" && chi.Conn != nil {
+		// Take the typed local address: core.AddrPort selects the IP,
+		// drops any 4-in-6 mapping and scope zone, and lands on the
+		// bracketed form Names stores under. Pass LocalAddr(), not Conn
+		// itself, whose RemoteAddr() arm would resolve the client address.
+		if ap, ok := core.AddrPort(chi.Conn.LocalAddr()); ok {
+			serverName = fmt.Sprintf("[%s]", ap.Addr())
 		}
 	}
 

--- a/tls/store_test.go
+++ b/tls/store_test.go
@@ -1,0 +1,98 @@
+package tls_test
+
+// cspell:words stdtls
+
+import (
+	stdtls "crypto/tls"
+	"net"
+	"testing"
+
+	"darvaza.org/core"
+
+	"darvaza.org/x/tls"
+)
+
+var _ core.TestCase = splitCHITestCase{}
+
+// stubAddr is a net.Addr that is neither TCP nor UDP and exposes no typed
+// address, so core.AddrPort cannot resolve it.
+type stubAddr struct{}
+
+func (stubAddr) Network() string { return "stub" }
+func (stubAddr) String() string  { return "stub-addr" }
+
+// stubConn is a net.Conn whose LocalAddr is fixed; every other method is
+// inherited from the nil embedded Conn and must not be called.
+type stubConn struct {
+	net.Conn
+	local net.Addr
+}
+
+func (c stubConn) LocalAddr() net.Addr { return c.local }
+
+// splitCHITestCase exercises SplitClientHelloInfo's serverName derivation: the
+// explicit SNI passes through, and an empty SNI falls back to the connection's
+// local address in the bracketed form the store keys under, with any 4-in-6
+// mapping and scope zone removed.
+type splitCHITestCase struct {
+	conn       net.Conn
+	name       string
+	serverName string
+	wantName   string
+}
+
+func (tc splitCHITestCase) Name() string { return tc.name }
+
+func (tc splitCHITestCase) Test(t *testing.T) {
+	t.Helper()
+
+	chi := &stdtls.ClientHelloInfo{ServerName: tc.serverName, Conn: tc.conn}
+	_, name, err := tls.SplitClientHelloInfo(chi)
+	core.AssertMustNoError(t, err, "err")
+	core.AssertEqual(t, tc.wantName, name, "serverName")
+}
+
+func newSplitCHITestCase(name, serverName string, conn net.Conn,
+	wantName string) splitCHITestCase {
+	return splitCHITestCase{
+		conn:       conn,
+		name:       name,
+		serverName: serverName,
+		wantName:   wantName,
+	}
+}
+
+func tcpAddr(ip string, zone string) *net.TCPAddr {
+	return &net.TCPAddr{IP: net.ParseIP(ip), Zone: zone, Port: 443}
+}
+
+// TestSplitClientHelloInfo covers the F60 fallback: the typed local address is
+// taken through core.AddrPort, which selects the IP, removes any 4-in-6
+// mapping and drops the scope zone, landing on the bracketed key form. A
+// connection with no resolvable address yields an empty serverName rather than
+// a bracketed string.
+func TestSplitClientHelloInfo(t *testing.T) {
+	cases := []splitCHITestCase{
+		newSplitCHITestCase("explicit SNI", "example.com", nil,
+			"example.com"),
+		newSplitCHITestCase("IPv4 local address", "",
+			stubConn{local: tcpAddr("192.0.2.1", "")}, "[192.0.2.1]"),
+		newSplitCHITestCase("4-in-6 unmapped", "",
+			stubConn{local: &net.TCPAddr{IP: net.IPv4(192, 0, 2, 2),
+				Port: 443}}, "[192.0.2.2]"),
+		newSplitCHITestCase("IPv6 zone dropped", "",
+			stubConn{local: tcpAddr("fe80::1", "eth0")}, "[fe80::1]"),
+		newSplitCHITestCase("nil Conn", "", nil, ""),
+		newSplitCHITestCase("unresolvable local address", "",
+			stubConn{local: stubAddr{}}, ""),
+	}
+
+	core.RunTestCases(t, cases)
+}
+
+// TestSplitClientHelloInfoNil confirms a nil ClientHelloInfo is rejected.
+func TestSplitClientHelloInfoNil(t *testing.T) {
+	_, name, err := tls.SplitClientHelloInfo(nil)
+	core.AssertError(t, err, "nil chi")
+	core.AssertEqual(t, "", name, "serverName")
+}


### PR DESCRIPTION
## What

When a client connects without SNI, `SplitClientHelloInfo` falls back to
the connection's local address so the store can still choose a serving
certificate. That fallback is fixed to land on the address form the store
actually indexes certificates under, and to stop guessing when the address
is not an IP.

## Why

The previous fallback parsed `chi.Conn.LocalAddr().String()` and bracketed
whatever host it found. Two problems followed:

- It dereferenced `chi.Conn` unconditionally, so a `ClientHelloInfo` with a
  nil `Conn` panicked instead of returning cleanly.
- The bracketed string did not match the key `x509utils.Names` stores IP
  SANs under (4-in-6 mapped forms and scope zones were left intact), so an
  IP-SAN certificate never resolved through the fallback. A non-IP address
  such as a Unix socket or a pipe was still bracketed into a bogus server
  name.

## How

The fallback now takes the typed local address through `core.AddrPort`,
which selects the IP, unmaps any 4-in-6 form and drops the scope zone,
landing on the same bracketed key `Names` uses. A nil `chi.Conn` is guarded
so the fallback no longer panics, and a non-IP `net.Addr` now yields an
empty server name rather than a bracketed guess.

The behaviour is exercised by new tests in `tls/store_test.go` covering the
IP-SAN match, the nil-`Conn` guard, and the non-IP address case.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved TLS server name detection when SNI is unavailable by deriving it from the connection’s local address.
  - Correctly formats local IP addresses, including IPv6 addresses, while removing unsupported mapping and scope details.
  - Gracefully handles missing connections, unresolved addresses, and invalid client hello information.

- **Tests**
  - Added coverage for explicit SNI, local address-based detection, invalid inputs, and unresolved addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->