### PR TITLE
fix(net/reconnect): match Windows connection errnos

### DIFF
--- a/net/reconnect/client_refused_unix_test.go
+++ b/net/reconnect/client_refused_unix_test.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package reconnect_test
+
+import "syscall"
+
+// errConnRefused is the errno a dial to a closed port reports on this
+// platform: the POSIX ECONNREFUSED on unix-like systems.
+var errConnRefused error = syscall.ECONNREFUSED

--- a/net/reconnect/client_refused_windows_test.go
+++ b/net/reconnect/client_refused_windows_test.go
@@ -1,0 +1,8 @@
+package reconnect_test
+
+import "golang.org/x/sys/windows"
+
+// errConnRefused is the errno a dial to a closed port reports on
+// Windows: the Winsock WSAECONNREFUSED. Go's std syscall.ECONNREFUSED is
+// an invented placeholder there, not the value the socket layer returns.
+var errConnRefused error = windows.WSAECONNREFUSED

--- a/net/reconnect/client_test.go
+++ b/net/reconnect/client_test.go
@@ -5,7 +5,6 @@ import (
 	"net"
 	"sync"
 	"sync/atomic"
-	"syscall"
 	"testing"
 	"time"
 
@@ -560,8 +559,8 @@ func TestClientReconnectDialFails(t *testing.T) {
 	waiter, waiterCalls := newReconnectWaiter(1, errStopWaiting)
 
 	// bind a port then release it, so every dial fails non-fatally
-	// (ECONNREFUSED): the synchronous Connect dial and the reconnect
-	// dial alike.
+	// (connection refused): the synchronous Connect dial and the
+	// reconnect dial alike.
 	lsn, err := net.Listen("tcp", addrLoopbackAny)
 	core.AssertMustNoError(t, err, "listen")
 	unreachableAddr := lsn.Addr().String()
@@ -593,7 +592,7 @@ func TestClientReconnectDialFails(t *testing.T) {
 	// both dials are refused and reported: the synchronous Connect dial
 	// and the reconnect dial routed through handleReconnectError.
 	core.AssertEqual(t, 2,
-		countMatchingErrors(errs.Errors(), syscall.ECONNREFUSED),
+		countMatchingErrors(errs.Errors(), errConnRefused),
 		"refused dials reported")
 }
 

--- a/net/reconnect/errors.go
+++ b/net/reconnect/errors.go
@@ -81,20 +81,24 @@ func checkIsFatal(err error) (is, certainly bool) {
 	}
 }
 
-func checkIsExpectable(err error) (is, certainly bool) {
-	switch err {
-	case fs.ErrClosed,
-		os.ErrDeadlineExceeded,
-		syscall.ECONNABORTED,
-		syscall.ECONNREFUSED,
-		syscall.ECONNRESET:
-		// reconnect
-		return true, true
-	default:
-		// unknown
-		return false, false
-	}
-}
+// expectableConnErrors are the connection failures the reconnect loop
+// treats as recoverable: the transport or the peer dropped the
+// connection in a way a redial can legitimately recover from. The
+// per-platform set in expectableConnErrorsOS adds the equivalents that
+// exist only on that platform — the WSAE* family on Windows, where a
+// dial or an established connection reports those rather than the POSIX
+// ECONN* values above.
+var expectableConnErrors = append([]error{
+	fs.ErrClosed,
+	os.ErrDeadlineExceeded,
+	syscall.ECONNABORTED,
+	syscall.ECONNREFUSED,
+	syscall.ECONNRESET,
+}, expectableConnErrorsOS...)
+
+// checkIsExpectable reports whether err is a recoverable connection
+// failure, matching any node in its chain against expectableConnErrors.
+var checkIsExpectable = core.NewCheckErrorIsIn2(expectableConnErrors)
 
 // filterNonError checks if the cause of the shutdown is worth
 // reporting or it was initiated by the user instead.

--- a/net/reconnect/errors_unix.go
+++ b/net/reconnect/errors_unix.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package reconnect
+
+// expectableConnErrorsOS holds the platform-specific recoverable
+// connection errors. Unix-like systems surface the POSIX ECONN* errnos
+// already listed in expectableConnErrors, so there is nothing further
+// to add here.
+var expectableConnErrorsOS []error

--- a/net/reconnect/errors_windows.go
+++ b/net/reconnect/errors_windows.go
@@ -1,0 +1,16 @@
+package reconnect
+
+import "golang.org/x/sys/windows"
+
+// expectableConnErrorsOS holds the Windows Sockets connection errnos. A
+// dial or an established connection reports the WSAE* errnos, not the
+// POSIX ECONN* values expectableConnErrors matches: Go's std syscall
+// package defines those as invented placeholders on Windows, distinct
+// from the numbers the socket layer actually returns. Listing the real
+// Winsock codes keeps the recoverable-connection contract holding on
+// Windows too.
+var expectableConnErrorsOS = []error{
+	windows.WSAECONNABORTED,
+	windows.WSAECONNREFUSED,
+	windows.WSAECONNRESET,
+}


### PR DESCRIPTION
## What

On Windows, the reconnect client failed to recognise a dropped or refused
connection as recoverable, so the reconnect loop did not redial when it
should have. This makes the recoverable-connection contract hold on Windows
as it already does on unix-like systems.

## Why

The classifier and the reconnect-dial test both matched failures against
the POSIX `syscall.ECONNABORTED` / `ECONNREFUSED` / `ECONNRESET` values. On
Windows the socket layer reports the Winsock `WSAE*` errnos instead; Go's
standard `syscall` package defines the `ECONN*` names there as invented
placeholders, distinct from the numbers a dial actually returns. Matching
the placeholders meant a refused or reset connection on Windows was never
classified as recoverable, and `TestClientReconnectDialFails` counted zero
refused dials there.

## How

`checkIsExpectable` is rebuilt on `core.NewCheckErrorIsIn2` over a shared
error set plus a per-platform `expectableConnErrorsOS`:

- `errors_windows.go` adds the real Winsock trio (`WSAECONNABORTED`,
  `WSAECONNREFUSED`, `WSAECONNRESET`).
- `errors_unix.go` adds nothing — the POSIX errnos already cover unix-like
  systems.

The test side follows the same split: `TestClientReconnectDialFails` now
counts a per-OS `errConnRefused` (POSIX `ECONNREFUSED` on unix, Winsock
`WSAECONNREFUSED` on Windows) instead of the fixed POSIX value.

The Windows `WSAE*` values come from `golang.org/x/sys/windows`. The
per-platform behaviour is only executed natively on each OS, but `make vet`
cross-compiles every module for linux, darwin and Windows, so the Windows
build path is checked in CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reconnect error handling across operating systems.
  * Correctly recognizes recoverable connection failures on Windows and POSIX-compatible systems.
  * Preserves consistent behavior when connection attempts are refused, reset, or aborted.

* **Tests**
  * Added platform-specific coverage for connection-refused errors.
  * Updated reconnect failure tests to validate platform-appropriate error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->